### PR TITLE
fix loading msgpack.so

### DIFF
--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -6,5 +6,9 @@ begin
   ver = '1.9' if ver == '2.0'
   require File.join(here, 'msgpack', ver, 'msgpack')
 rescue LoadError
-  require File.join(here, 'msgpack', 'msgpack')
+  begin
+    require File.join(here, 'msgpack', 'msgpack')
+  rescue LoadError
+    require 'msgpack/msgpack'
+  end
 end


### PR DESCRIPTION
以下の環境で「require 'msgpack'」をしたところエラーが発生しました。
msgpack.soがext配下にあり、フルパスでrequireしているのが原因のようでした。
修正を取り込んでいただけると幸いです。

---

[ec2-user@cthulhu msgpack-ruby]$ uname  -a
Linux cthulhu 3.4.43-43.43.amzn1.x86_64 #1 SMP Mon May 6 18:04:41 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
[ec2-user@cthulhu msgpack-ruby]$ ruby -v
ruby 1.9.3p286 (2012-10-12 revision 37165) [x86_64-linux]
[ec2-user@cthulhu msgpack-ruby]$ gem -v
1.8.23
[ec2-user@cthulhu msgpack-ruby]$ ruby -e 'require "msgpack"'
/usr/share/rubygems1.9/rubygems/custom_require.rb:36:in `require': cannot load such file -- /usr/local/share/gems/gems/msgpack-0.5.5/lib/msgpack/msgpack (LoadError)
    from /usr/share/rubygems1.9/rubygems/custom_require.rb:36:in`require'
    from /usr/local/share/gems/gems/msgpack-0.5.5/lib/msgpack.rb:9:in `rescue in <top (required)>'
    from /usr/local/share/gems/gems/msgpack-0.5.5/lib/msgpack.rb:3:in`<top (required)>'
    from /usr/share/rubygems1.9/rubygems/custom_require.rb:60:in `require'
    from /usr/share/rubygems1.9/rubygems/custom_require.rb:60:in`rescue in require'
    from /usr/share/rubygems1.9/rubygems/custom_require.rb:35:in `require'
##     from -e:1:in `<main>'

---
