### PR TITLE
Getting msgpack to work with Ruby v2.0

### DIFF
--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -3,7 +3,6 @@ require File.join(here, 'msgpack', 'version')
 begin
   m = /(\d+.\d+)/.match(RUBY_VERSION)
   ver = m[1]
-  ver = '1.9' if ver == '2.0'
   require File.join(here, 'msgpack', ver, 'msgpack')
 rescue LoadError
   require File.join(here, 'msgpack', 'msgpack')


### PR DESCRIPTION
Hi there,

I was running into a LoadError with Ruby v2.0.0 when using msgpack -

C:/Ruby200/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require': c
annot load such file -- C:/Ruby200/lib/ruby/gems/2.0.0/gems/msgpack-0.5.5-x86-mi
ngw32/lib/msgpack/msgpack (LoadError)
        from C:/Ruby200/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in
`require'
        from C:/Ruby200/lib/ruby/gems/2.0.0/gems/msgpack-0.5.5-x86-mingw32/lib/m
sgpack.rb:9:in `rescue in <top (required)>'
        from C:/Ruby200/lib/ruby/gems/2.0.0/gems/msgpack-0.5.5-x86-mingw32/lib/m
sgpack.rb:3:in`<top (required)>'
        from C:/Ruby200/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in
 `require'
        from C:/Ruby200/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in
`require'

The change I've made seems to fix it, feel free to merge if you think it is appropriate.
