### PR TITLE
Visual C++ support.

### DIFF
--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -304,6 +304,8 @@ static inline int msgpack_buffer_read_top_1(msgpack_buffer_t* b)
 
 static inline int msgpack_buffer_read_1(msgpack_buffer_t* b)
 {
+    int r;
+
     if(msgpack_buffer_top_readable_size(b) <= 0) {
         if(b->io == Qnil) {
             return -1;
@@ -311,7 +313,7 @@ static inline int msgpack_buffer_read_1(msgpack_buffer_t* b)
         _msgpack_buffer_feed_from_io(b);
     }
 
-    int r = (int) (unsigned char) b->read_buffer[0];
+    r = (int) (unsigned char) b->read_buffer[0];
     _msgpack_buffer_consumed(b, 1);
 
     return r;
@@ -377,11 +379,13 @@ size_t msgpack_buffer_read_to_string_nonblock(msgpack_buffer_t* b, VALUE string,
 
 static inline size_t msgpack_buffer_read_to_string(msgpack_buffer_t* b, VALUE string, size_t length)
 {
+    size_t avail;
+
     if(length == 0) {
         return 0;
     }
 
-    size_t avail = msgpack_buffer_top_readable_size(b);
+    avail = msgpack_buffer_top_readable_size(b);
     if(avail > 0) {
         return msgpack_buffer_read_to_string_nonblock(b, string, length);
     } else if(b->io != Qnil) {
@@ -393,11 +397,13 @@ static inline size_t msgpack_buffer_read_to_string(msgpack_buffer_t* b, VALUE st
 
 static inline size_t msgpack_buffer_skip(msgpack_buffer_t* b, size_t length)
 {
+    size_t avail;
+
     if(length == 0) {
         return 0;
     }
 
-    size_t avail = msgpack_buffer_top_readable_size(b);
+    avail = msgpack_buffer_top_readable_size(b);
     if(avail > 0) {
         return msgpack_buffer_skip_nonblock(b, length);
     } else if(b->io != Qnil) {
@@ -420,6 +426,8 @@ static inline VALUE _msgpack_buffer_refer_head_mapped_string(msgpack_buffer_t* b
 
 static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_t length, bool will_be_frozen)
 {
+    VALUE result;
+
 #ifndef DISABLE_BUFFER_READ_REFERENCE_OPTIMIZE
     /* optimize */
     if(!will_be_frozen &&
@@ -431,7 +439,7 @@ static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_
     }
 #endif
 
-    VALUE result = rb_str_new(b->read_buffer, length);
+    result = rb_str_new(b->read_buffer, length);
     _msgpack_buffer_consumed(b, length);
     return result;
 }

--- a/ext/msgpack/core_ext.c
+++ b/ext/msgpack/core_ext.c
@@ -36,11 +36,12 @@ static inline VALUE delegete_to_pack(int argc, VALUE* argv, VALUE self)
 }
 
 #define ENSURE_PACKER(argc, argv, packer, pk) \
+    VALUE packer; \
+    msgpack_packer_t *pk; \
     if(argc != 1 || rb_class_of(argv[0]) != cMessagePack_Packer) { \
         return delegete_to_pack(argc, argv, self); \
     } \
-    VALUE packer = argv[0]; \
-    msgpack_packer_t *pk; \
+    packer = argv[0]; \
     Data_Get_Struct(packer, msgpack_packer_t, pk);
 
 static VALUE NilClass_to_msgpack(int argc, VALUE* argv, VALUE self)

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -4,7 +4,11 @@ have_header("ruby/st.h")
 have_header("st.h")
 have_func("rb_str_replace", ["ruby.h"])
 
-$CFLAGS << %[ -I.. -Wall -O3 -g -std=c99]
+if /mswin/ =~ RUBY_PLATFORM
+  $CFLAGS << " -I.."
+else
+  $CFLAGS << %[ -I.. -Wall -O3 -g -std=c99]
+end
 #$CFLAGS << %[ -DDISABLE_RMEM]
 #$CFLAGS << %[ -DDISABLE_RMEM_REUSE_INTERNAL_FRAGMENT]
 #$CFLAGS << %[ -DDISABLE_BUFFER_READ_REFERENCE_OPTIMIZE]

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -74,14 +74,15 @@ void msgpack_packer_reset(msgpack_packer_t* pk)
 void msgpack_packer_write_array_value(msgpack_packer_t* pk, VALUE v)
 {
     /* actual return type of RARRAY_LEN is long */
+    unsigned int len32;
+    unsigned int i;
     unsigned long len = RARRAY_LEN(v);
     if(len > 0xffffffffUL) {
         rb_raise(rb_eArgError, "size of array is too long to pack: %lu bytes should be <= %lu", len, 0xffffffffUL);
     }
-    unsigned int len32 = (unsigned int)len;
+    len32 = (unsigned int)len;
     msgpack_packer_write_array_header(pk, len32);
 
-    unsigned int i;
     for(i=0; i < len32; ++i) {
         VALUE e = rb_ary_entry(v, i);
         msgpack_packer_write_value(pk, e);
@@ -90,10 +91,12 @@ void msgpack_packer_write_array_value(msgpack_packer_t* pk, VALUE v)
 
 static int write_hash_foreach(VALUE key, VALUE value, VALUE pk_value)
 {
+    msgpack_packer_t* pk;
+
     if (key == Qundef) {
         return ST_CONTINUE;
     }
-    msgpack_packer_t* pk = (msgpack_packer_t*) pk_value;
+    pk = (msgpack_packer_t*) pk_value;
     msgpack_packer_write_value(pk, key);
     msgpack_packer_write_value(pk, value);
     return ST_CONTINUE;
@@ -103,11 +106,12 @@ void msgpack_packer_write_hash_value(msgpack_packer_t* pk, VALUE v)
 {
     /* actual return type of RHASH_SIZE is long (if SIZEOF_LONG == SIZEOF_VOIDP
      * or long long (if SIZEOF_LONG_LONG == SIZEOF_VOIDP. See st.h. */
+    unsigned int len32;
     unsigned long len = RHASH_SIZE(v);
     if(len > 0xffffffffUL) {
         rb_raise(rb_eArgError, "size of array is too long to pack: %ld bytes should be <= %lu", len, 0xffffffffUL);
     }
-    unsigned int len32 = (unsigned int)len;
+    len32 = (unsigned int)len;
     msgpack_packer_write_map_header(pk, len32);
 
 #ifdef RUBINIUS

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -99,22 +99,25 @@ static inline void _msgpack_packer_write_uint8(msgpack_packer_t* pk, uint8_t v)
 
 static inline void _msgpack_packer_write_uint16(msgpack_packer_t* pk, uint16_t v)
 {
+    uint16_t be;
     msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 3);
-    uint16_t be = _msgpack_be16(v);
+    be = _msgpack_be16(v);
     msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xcd, (const void*)&be, 2);
 }
 
 static inline void _msgpack_packer_write_uint32(msgpack_packer_t* pk, uint32_t v)
 {
+    uint32_t be;
     msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 5);
-    uint32_t be = _msgpack_be32(v);
+    be = _msgpack_be32(v);
     msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xce, (const void*)&be, 4);
 }
 
 static inline void _msgpack_packer_write_uint64(msgpack_packer_t* pk, uint64_t v)
 {
+    uint64_t be;
     msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 9);
-    uint64_t be = _msgpack_be64(v);
+    be = _msgpack_be64(v);
     msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xcf, (const void*)&be, 8);
 }
 
@@ -126,22 +129,25 @@ static inline void _msgpack_packer_write_int8(msgpack_packer_t* pk, int8_t v)
 
 static inline void _msgpack_packer_write_int16(msgpack_packer_t* pk, int16_t v)
 {
+    uint16_t be;
     msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 3);
-    uint16_t be = _msgpack_be16(v);
+    be = _msgpack_be16(v);
     msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xd1, (const void*)&be, 2);
 }
 
 static inline void _msgpack_packer_write_int32(msgpack_packer_t* pk, int32_t v)
 {
+    uint32_t be;
     msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 5);
-    uint32_t be = _msgpack_be32(v);
+    be = _msgpack_be32(v);
     msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xd2, (const void*)&be, 4);
 }
 
 static inline void _msgpack_packer_write_int64(msgpack_packer_t* pk, int64_t v)
 {
+    uint64_t be;
     msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 9);
-    uint64_t be = _msgpack_be64(v);
+    be = _msgpack_be64(v);
     msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xd3, (const void*)&be, 8);
 }
 
@@ -255,12 +261,12 @@ static inline void msgpack_packer_write_u64(msgpack_packer_t* pk, uint64_t v)
 
 static inline void msgpack_packer_write_double(msgpack_packer_t* pk, double v)
 {
-    msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 9);
     union {
         double d;
         uint64_t u64;
         char mem[8];
     } castbuf = { v };
+    msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 9);
     castbuf.u64 = _msgpack_be_double(castbuf.u64);
     msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xcb, castbuf.mem, 8);
 }
@@ -268,16 +274,19 @@ static inline void msgpack_packer_write_double(msgpack_packer_t* pk, double v)
 static inline void msgpack_packer_write_raw_header(msgpack_packer_t* pk, unsigned int n)
 {
     if(n < 32) {
+        unsigned char h;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 1);
-        unsigned char h = 0xa0 | (uint8_t) n;
+        h = 0xa0 | (uint8_t) n;
         msgpack_buffer_write_1(PACKER_BUFFER_(pk), h);
     } else if(n < 65536) {
+        uint16_t be;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 3);
-        uint16_t be = _msgpack_be16(n);
+        be = _msgpack_be16(n);
         msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xda, (const void*)&be, 2);
     } else {
+        uint32_t be;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 5);
-        uint32_t be = _msgpack_be32(n);
+        be = _msgpack_be32(n);
         msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xdb, (const void*)&be, 4);
     }
 }
@@ -285,16 +294,19 @@ static inline void msgpack_packer_write_raw_header(msgpack_packer_t* pk, unsigne
 static inline void msgpack_packer_write_array_header(msgpack_packer_t* pk, unsigned int n)
 {
     if(n < 16) {
+        unsigned char h;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 1);
-        unsigned char h = 0x90 | (uint8_t) n;
+        h = 0x90 | (uint8_t) n;
         msgpack_buffer_write_1(PACKER_BUFFER_(pk), h);
     } else if(n < 65536) {
+        uint16_t be;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 3);
-        uint16_t be = _msgpack_be16(n);
+        be = _msgpack_be16(n);
         msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xdc, (const void*)&be, 2);
     } else {
+        uint32_t be;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 5);
-        uint32_t be = _msgpack_be32(n);
+        be = _msgpack_be32(n);
         msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xdd, (const void*)&be, 4);
     }
 }
@@ -302,16 +314,19 @@ static inline void msgpack_packer_write_array_header(msgpack_packer_t* pk, unsig
 static inline void msgpack_packer_write_map_header(msgpack_packer_t* pk, unsigned int n)
 {
     if(n < 16) {
+        unsigned char h;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 1);
-        unsigned char h = 0x80 | (uint8_t) n;
+        h = 0x80 | (uint8_t) n;
         msgpack_buffer_write_1(PACKER_BUFFER_(pk), h);
     } else if(n < 65536) {
+        uint16_t be;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 3);
-        uint16_t be = _msgpack_be16(n);
+        be = _msgpack_be16(n);
         msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xde, (const void*)&be, 2);
     } else {
+        uint32_t be;
         msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 5);
-        uint32_t be = _msgpack_be32(n);
+        be = _msgpack_be32(n);
         msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xdf, (const void*)&be, 4);
     }
 }

--- a/ext/msgpack/rmem.c
+++ b/ext/msgpack/rmem.c
@@ -38,6 +38,7 @@ void msgpack_rmem_destroy(msgpack_rmem_t* pm)
 
 void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
 {
+    msgpack_rmem_chunk_t tmp;
     msgpack_rmem_chunk_t* c = pm->array_first;
     msgpack_rmem_chunk_t* last = pm->array_last;
     for(; c != last; c++) {
@@ -53,10 +54,11 @@ void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
     }
 
     if(c == pm->array_end) {
+        msgpack_rmem_chunk_t* array;
         size_t capacity = c - pm->array_first;
         size_t length = last - pm->array_first;
         capacity = (capacity == 0) ? 8 : capacity * 2;
-        msgpack_rmem_chunk_t* array = realloc(pm->array_first, capacity * sizeof(msgpack_rmem_chunk_t));
+        array = realloc(pm->array_first, capacity * sizeof(msgpack_rmem_chunk_t));
         pm->array_first = array;
         pm->array_last = array + length;
         pm->array_end = array + capacity;
@@ -66,7 +68,7 @@ void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
     c = pm->array_last++;
 
     /* move to head */
-    msgpack_rmem_chunk_t tmp = pm->head;
+    tmp = pm->head;
     pm->head = *c;
     *c = tmp;
 
@@ -78,6 +80,8 @@ void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
 
 void _msgpack_rmem_chunk_free(msgpack_rmem_t* pm, msgpack_rmem_chunk_t* c)
 {
+    msgpack_rmem_chunk_t tmp;
+
     if(pm->array_first->mask == 0xffffffff) {
         /* free and move to last */
         pm->array_last--;
@@ -87,7 +91,7 @@ void _msgpack_rmem_chunk_free(msgpack_rmem_t* pm, msgpack_rmem_chunk_t* c)
     }
 
     /* move to first */
-    msgpack_rmem_chunk_t tmp = *pm->array_first;
+    tmp = *pm->array_first;
     *pm->array_first = *c;
     *c = tmp;
 }

--- a/ext/msgpack/rmem.h
+++ b/ext/msgpack/rmem.h
@@ -86,13 +86,16 @@ void _msgpack_rmem_chunk_free(msgpack_rmem_t* pm, msgpack_rmem_chunk_t* c);
 
 static inline bool msgpack_rmem_free(msgpack_rmem_t* pm, void* mem)
 {
+    msgpack_rmem_chunk_t* c;
+    msgpack_rmem_chunk_t* before_first;
+
     if(_msgpack_rmem_chunk_try_free(&pm->head, mem)) {
         return true;
     }
 
     /* search from last */
-    msgpack_rmem_chunk_t* c = pm->array_last - 1;
-    msgpack_rmem_chunk_t* before_first = pm->array_first - 1;
+    c = pm->array_last - 1;
+    before_first = pm->array_first - 1;
     for(; c != before_first; c--) {
         if(_msgpack_rmem_chunk_try_free(c, mem)) {
             if(c != pm->array_first && c->mask == 0xffffffff) {

--- a/ext/msgpack/sysdep_types.h
+++ b/ext/msgpack/sysdep_types.h
@@ -38,7 +38,17 @@ typedef unsigned __int64 uint64_t;
 
 #else
 #include <stdint.h>
+#endif
+
+#if __STDC_VERSION__ > 199901L
 #include <stdbool.h>
+#elif !defined(__bool_true_false_are_defined)
+#if !defined(bool)
+#define bool int
+#define false 0
+#define true (!false)
+#endif
+#define __bool_true_false_are_defined
 #endif
 
 


### PR DESCRIPTION
* ext/msgpack/sysdep_types.h (bool): Visual C++ in C mode does not have bool.
  define it just like the C99 way.

* others: narrow scoping is a good practice.  but suddly Visual C++ in C mode
  does not support declaring variables except the top of functions.