### PR TITLE
JRuby support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.bundle
 *.gem
 *.class
+*.jar
 .bundle
 Gemfile*
 pkg
@@ -14,5 +15,4 @@ tmp
 .project
 .settings
 /nbproject/private/
-ext/java/build
-ext/java/msgpack.jar
+

--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,8 @@ if RUBY_PLATFORM =~ /java/
     jars = ["#{jruby_home}/lib/jruby.jar"]
     ext.classpath = jars.map { |x| File.expand_path(x) }.join(':')
     ext.lib_dir = File.join('lib', 'msgpack')
+    ext.source_version = '1.6'
+    ext.target_version = '1.6'
   end
 
 else

--- a/Rakefile
+++ b/Rakefile
@@ -37,9 +37,10 @@ if RUBY_PLATFORM =~ /java/
 
   Rake::JavaExtensionTask.new('msgpack', spec) do |ext|
     ext.ext_dir = 'ext/java'
-    #jruby_home = RbConfig::CONFIG['prefix']
-    #jars = ["#{jruby_home}/lib/jruby.jar"] + FileList['lib/*.jar']
-    #ext.classpath = jars.map { |x| File.expand_path x }.join ':'
+    jruby_home = RbConfig::CONFIG['prefix']
+    jars = ["#{jruby_home}/lib/jruby.jar"]
+    ext.classpath = jars.map { |x| File.expand_path(x) }.join(':')
+    ext.lib_dir = File.join('lib', 'msgpack')
   end
 
 else

--- a/ext/java/org/msgpack/jruby/Buffer.java
+++ b/ext/java/org/msgpack/jruby/Buffer.java
@@ -1,0 +1,221 @@
+package org.msgpack.jruby;
+
+
+import java.nio.ByteBuffer;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.RubyHash;
+import org.jruby.RubyIO;
+import org.jruby.RubyInteger;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.util.ByteList;
+
+import org.jcodings.Encoding;
+
+
+@JRubyClass(name="MessagePack::Buffer")
+public class Buffer extends RubyObject {
+  private RubyHash options;
+  private IRubyObject io;
+  private ByteBuffer buffer;
+  private boolean writeMode;
+  private Encoding binaryEncoding;
+
+  private static final int CACHE_LINE_SIZE = 64;
+  private static final int ARRAY_HEADER_SIZE = 24;
+
+  public Buffer(Ruby runtime, RubyClass type) {
+    super(runtime, type);
+  }
+
+  static class BufferAllocator implements ObjectAllocator {
+    public IRubyObject allocate(Ruby runtime, RubyClass type) {
+      return new Buffer(runtime, type);
+    }
+  }
+
+  @JRubyMethod(name = "initialize", optional = 2)
+  public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
+    if (args.length > 0) {
+      if (args[0].respondsTo("read") && args[0].respondsTo("write")) {
+        this.io = args[0];
+      }
+      if (args[args.length - 1] instanceof RubyHash) {
+        this.options = (RubyHash) args[args.length - 1];
+      }
+    }
+    this.buffer = ByteBuffer.allocate(CACHE_LINE_SIZE - ARRAY_HEADER_SIZE);
+    this.writeMode = true;
+    this.binaryEncoding = ctx.getRuntime().getEncodingService().getAscii8bitEncoding();
+    return this;
+  }
+
+  private void ensureRemainingCapacity(int c) {
+    if (!writeMode) {
+      buffer.compact();
+      writeMode = true;
+    }
+    if (buffer.remaining() < c) {
+      int newLength = Math.max(buffer.capacity() + (buffer.capacity() >> 1), buffer.capacity() + c);
+      newLength += CACHE_LINE_SIZE - ((ARRAY_HEADER_SIZE + newLength) % CACHE_LINE_SIZE);
+      buffer = ByteBuffer.allocate(newLength).put(buffer.array(), 0, buffer.position());
+    }
+  }
+
+  private void ensureReadMode() {
+    if (writeMode) {
+      buffer.flip();
+      writeMode = false;
+    }
+  }
+
+  private int rawSize() {
+    if (writeMode) {
+      return buffer.position();
+    } else {
+      return buffer.limit() - buffer.position();
+    }
+  }
+
+  @JRubyMethod(name = "clear")
+  public IRubyObject clear(ThreadContext ctx) {
+    buffer.clear();
+    return ctx.getRuntime().getNil();
+  }
+
+  @JRubyMethod(name = "size")
+  public IRubyObject size(ThreadContext ctx) {
+    return ctx.getRuntime().newFixnum(rawSize());
+  }
+
+  @JRubyMethod(name = "empty?")
+  public IRubyObject isEmpty(ThreadContext ctx) {
+    return rawSize() == 0 ? ctx.getRuntime().getTrue() : ctx.getRuntime().getFalse();
+  }
+
+  private IRubyObject bufferWrite(ThreadContext ctx, IRubyObject str) {
+    ByteList bytes = str.asString().getByteList();
+    int length = bytes.length();
+    ensureRemainingCapacity(length);
+    buffer.put(bytes.unsafeBytes(), bytes.begin(), length);
+    return ctx.getRuntime().newFixnum(length);
+
+  }
+
+  @JRubyMethod(name = "write", alias = {"<<"})
+  public IRubyObject write(ThreadContext ctx, IRubyObject str) {
+    if (io == null) {
+      return bufferWrite(ctx, str);
+    } else {
+      return io.callMethod(ctx, "write", str);
+    }
+  }
+
+  private void feed(ThreadContext ctx) {
+    if (io != null) {
+      bufferWrite(ctx, io.callMethod(ctx, "read"));
+    }
+  }
+
+  private IRubyObject readCommon(ThreadContext ctx, IRubyObject[] args, boolean raiseOnUnderflow) {
+    feed(ctx);
+    int length = rawSize();
+    if (args != null && args.length == 1) {
+      length = (int) args[0].convertToInteger().getLongValue();
+    }
+    if (raiseOnUnderflow && rawSize() < length) {
+      throw ctx.getRuntime().newEOFError();
+    }
+    int readLength = Math.min(length, rawSize());
+    if (readLength == 0 && length > 0) {
+      return ctx.getRuntime().getNil();
+    } else if (readLength == 0) {
+      return ctx.getRuntime().newString();
+    } else {
+      ensureReadMode();
+      byte[] bytes = new byte[readLength];
+      buffer.get(bytes);
+      ByteList byteList = new ByteList(bytes, binaryEncoding);
+      return ctx.getRuntime().newString(byteList);
+    }
+  }
+
+  @JRubyMethod(name = "read", optional = 1)
+  public IRubyObject read(ThreadContext ctx, IRubyObject[] args) {
+    return readCommon(ctx, args, false);
+  }
+
+  @JRubyMethod(name = "read_all", optional = 1)
+  public IRubyObject readAll(ThreadContext ctx, IRubyObject[] args) {
+    return readCommon(ctx, args, true);
+  }
+
+  private IRubyObject skipCommon(ThreadContext ctx, IRubyObject _length, boolean raiseOnUnderflow) {
+    feed(ctx);
+    int length = (int) _length.convertToInteger().getLongValue();
+    if (raiseOnUnderflow && rawSize() < length) {
+      throw ctx.getRuntime().newEOFError();
+    }
+    ensureReadMode();
+    int skipLength = Math.min(length, rawSize());
+    buffer.position(buffer.position() + skipLength);
+    return ctx.getRuntime().newFixnum(skipLength);
+  }
+
+  @JRubyMethod(name = "skip")
+  public IRubyObject skip(ThreadContext ctx, IRubyObject length) {
+    return skipCommon(ctx, length, false);
+  }
+
+  @JRubyMethod(name = "skip_all")
+  public IRubyObject skipAll(ThreadContext ctx, IRubyObject length) {
+    return skipCommon(ctx, length, true);
+  }
+
+  @JRubyMethod(name = "to_s", alias = {"to_str"})
+  public IRubyObject toS(ThreadContext ctx) {
+    ensureReadMode();
+    int length = buffer.limit() - buffer.position();
+    ByteList str = new ByteList(buffer.array(), buffer.position(), length, binaryEncoding, true);
+    return ctx.getRuntime().newString(str);
+  }
+
+  @JRubyMethod(name = "to_a")
+  public IRubyObject toA(ThreadContext ctx) {
+    return ctx.getRuntime().newArray(toS(ctx));
+  }
+
+  @JRubyMethod(name = "io")
+  public IRubyObject getIo(ThreadContext ctx) {
+    return io == null ? ctx.getRuntime().getNil() : io;
+  }
+
+  @JRubyMethod(name = "flush")
+  public IRubyObject flush(ThreadContext ctx) {
+    if (io == null) {
+      return ctx.getRuntime().getNil();
+    } else {
+      return io.callMethod(ctx, "flush");
+    }
+  }
+
+  @JRubyMethod(name = "close")
+  public IRubyObject close(ThreadContext ctx) {
+    if (io == null) {
+      return ctx.getRuntime().getNil();
+    } else {
+      return io.callMethod(ctx, "close");
+    }
+  }
+
+  @JRubyMethod(name = "write_to")
+  public IRubyObject writeTo(ThreadContext ctx, IRubyObject io) {
+    return io.callMethod(ctx, "write", readCommon(ctx, null, false));
+  }
+}

--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 
 import org.jruby.Ruby;
 import org.jruby.RubyObject;
+import org.jruby.RubyClass;
 import org.jruby.RubyBignum;
 import org.jruby.RubyHash;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -20,12 +21,14 @@ public class Decoder {
   private final ByteBuffer buffer;
   private final Encoding binaryEncoding;
   private final Encoding utf8Encoding;
+  private final RubyClass unpackErrorClass;
 
   public Decoder(Ruby runtime, byte[] buffer) {
     this.runtime = runtime;
     this.buffer = ByteBuffer.wrap(buffer);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
     this.utf8Encoding = UTF8Encoding.INSTANCE;
+    this.unpackErrorClass = runtime.getModule("MessagePack").getClass("UnpackError");
   }
 
   private IRubyObject consumeUnsignedLong() {
@@ -99,6 +102,6 @@ public class Decoder {
         return consumeHash(b & 0x0f);
       }
     }
-    return runtime.getNil();
+    throw runtime.newRaiseException(unpackErrorClass, String.format("Illegal byte sequence"));
   }
 }

--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -1,0 +1,104 @@
+package org.msgpack.jruby;
+
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+import org.jruby.Ruby;
+import org.jruby.RubyObject;
+import org.jruby.RubyBignum;
+import org.jruby.RubyHash;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
+
+import org.jcodings.Encoding;
+import org.jcodings.specific.UTF8Encoding;
+
+
+public class Decoder {
+  private final Ruby runtime;
+  private final ByteBuffer buffer;
+  private final Encoding binaryEncoding;
+  private final Encoding utf8Encoding;
+
+  public Decoder(Ruby runtime, byte[] buffer) {
+    this.runtime = runtime;
+    this.buffer = ByteBuffer.wrap(buffer);
+    this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
+    this.utf8Encoding = UTF8Encoding.INSTANCE;
+  }
+
+  private IRubyObject consumeUnsignedLong() {
+    long value = buffer.getLong();
+    if (value < 0) {
+      return RubyBignum.newBignum(runtime, BigInteger.valueOf(value & ((1L<<63)-1)).setBit(63));
+    } else {
+      return runtime.newFixnum(value);
+    }
+  }
+
+  private IRubyObject consumeString(int size, Encoding encoding) {
+    byte[] bytes = new byte[size];
+    buffer.get(bytes);
+    ByteList byteList = new ByteList(bytes, encoding);
+    return runtime.newString(byteList);
+  }
+
+  private IRubyObject consumeArray(int size) {
+    IRubyObject[] elements = new IRubyObject[size];
+    for (int i = 0; i < size; i++) {
+      elements[i] = next();
+    }
+    return runtime.newArray(elements);
+  }
+
+  private IRubyObject consumeHash(int size) {
+    RubyHash hash = RubyHash.newHash(runtime);
+    for (int i = 0; i < size; i++) {
+      hash.fastASet(next(), next());
+    }
+    return hash;
+  }
+
+  public IRubyObject next() {
+    int b = buffer.get() & 0xff;
+    switch (b) {
+    case 0xc0: return runtime.getNil();
+    case 0xc2: return runtime.newBoolean(false);
+    case 0xc3: return runtime.newBoolean(true);
+    case 0xc4: return consumeString(buffer.get() & 0xff, binaryEncoding);
+    case 0xc5: return consumeString(buffer.getShort() & 0xffff, binaryEncoding);
+    case 0xc6: return consumeString(buffer.getInt(), binaryEncoding);
+    case 0xca: return runtime.newFloat(buffer.getFloat());
+    case 0xcb: return runtime.newFloat(buffer.getDouble());
+    case 0xcc: return runtime.newFixnum(buffer.get() & 0xffL);
+    case 0xcd: return runtime.newFixnum(buffer.getShort() & 0xffffL);
+    case 0xce: return runtime.newFixnum(buffer.getInt() & 0xffffffffL);
+    case 0xcf: return consumeUnsignedLong();
+    case 0xd0: return runtime.newFixnum(buffer.get());
+    case 0xd1: return runtime.newFixnum(buffer.getShort());
+    case 0xd2: return runtime.newFixnum(buffer.getInt());
+    case 0xd3: return runtime.newFixnum(buffer.getLong());
+    case 0xd9: return consumeString(buffer.get() & 0xff, utf8Encoding);
+    case 0xda: return consumeString(buffer.getShort() & 0xffff, utf8Encoding);
+    case 0xdb: return consumeString(buffer.getInt(), utf8Encoding);
+    case 0xdc: return consumeArray(buffer.getShort() & 0xffff);
+    case 0xdd: return consumeArray(buffer.getInt());
+    case 0xde: return consumeHash(buffer.getShort() & 0xffff);
+    case 0xdf: return consumeHash(buffer.getInt());
+    default:
+      if (b <= 0x7f) {
+        return runtime.newFixnum(b);
+      } else if ((b & 0xe0) == 0xe0) {
+        return runtime.newFixnum(b - 0x100);
+      } else if ((b & 0xe0) == 0xa0) {
+        return consumeString(b & 0x1f, utf8Encoding);
+      } else if ((b & 0xf0) == 0x90) {
+        return consumeArray(b & 0x0f);
+      } else if ((b & 0xf0) == 0x80) {
+        return consumeHash(b & 0x0f);
+      }
+    }
+    return runtime.getNil();
+  }
+}

--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -15,6 +15,8 @@ import org.jruby.util.ByteList;
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
 
+import static org.msgpack.jruby.Types.*;
+
 
 public class Decoder {
   private final Ruby runtime;
@@ -63,32 +65,47 @@ public class Decoder {
     return hash;
   }
 
+  private IRubyObject consumeExtension(int size) {
+    int type = buffer.get();
+    byte[] payload = new byte[size];
+    buffer.get(payload);
+    return ExtensionValue.newExtensionValue(runtime, type, payload);
+  }
+
   public IRubyObject next() {
     int b = buffer.get() & 0xff;
-    switch (b) {
-    case 0xc0: return runtime.getNil();
-    case 0xc2: return runtime.newBoolean(false);
-    case 0xc3: return runtime.newBoolean(true);
-    case 0xc4: return consumeString(buffer.get() & 0xff, binaryEncoding);
-    case 0xc5: return consumeString(buffer.getShort() & 0xffff, binaryEncoding);
-    case 0xc6: return consumeString(buffer.getInt(), binaryEncoding);
-    case 0xca: return runtime.newFloat(buffer.getFloat());
-    case 0xcb: return runtime.newFloat(buffer.getDouble());
-    case 0xcc: return runtime.newFixnum(buffer.get() & 0xffL);
-    case 0xcd: return runtime.newFixnum(buffer.getShort() & 0xffffL);
-    case 0xce: return runtime.newFixnum(buffer.getInt() & 0xffffffffL);
-    case 0xcf: return consumeUnsignedLong();
-    case 0xd0: return runtime.newFixnum(buffer.get());
-    case 0xd1: return runtime.newFixnum(buffer.getShort());
-    case 0xd2: return runtime.newFixnum(buffer.getInt());
-    case 0xd3: return runtime.newFixnum(buffer.getLong());
-    case 0xd9: return consumeString(buffer.get() & 0xff, utf8Encoding);
-    case 0xda: return consumeString(buffer.getShort() & 0xffff, utf8Encoding);
-    case 0xdb: return consumeString(buffer.getInt(), utf8Encoding);
-    case 0xdc: return consumeArray(buffer.getShort() & 0xffff);
-    case 0xdd: return consumeArray(buffer.getInt());
-    case 0xde: return consumeHash(buffer.getShort() & 0xffff);
-    case 0xdf: return consumeHash(buffer.getInt());
+    switch ((byte) b) {
+    case NIL:      return runtime.getNil();
+    case FALSE:    return runtime.getFalse();
+    case TRUE:     return runtime.getTrue();
+    case BIN8:     return consumeString(buffer.get() & 0xff, binaryEncoding);
+    case BIN16:    return consumeString(buffer.getShort() & 0xffff, binaryEncoding);
+    case BIN32:    return consumeString(buffer.getInt(), binaryEncoding);
+    case VAREXT8:  return consumeExtension(buffer.get());
+    case VAREXT16: return consumeExtension(buffer.getShort());
+    case VAREXT32: return consumeExtension(buffer.getInt());
+    case FLOAT32:  return runtime.newFloat(buffer.getFloat());
+    case FLOAT64:  return runtime.newFloat(buffer.getDouble());
+    case UINT8:    return runtime.newFixnum(buffer.get() & 0xffL);
+    case UINT16:   return runtime.newFixnum(buffer.getShort() & 0xffffL);
+    case UINT32:   return runtime.newFixnum(buffer.getInt() & 0xffffffffL);
+    case UINT64:   return consumeUnsignedLong();
+    case INT8:     return runtime.newFixnum(buffer.get());
+    case INT16:    return runtime.newFixnum(buffer.getShort());
+    case INT32:    return runtime.newFixnum(buffer.getInt());
+    case INT64:    return runtime.newFixnum(buffer.getLong());
+    case FIXEXT1:  return consumeExtension(1);
+    case FIXEXT2:  return consumeExtension(2);
+    case FIXEXT4:  return consumeExtension(4);
+    case FIXEXT8:  return consumeExtension(8);
+    case FIXEXT16: return consumeExtension(16);
+    case STR8:     return consumeString(buffer.get() & 0xff, utf8Encoding);
+    case STR16:    return consumeString(buffer.getShort() & 0xffff, utf8Encoding);
+    case STR32:    return consumeString(buffer.getInt(), utf8Encoding);
+    case ARY16:    return consumeArray(buffer.getShort() & 0xffff);
+    case ARY32:    return consumeArray(buffer.getInt());
+    case MAP16:    return consumeHash(buffer.getShort() & 0xffff);
+    case MAP32:    return consumeHash(buffer.getInt());
     default:
       if (b <= 0x7f) {
         return runtime.newFixnum(b);

--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -3,12 +3,16 @@ package org.msgpack.jruby;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.BufferUnderflowException;
+import java.util.Iterator;
+import java.util.Arrays;
 
 import org.jruby.Ruby;
 import org.jruby.RubyObject;
 import org.jruby.RubyClass;
 import org.jruby.RubyBignum;
 import org.jruby.RubyHash;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 
@@ -18,19 +22,54 @@ import org.jcodings.specific.UTF8Encoding;
 import static org.msgpack.jruby.Types.*;
 
 
-public class Decoder {
+public class Decoder implements Iterator<IRubyObject> {
   private final Ruby runtime;
-  private final ByteBuffer buffer;
   private final Encoding binaryEncoding;
   private final Encoding utf8Encoding;
   private final RubyClass unpackErrorClass;
+  private final RubyClass underflowErrorClass;
 
-  public Decoder(Ruby runtime, byte[] buffer) {
+  private ByteBuffer buffer;
+
+  public Decoder(Ruby runtime) {
+    this(runtime, new byte[] {}, 0, 0);
+  }
+
+  public Decoder(Ruby runtime, byte[] bytes) {
+    this(runtime, bytes, 0, bytes.length);
+  }
+
+  public Decoder(Ruby runtime, byte[] bytes, int offset, int length) {
     this.runtime = runtime;
-    this.buffer = ByteBuffer.wrap(buffer);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
     this.utf8Encoding = UTF8Encoding.INSTANCE;
     this.unpackErrorClass = runtime.getModule("MessagePack").getClass("UnpackError");
+    this.underflowErrorClass = runtime.getModule("MessagePack").getClass("UnderflowError");
+    feed(bytes, offset, length);
+  }
+
+  public void feed(byte[] bytes) {
+    feed(bytes, 0, bytes.length);
+  }
+
+  public void feed(byte[] bytes, int offset, int length) {
+    if (buffer == null) {
+      buffer = ByteBuffer.wrap(bytes, offset, length);
+    } else {
+      ByteBuffer newBuffer = ByteBuffer.allocate(buffer.remaining() + length);
+      newBuffer.put(buffer);
+      newBuffer.put(bytes, offset, length);
+      newBuffer.flip();
+      buffer = newBuffer;
+    }
+  }
+
+  public void reset() {
+    buffer.rewind();
+  }
+
+  public int offset() {
+    return buffer.position();
   }
 
   private IRubyObject consumeUnsignedLong() {
@@ -43,8 +82,7 @@ public class Decoder {
   }
 
   private IRubyObject consumeString(int size, Encoding encoding) {
-    byte[] bytes = new byte[size];
-    buffer.get(bytes);
+    byte[] bytes = readBytes(size);
     ByteList byteList = new ByteList(bytes, encoding);
     return runtime.newString(byteList);
   }
@@ -67,62 +105,87 @@ public class Decoder {
 
   private IRubyObject consumeExtension(int size) {
     int type = buffer.get();
-    byte[] payload = new byte[size];
-    buffer.get(payload);
+    byte[] payload = readBytes(size);
     return ExtensionValue.newExtensionValue(runtime, type, payload);
   }
 
+  private byte[] readBytes(int size) {
+    byte[] payload = new byte[size];
+    buffer.get(payload);
+    return payload;
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return buffer.remaining() > 0;
+  }
+
+  @Override
   public IRubyObject next() {
-    byte b = buffer.get();
-outer:
-    switch ((b >> 4) & 0xf) {
-    case 0x8: return consumeHash(b & 0x0f);
-    case 0x9: return consumeArray(b & 0x0f);
-    case 0xa:
-    case 0xb: return consumeString(b & 0x1f, utf8Encoding);
-    case 0xc:
-      switch (b) {
-      case NIL:      return runtime.getNil();
-      case FALSE:    return runtime.getFalse();
-      case TRUE:     return runtime.getTrue();
-      case BIN8:     return consumeString(buffer.get() & 0xff, binaryEncoding);
-      case BIN16:    return consumeString(buffer.getShort() & 0xffff, binaryEncoding);
-      case BIN32:    return consumeString(buffer.getInt(), binaryEncoding);
-      case VAREXT8:  return consumeExtension(buffer.get());
-      case VAREXT16: return consumeExtension(buffer.getShort());
-      case VAREXT32: return consumeExtension(buffer.getInt());
-      case FLOAT32:  return runtime.newFloat(buffer.getFloat());
-      case FLOAT64:  return runtime.newFloat(buffer.getDouble());
-      case UINT8:    return runtime.newFixnum(buffer.get() & 0xffL);
-      case UINT16:   return runtime.newFixnum(buffer.getShort() & 0xffffL);
-      case UINT32:   return runtime.newFixnum(buffer.getInt() & 0xffffffffL);
-      case UINT64:   return consumeUnsignedLong();
-      default: break outer;
+    int position = buffer.position();
+    try {
+      byte b = buffer.get();
+      outer: switch ((b >> 4) & 0xf) {
+      case 0x8: return consumeHash(b & 0x0f);
+      case 0x9: return consumeArray(b & 0x0f);
+      case 0xa:
+      case 0xb: return consumeString(b & 0x1f, utf8Encoding);
+      case 0xc:
+        switch (b) {
+        case NIL:      return runtime.getNil();
+        case FALSE:    return runtime.getFalse();
+        case TRUE:     return runtime.getTrue();
+        case BIN8:     return consumeString(buffer.get() & 0xff, binaryEncoding);
+        case BIN16:    return consumeString(buffer.getShort() & 0xffff, binaryEncoding);
+        case BIN32:    return consumeString(buffer.getInt(), binaryEncoding);
+        case VAREXT8:  return consumeExtension(buffer.get());
+        case VAREXT16: return consumeExtension(buffer.getShort());
+        case VAREXT32: return consumeExtension(buffer.getInt());
+        case FLOAT32:  return runtime.newFloat(buffer.getFloat());
+        case FLOAT64:  return runtime.newFloat(buffer.getDouble());
+        case UINT8:    return runtime.newFixnum(buffer.get() & 0xffL);
+        case UINT16:   return runtime.newFixnum(buffer.getShort() & 0xffffL);
+        case UINT32:   return runtime.newFixnum(buffer.getInt() & 0xffffffffL);
+        case UINT64:   return consumeUnsignedLong();
+        default: break outer;
+        }
+      case 0xd:
+        switch (b) {
+        case INT8:     return runtime.newFixnum(buffer.get());
+        case INT16:    return runtime.newFixnum(buffer.getShort());
+        case INT32:    return runtime.newFixnum(buffer.getInt());
+        case INT64:    return runtime.newFixnum(buffer.getLong());
+        case FIXEXT1:  return consumeExtension(1);
+        case FIXEXT2:  return consumeExtension(2);
+        case FIXEXT4:  return consumeExtension(4);
+        case FIXEXT8:  return consumeExtension(8);
+        case FIXEXT16: return consumeExtension(16);
+        case STR8:     return consumeString(buffer.get() & 0xff, utf8Encoding);
+        case STR16:    return consumeString(buffer.getShort() & 0xffff, utf8Encoding);
+        case STR32:    return consumeString(buffer.getInt(), utf8Encoding);
+        case ARY16:    return consumeArray(buffer.getShort() & 0xffff);
+        case ARY32:    return consumeArray(buffer.getInt());
+        case MAP16:    return consumeHash(buffer.getShort() & 0xffff);
+        case MAP32:    return consumeHash(buffer.getInt());
+        default: break outer;
+        }
+      case 0xe:
+      case 0xf: return runtime.newFixnum((0x1f & b) - 0x20);
+      default: return runtime.newFixnum(b);
       }
-    case 0xd:
-      switch (b) {
-      case INT8:     return runtime.newFixnum(buffer.get());
-      case INT16:    return runtime.newFixnum(buffer.getShort());
-      case INT32:    return runtime.newFixnum(buffer.getInt());
-      case INT64:    return runtime.newFixnum(buffer.getLong());
-      case FIXEXT1:  return consumeExtension(1);
-      case FIXEXT2:  return consumeExtension(2);
-      case FIXEXT4:  return consumeExtension(4);
-      case FIXEXT8:  return consumeExtension(8);
-      case FIXEXT16: return consumeExtension(16);
-      case STR8:     return consumeString(buffer.get() & 0xff, utf8Encoding);
-      case STR16:    return consumeString(buffer.getShort() & 0xffff, utf8Encoding);
-      case STR32:    return consumeString(buffer.getInt(), utf8Encoding);
-      case ARY16:    return consumeArray(buffer.getShort() & 0xffff);
-      case ARY32:    return consumeArray(buffer.getInt());
-      case MAP16:    return consumeHash(buffer.getShort() & 0xffff);
-      case MAP32:    return consumeHash(buffer.getInt());
-      default: break outer;
-      }
-    case 0xe:
-    case 0xf: return runtime.newFixnum((0x1f & b) - 0x20);
-    default: return runtime.newFixnum(b);
+      buffer.position(position);
+      throw runtime.newRaiseException(unpackErrorClass, "Illegal byte sequence");
+    } catch (RaiseException re) {
+      buffer.position(position);
+      throw re;
+    } catch (BufferUnderflowException bue) {
+      buffer.position(position);
+      throw runtime.newRaiseException(underflowErrorClass, "Not enough bytes available");
     }
-    throw runtime.newRaiseException(unpackErrorClass, String.format("Illegal byte sequence"));
   }
 }

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -42,7 +42,7 @@ public class Encoder {
 
   private void ensureRemainingCapacity(int c) {
     if (buffer.remaining() < c) {
-      int newLength = Math.max(buffer.capacity() * 2, buffer.capacity() + c);
+      int newLength = Math.max(buffer.capacity() + (buffer.capacity() >> 1), buffer.capacity() + c);
       buffer = ByteBuffer.allocate(newLength).put(buffer.array(), 0, buffer.position());
     }
   }

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -135,7 +135,7 @@ public class Encoder {
       buffer.putInt((int) value);
     } else {
       ensureRemainingCapacity(9);
-      buffer.put(UINT64);
+      buffer.put(INT64);
       buffer.putLong(value);
     }
   }

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -31,32 +31,25 @@ public class Encoder {
   private final Encoding binaryEncoding;
   private final Encoding utf8Encoding;
 
-  private byte[] bytes;
   private ByteBuffer buffer;
 
   public Encoder(Ruby runtime) {
     this.runtime = runtime;
-    this.bytes = new byte[65535];
-    this.buffer = ByteBuffer.wrap(bytes);
+    this.buffer = ByteBuffer.allocate(65535);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
     this.utf8Encoding = UTF8Encoding.INSTANCE;
   }
 
   private void ensureCapacity(int c) {
     if (buffer.remaining() < c) {
-      byte[] oldBytes = bytes;
-      int oldPosition = buffer.position();
-      int newLength = Math.max(oldBytes.length * 2, oldBytes.length + c);
-      bytes = new byte[newLength];
-      System.arraycopy(oldBytes, 0, bytes, 0, oldBytes.length);
-      buffer = ByteBuffer.wrap(bytes);
-      buffer.position(oldPosition);
+      int newLength = Math.max(buffer.capacity() * 2, buffer.capacity() + c);
+      buffer = ByteBuffer.allocate(newLength).put(buffer.array(), 0, buffer.position());
     }
   }
 
   public IRubyObject encode(IRubyObject object) {
     encodeObject(object);
-    return runtime.newString(new ByteList(bytes, 0, buffer.position(), binaryEncoding, false));
+    return runtime.newString(new ByteList(buffer.array(), 0, buffer.position(), binaryEncoding, false));
   }
 
   private void encodeObject(IRubyObject object) {

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -98,45 +98,53 @@ public class Encoder {
 
   private void encodeInteger(RubyInteger object) {
     long value = ((RubyInteger) object).getLongValue();
-    if (value < Integer.MIN_VALUE) {
-      ensureRemainingCapacity(9);
-      buffer.put(INT64);
-      buffer.putLong(value);
-    } else if (value < Short.MIN_VALUE) {
-      ensureRemainingCapacity(5);
-      buffer.put(INT32);
-      buffer.putInt((int) value);
-    } else if (value < Byte.MIN_VALUE) {
-      ensureRemainingCapacity(3);
-      buffer.put(INT16);
-      buffer.putShort((short) value);
-    } else if (value < -0x20L) {
-      ensureRemainingCapacity(2);
-      buffer.put(INT8);
-      buffer.put((byte) value);
-    } else if (value < 0L) {
-      ensureRemainingCapacity(1);
-      byte b = (byte) (value | 0xe0);
-      buffer.put(b);
-    } else if (value < 128L) {
-      ensureRemainingCapacity(1);
-      buffer.put((byte) value);
-    } else if (value < 0x100L) {
-      ensureRemainingCapacity(2);
-      buffer.put(UINT8);
-      buffer.put((byte) value);
-    } else if (value < 0x10000L) {
-      ensureRemainingCapacity(3);
-      buffer.put(UINT16);
-      buffer.putShort((short) value);
-    } else if (value < 0x100000000L) {
-      ensureRemainingCapacity(5);
-      buffer.put(UINT32);
-      buffer.putInt((int) value);
+    if (value < 0) {
+      if (value < Short.MIN_VALUE) {
+        if (value < Integer.MIN_VALUE) {
+          ensureRemainingCapacity(9);
+          buffer.put(INT64);
+          buffer.putLong(value);
+        } else {
+          ensureRemainingCapacity(5);
+          buffer.put(INT32);
+          buffer.putInt((int) value);
+        }
+      } else if (value >= -0x20L) {
+        ensureRemainingCapacity(1);
+        byte b = (byte) (value | 0xe0);
+        buffer.put(b);
+      } else if (value < Byte.MIN_VALUE) {
+        ensureRemainingCapacity(3);
+        buffer.put(INT16);
+        buffer.putShort((short) value);
+      } else {
+        ensureRemainingCapacity(2);
+        buffer.put(INT8);
+        buffer.put((byte) value);
+      }
     } else {
-      ensureRemainingCapacity(9);
-      buffer.put(INT64);
-      buffer.putLong(value);
+      if (value < 0x10000L) {
+        if (value < 128L) {
+          ensureRemainingCapacity(1);
+          buffer.put((byte) value);
+        } else if (value < 0x100L) {
+          ensureRemainingCapacity(2);
+          buffer.put(UINT8);
+          buffer.put((byte) value);
+        } else {
+          ensureRemainingCapacity(3);
+          buffer.put(UINT16);
+          buffer.putShort((short) value);
+        }
+      } else if (value < 0x100000000L) {
+        ensureRemainingCapacity(5);
+        buffer.put(UINT32);
+        buffer.putInt((int) value);
+      } else {
+        ensureRemainingCapacity(9);
+        buffer.put(INT64);
+        buffer.putLong(value);
+      }
     }
   }
 

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -103,6 +103,7 @@ public class Encoder {
     } else if (object instanceof RubyHash) {
       encodeHash((RubyHash) object);
     } else {
+      throw runtime.newArgumentError(String.format("Cannot pack type: %s", object.getClass().getName()));
     }
   }
 

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -86,13 +86,12 @@ public class Encoder {
   }
 
   private void encodeBignum(RubyBignum object) {
-    ensureRemainingCapacity(9);
     BigInteger value = ((RubyBignum) object).getBigIntegerValue();
-    if (value.compareTo(BigInteger.ZERO) == -1) {
-      buffer.put(INT64);
-    } else {
-      buffer.put(UINT64);
+    if (value.bitLength() > 64 || (value.bitLength() > 63 && value.signum() < 0)) {
+      throw runtime.newArgumentError(String.format("Cannot pack big integer: %s", value));
     }
+    ensureRemainingCapacity(9);
+    buffer.put(value.signum() < 0 ? INT64 : UINT64);
     byte[] b = value.toByteArray();
     buffer.put(b, b.length - 8, 8);
   }

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -204,7 +204,7 @@ public class Encoder {
       buffer.putInt(size);
     }
     for (int i = 0; i < size; i++) {
-      encodeObject(object.entry(i));
+      encodeObject(object.eltOk(i));
     }
   }
 

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -102,11 +102,11 @@ public class Encoder {
       ensureRemainingCapacity(9);
       buffer.put(INT64);
       buffer.putLong(value);
-    } else if (value < -0x7fffL) {
+    } else if (value < Short.MIN_VALUE) {
       ensureRemainingCapacity(5);
       buffer.put(INT32);
       buffer.putInt((int) value);
-    } else if (value < -0x7fL) {
+    } else if (value < Byte.MIN_VALUE) {
       ensureRemainingCapacity(3);
       buffer.put(INT16);
       buffer.putShort((short) value);

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -1,0 +1,246 @@
+package org.msgpack.jruby;
+
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+import org.jruby.Ruby;
+import org.jruby.RubyObject;
+import org.jruby.RubyNil;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyBignum;
+import org.jruby.RubyInteger;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyFloat;
+import org.jruby.RubyString;
+import org.jruby.RubySymbol;
+import org.jruby.RubyArray;
+import org.jruby.RubyHash;
+import org.jruby.RubyEncoding;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
+
+import org.jcodings.Encoding;
+import org.jcodings.specific.UTF8Encoding;
+
+
+public class Encoder {
+  private static final byte NIL     = (byte) 0xc0;
+  private static final byte FALSE   = (byte) 0xc2;
+  private static final byte TRUE    = (byte) 0xc3;
+  private static final byte BIN8    = (byte) 0xc4;
+  private static final byte BIN16   = (byte) 0xc5;
+  private static final byte BIN32   = (byte) 0xc6;
+  private static final byte FLOAT32 = (byte) 0xca;
+  private static final byte FLOAT64 = (byte) 0xcb;
+  private static final byte UINT8   = (byte) 0xcc;
+  private static final byte UINT16  = (byte) 0xcd;
+  private static final byte UINT32  = (byte) 0xce;
+  private static final byte UINT64  = (byte) 0xcf;
+  private static final byte INT8    = (byte) 0xd0;
+  private static final byte INT16   = (byte) 0xd1;
+  private static final byte INT32   = (byte) 0xd2;
+  private static final byte INT64   = (byte) 0xd3;
+  private static final byte STR8    = (byte) 0xd9;
+  private static final byte STR16   = (byte) 0xda;
+  private static final byte STR32   = (byte) 0xdb;
+  private static final byte ARY16   = (byte) 0xdc;
+  private static final byte ARY32   = (byte) 0xdd;
+  private static final byte MAP16   = (byte) 0xde;
+  private static final byte MAP32   = (byte) 0xdf;
+
+  private final Ruby runtime;
+  private final Encoding binaryEncoding;
+  private final Encoding utf8Encoding;
+
+  private byte[] bytes;
+  private ByteBuffer buffer;
+
+  public Encoder(Ruby runtime) {
+    this.runtime = runtime;
+    this.bytes = new byte[65535];
+    this.buffer = ByteBuffer.wrap(bytes);
+    this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
+    this.utf8Encoding = UTF8Encoding.INSTANCE;
+  }
+
+  private void ensureCapacity(int c) {
+    if (buffer.remaining() < c) {
+      byte[] oldBytes = bytes;
+      int oldPosition = buffer.position();
+      int newLength = Math.max(oldBytes.length * 2, oldBytes.length + c);
+      bytes = new byte[newLength];
+      System.arraycopy(oldBytes, 0, bytes, 0, oldBytes.length);
+      buffer = ByteBuffer.wrap(bytes);
+      buffer.position(oldPosition);
+    }
+  }
+
+  public IRubyObject encode(IRubyObject object) {
+    encodeObject(object);
+    return runtime.newString(new ByteList(bytes, 0, buffer.position(), binaryEncoding, false));
+  }
+
+  private void encodeObject(IRubyObject object) {
+    if (object == null || object instanceof RubyNil) {
+      ensureCapacity(1);
+      buffer.put(NIL);
+    } else if (object instanceof RubyBoolean) {
+      ensureCapacity(1);
+      buffer.put(((RubyBoolean) object).isTrue() ? TRUE : FALSE);
+    } else if (object instanceof RubyBignum) {
+      encodeBignum((RubyBignum) object);
+    } else if (object instanceof RubyInteger) {
+      encodeInteger((RubyInteger) object);
+    } else if (object instanceof RubyFloat) {
+      encodeFloat((RubyFloat) object);
+    } else if (object instanceof RubyString) {
+      encodeString((RubyString) object);
+    } else if (object instanceof RubySymbol) {
+      encodeString(((RubySymbol) object).asString());
+    } else if (object instanceof RubyArray) {
+      encodeArray((RubyArray) object);
+    } else if (object instanceof RubyHash) {
+      encodeHash((RubyHash) object);
+    } else {
+    }
+  }
+
+  private void encodeBignum(RubyBignum object) {
+    ensureCapacity(9);
+    BigInteger value = ((RubyBignum) object).getBigIntegerValue();
+    if (value.compareTo(BigInteger.ZERO) == -1) {
+      buffer.put(INT64);
+    } else {
+      buffer.put(UINT64);
+    }
+    byte[] b = value.toByteArray();
+    buffer.put(b, b.length - 8, 8);
+  }
+
+  private void encodeInteger(RubyInteger object) {
+    long value = ((RubyInteger) object).getLongValue();
+    if (value < Integer.MIN_VALUE) {
+      ensureCapacity(9);
+      buffer.put(INT64);
+      buffer.putLong(value);
+    } else if (value < -0x7fffL) {
+      ensureCapacity(5);
+      buffer.put(INT32);
+      buffer.putInt((int) value);
+    } else if (value < -0x7fL) {
+      ensureCapacity(3);
+      buffer.put(INT16);
+      buffer.putShort((short) value);
+    } else if (value < -0x20L) {
+      ensureCapacity(2);
+      buffer.put(INT8);
+      buffer.put((byte) value);
+    } else if (value < 0L) {
+      ensureCapacity(1);
+      byte b = (byte) (value | 0xe0);
+      buffer.put(b);
+    } else if (value < 128L) {
+      ensureCapacity(1);
+      buffer.put((byte) value);
+    } else if (value < 0x100L) {
+      ensureCapacity(2);
+      buffer.put(UINT8);
+      buffer.put((byte) value);
+    } else if (value < 0x10000L) {
+      ensureCapacity(3);
+      buffer.put(UINT16);
+      buffer.putShort((short) value);
+    } else if (value < 0x100000000L) {
+      ensureCapacity(5);
+      buffer.put(UINT32);
+      buffer.putInt((int) value);
+    } else {
+      ensureCapacity(9);
+      buffer.put(UINT64);
+      buffer.putLong(value);
+    }
+  }
+
+  private void encodeFloat(RubyFloat object) {
+    double value = object.getDoubleValue();
+    float f = (float) value;
+    if (Double.compare(f, value) == 0) {
+      ensureCapacity(5);
+      buffer.put(FLOAT32);
+      buffer.putFloat(f);
+    } else {
+      ensureCapacity(9);
+      buffer.put(FLOAT64);
+      buffer.putDouble(value);
+    }
+  }
+
+  private void encodeString(RubyString object) {
+    Encoding encoding = object.getEncoding();
+    boolean binary = encoding == binaryEncoding;
+    if (encoding != utf8Encoding && encoding != binaryEncoding) {
+      object = (RubyString) object.encode(runtime.getCurrentContext(), RubyEncoding.newEncoding(runtime, utf8Encoding));
+    }
+    ByteList bytes = object.getByteList();
+    int length = bytes.length();
+    if (length < 32 && !binary) {
+      ensureCapacity(1 + length);
+      buffer.put((byte) (length | 0xa0));
+    } else if (length < 0xff) {
+      ensureCapacity(2 + length);
+      buffer.put(binary ? BIN8 : STR8);
+      buffer.put((byte) length);
+    } else if (length < 0xffff) {
+      ensureCapacity(3 + length);
+      buffer.put(binary ? BIN16 : STR16);
+      buffer.putShort((short) length);
+    } else {
+      ensureCapacity(5 + length);
+      buffer.put(binary ? BIN32 : STR32);
+      buffer.putInt((int) length);
+    }
+    buffer.put(bytes.unsafeBytes(), bytes.begin(), length);
+  }
+
+  private void encodeArray(RubyArray object) {
+    int size = object.size();
+    if (size < 16) {
+      ensureCapacity(1);
+      buffer.put((byte) (size | 0x90));
+    } else if (size < 0x10000) {
+      ensureCapacity(3);
+      buffer.put(ARY16);
+      buffer.putShort((short) size);
+    } else {
+      ensureCapacity(5);
+      buffer.put(ARY32);
+      buffer.putInt(size);
+    }
+    for (int i = 0; i < size; i++) {
+      encodeObject(object.entry(i));
+    }
+  }
+
+  private void encodeHash(RubyHash object) {
+    int size = object.size();
+    if (size < 16) {
+      ensureCapacity(1);
+      buffer.put((byte) (size | 0x80));
+    } else if (size < 0x10000) {
+      ensureCapacity(3);
+      buffer.put(MAP16);
+      buffer.putShort((short) size);
+    } else {
+      ensureCapacity(5);
+      buffer.put(MAP32);
+      buffer.putInt(size);
+    }
+    RubyArray keys = object.keys();
+    RubyArray values = object.rb_values();
+    for (int i = 0; i < size; i++) {
+      encodeObject(keys.entry(i));
+      encodeObject(values.entry(i));
+    }
+  }
+}

--- a/ext/java/org/msgpack/jruby/ExtensionValue.java
+++ b/ext/java/org/msgpack/jruby/ExtensionValue.java
@@ -1,0 +1,134 @@
+package org.msgpack.jruby;
+
+
+import java.util.Arrays;
+import java.nio.ByteBuffer;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyString;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.util.ByteList;
+
+import org.jcodings.Encoding;
+
+import static org.msgpack.jruby.Types.*;
+
+
+@JRubyClass(name="MessagePack::ExtensionValue")
+public class ExtensionValue extends RubyObject {
+  private final Encoding binaryEncoding;
+
+  private RubyFixnum type;
+  private RubyString payload;
+
+  public ExtensionValue(Ruby runtime, RubyClass type) {
+    super(runtime, type);
+    this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
+  }
+
+  public static class ExtensionValueAllocator implements ObjectAllocator {
+    public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+      return new ExtensionValue(runtime, klass);
+    }
+  }
+
+  public static ExtensionValue newExtensionValue(Ruby runtime, int type, byte[] payload) {
+    ExtensionValue v = new ExtensionValue(runtime, runtime.getModule("MessagePack").getClass("ExtensionValue"));
+    ByteList byteList = new ByteList(payload, runtime.getEncodingService().getAscii8bitEncoding());
+    v.initialize(runtime.getCurrentContext(), runtime.newFixnum(type), runtime.newString(byteList));
+    return v;
+  }
+
+  @JRubyMethod(name = "initialize", required = 2)
+  public IRubyObject initialize(ThreadContext ctx, IRubyObject type, IRubyObject payload) {
+    this.type = (RubyFixnum) type;
+    this.payload = (RubyString) payload;
+    return this;
+  }
+
+  @JRubyMethod(name = "to_msgpack")
+  public IRubyObject toMsgpack() {
+    ByteList payloadBytes = payload.getByteList();
+    int payloadSize = payloadBytes.length();
+    int outputSize = 0;
+    boolean fixSize = payloadSize == 1 || payloadSize == 2 || payloadSize == 4 || payloadSize == 8 || payloadSize == 16;
+    if (fixSize) {
+      outputSize = 2 + payloadSize;
+    } else if (payloadSize < 0x100) {
+      outputSize = 3 + payloadSize;
+    } else if (payloadSize < 0x10000) {
+      outputSize = 4 + payloadSize;
+    } else {
+      outputSize = 6 + payloadSize;
+    }
+    byte[] bytes = new byte[outputSize];
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    if (payloadSize == 1) {
+      buffer.put(FIXEXT1);
+      buffer.put((byte) type.getLongValue());
+      buffer.put((byte) payloadBytes.get(0));
+    } else if (payloadSize == 2) {
+      buffer.put(FIXEXT2);
+      buffer.put((byte) type.getLongValue());
+      buffer.put(payloadBytes.unsafeBytes(), payloadBytes.begin(), 2);
+    } else if (payloadSize == 4) {
+      buffer.put(FIXEXT4);
+      buffer.put((byte) type.getLongValue());
+      buffer.put(payloadBytes.unsafeBytes(), payloadBytes.begin(), 4);
+    } else if (payloadSize == 8) {
+      buffer.put(FIXEXT8);
+      buffer.put((byte) type.getLongValue());
+      buffer.put(payloadBytes.unsafeBytes(), payloadBytes.begin(), 8);
+    } else if (payloadSize == 16) {
+      buffer.put(FIXEXT16);
+      buffer.put((byte) type.getLongValue());
+      buffer.put(payloadBytes.unsafeBytes(), payloadBytes.begin(), 16);
+    } else if (payloadSize < 0x100) {
+      buffer.put(VAREXT8);
+      buffer.put((byte) payloadSize);
+      buffer.put((byte) type.getLongValue());
+      buffer.put(payloadBytes.unsafeBytes(), payloadBytes.begin(), payloadSize);
+    } else if (payloadSize < 0x10000) {
+      buffer.put(VAREXT16);
+      buffer.putShort((short) payloadSize);
+      buffer.put((byte) type.getLongValue());
+      buffer.put(payloadBytes.unsafeBytes(), payloadBytes.begin(), payloadSize);
+    } else {
+      buffer.put(VAREXT32);
+      buffer.putInt(payloadSize);
+      buffer.put((byte) type.getLongValue());
+      buffer.put(payloadBytes.unsafeBytes(), payloadBytes.begin(), payloadSize);
+    }
+    return getRuntime().newString(new ByteList(bytes, binaryEncoding, false));
+  }
+
+  @JRubyMethod(name = {"to_s", "inspect"})
+  @Override
+  public IRubyObject to_s() {
+    IRubyObject payloadStr = payload.callMethod(getRuntime().getCurrentContext(), "inspect");
+    return getRuntime().newString(String.format("#<MessagePack::ExtensionValue @type=%d, @payload=%s>", type.getLongValue(), payloadStr));
+  }
+
+  @JRubyMethod(name = "hash")
+  @Override
+  public RubyFixnum hash() {
+    long hash = payload.hashCode() & (type.getLongValue() << 56);
+    return RubyFixnum.newFixnum(getRuntime(), hash);
+  }
+
+  @JRubyMethod(name = "eql?")
+  public IRubyObject eql_p(ThreadContext ctx, IRubyObject o) {
+    if (o instanceof ExtensionValue) {
+      ExtensionValue other = (ExtensionValue) o;
+      return getRuntime().newBoolean(this.type.callMethod(ctx, "eql?", other.type).isTrue() && this.payload.callMethod(ctx, "eql?", other.payload).isTrue());
+    }
+    return getRuntime().getFalse();
+  }
+}

--- a/ext/java/org/msgpack/jruby/ExtensionValue.java
+++ b/ext/java/org/msgpack/jruby/ExtensionValue.java
@@ -16,6 +16,8 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.util.ByteList;
 
+import static org.jruby.runtime.Visibility.PRIVATE;
+
 import org.jcodings.Encoding;
 
 import static org.msgpack.jruby.Types.*;
@@ -46,7 +48,7 @@ public class ExtensionValue extends RubyObject {
     return v;
   }
 
-  @JRubyMethod(name = "initialize", required = 2)
+  @JRubyMethod(name = "initialize", required = 2, visibility = PRIVATE)
   public IRubyObject initialize(ThreadContext ctx, IRubyObject type, IRubyObject payload) {
     this.type = (RubyFixnum) type;
     this.payload = (RubyString) payload;

--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -24,6 +24,8 @@ public class MessagePackLibrary implements Library {
     extensionValueClass.defineAnnotatedMethods(ExtensionValue.class);
     RubyClass unpackerClass = msgpackModule.defineClassUnder("Unpacker", runtime.getObject(), new Unpacker.UnpackerAllocator());
     unpackerClass.defineAnnotatedMethods(Unpacker.class);
+    RubyClass bufferClass = msgpackModule.defineClassUnder("Buffer", runtime.getObject(), new Buffer.BufferAllocator());
+    bufferClass.defineAnnotatedMethods(Buffer.class);
   }
 
   @JRubyModule(name = "MessagePack")

--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -1,0 +1,38 @@
+package org.msgpack.jruby;
+
+
+import java.io.IOException;
+
+import org.jruby.Ruby;
+import org.jruby.RubyModule;
+import org.jruby.RubyClass;
+import org.jruby.RubyString;
+import org.jruby.RubyHash;
+import org.jruby.runtime.load.Library;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.anno.JRubyModule;
+import org.jruby.anno.JRubyMethod;
+
+
+public class MessagePackLibrary implements Library {
+  public void load(Ruby runtime, boolean wrap) throws IOException {
+    RubyModule msgpackModule = runtime.defineModule("MessagePack");
+    msgpackModule.defineAnnotatedMethods(MessagePackModule.class);
+  }
+
+  @JRubyModule(name = "MessagePack")
+  public static class MessagePackModule {
+    @JRubyMethod(module = true, required = 1, optional = 1, alias = {"dump"})
+    public static IRubyObject pack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) throws IOException {
+      Encoder encoder = new Encoder(ctx.getRuntime());
+      return encoder.encode(args[0]);
+    }
+
+    @JRubyMethod(module = true, required = 1, optional = 1, alias = {"load"})
+    public static IRubyObject unpack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) throws IOException {
+      Decoder decoder = new Decoder(ctx.getRuntime(), args[0].asString().getBytes());
+      return decoder.next();
+    }
+  }
+}

--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -17,6 +17,8 @@ public class MessagePackLibrary implements Library {
   public void load(Ruby runtime, boolean wrap) {
     RubyModule msgpackModule = runtime.defineModule("MessagePack");
     msgpackModule.defineAnnotatedMethods(MessagePackModule.class);
+    RubyClass extensionValueClass = msgpackModule.defineClassUnder("ExtensionValue", runtime.getObject(), new ExtensionValue.ExtensionValueAllocator());
+    extensionValueClass.defineAnnotatedMethods(ExtensionValue.class);
   }
 
   @JRubyModule(name = "MessagePack")

--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -17,8 +17,13 @@ public class MessagePackLibrary implements Library {
   public void load(Ruby runtime, boolean wrap) {
     RubyModule msgpackModule = runtime.defineModule("MessagePack");
     msgpackModule.defineAnnotatedMethods(MessagePackModule.class);
+    RubyClass standardErrorClass = runtime.getStandardError();
+    RubyClass unpackErrorClass = msgpackModule.defineClassUnder("UnpackError", standardErrorClass, standardErrorClass.getAllocator());
+    RubyClass underflowErrorClass = msgpackModule.defineClassUnder("UnderflowError", unpackErrorClass, unpackErrorClass.getAllocator());
     RubyClass extensionValueClass = msgpackModule.defineClassUnder("ExtensionValue", runtime.getObject(), new ExtensionValue.ExtensionValueAllocator());
     extensionValueClass.defineAnnotatedMethods(ExtensionValue.class);
+    RubyClass unpackerClass = msgpackModule.defineClassUnder("Unpacker", runtime.getObject(), new Unpacker.UnpackerAllocator());
+    unpackerClass.defineAnnotatedMethods(Unpacker.class);
   }
 
   @JRubyModule(name = "MessagePack")

--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -1,8 +1,6 @@
 package org.msgpack.jruby;
 
 
-import java.io.IOException;
-
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.RubyClass;
@@ -16,7 +14,7 @@ import org.jruby.anno.JRubyMethod;
 
 
 public class MessagePackLibrary implements Library {
-  public void load(Ruby runtime, boolean wrap) throws IOException {
+  public void load(Ruby runtime, boolean wrap) {
     RubyModule msgpackModule = runtime.defineModule("MessagePack");
     msgpackModule.defineAnnotatedMethods(MessagePackModule.class);
   }
@@ -24,13 +22,13 @@ public class MessagePackLibrary implements Library {
   @JRubyModule(name = "MessagePack")
   public static class MessagePackModule {
     @JRubyMethod(module = true, required = 1, optional = 1, alias = {"dump"})
-    public static IRubyObject pack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) throws IOException {
+    public static IRubyObject pack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) {
       Encoder encoder = new Encoder(ctx.getRuntime());
       return encoder.encode(args[0]);
     }
 
     @JRubyMethod(module = true, required = 1, optional = 1, alias = {"load"})
-    public static IRubyObject unpack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) throws IOException {
+    public static IRubyObject unpack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) {
       Decoder decoder = new Decoder(ctx.getRuntime(), args[0].asString().getBytes());
       return decoder.next();
     }

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -1,0 +1,78 @@
+package org.msgpack.jruby;
+
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.RubyHash;
+import org.jruby.RubyIO;
+import org.jruby.RubyInteger;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.util.ByteList;
+
+
+@JRubyClass(name="MessagePack::Packer")
+public class Packer extends RubyObject {
+  private Buffer buffer;
+  private Encoder encoder;
+
+  public Packer(Ruby runtime, RubyClass type) {
+    super(runtime, type);
+  }
+
+  static class PackerAllocator implements ObjectAllocator {
+    public IRubyObject allocate(Ruby runtime, RubyClass type) {
+      return new Packer(runtime, type);
+    }
+  }
+
+  @JRubyMethod(name = "initialize", optional = 2)
+  public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
+    this.encoder = new Encoder(ctx.getRuntime());
+    this.buffer = new Buffer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Buffer"));
+    this.buffer.initialize(ctx, args);
+    return this;
+  }
+
+  @JRubyMethod(name = "write")
+  public IRubyObject write(ThreadContext ctx, IRubyObject obj) {
+    return buffer.write(ctx, encoder.encode(obj, this));
+  }
+
+  @JRubyMethod(name = "write_nil")
+  public IRubyObject writeNil(ThreadContext ctx) {
+    return write(ctx, null);
+  }
+
+  @JRubyMethod(name = "write_array_header")
+  public IRubyObject writeArrayHeader(ThreadContext ctx, IRubyObject size) {
+    int s = (int) size.convertToInteger().getLongValue();
+    return buffer.write(ctx, encoder.encodeArrayHeader(s));
+  }
+
+  @JRubyMethod(name = "write_map_header")
+  public IRubyObject writeMapHeader(ThreadContext ctx, IRubyObject size) {
+    int s = (int) size.convertToInteger().getLongValue();
+    return buffer.write(ctx, encoder.encodeMapHeader(s));
+  }
+
+  @JRubyMethod(name = "to_s")
+  public IRubyObject toS(ThreadContext ctx) {
+    return buffer.toS(ctx);
+  }
+
+  @JRubyMethod(name = "buffer")
+  public IRubyObject buffer(ThreadContext ctx) {
+    return buffer;
+  }
+
+  @JRubyMethod(name = "flush")
+  public IRubyObject flush(ThreadContext ctx) {
+    return buffer.flush(ctx);
+  }
+
+}

--- a/ext/java/org/msgpack/jruby/Types.java
+++ b/ext/java/org/msgpack/jruby/Types.java
@@ -1,0 +1,36 @@
+package org.msgpack.jruby;
+
+
+public interface Types {
+  public static final byte NIL      = (byte) 0xc0;
+  public static final byte FALSE    = (byte) 0xc2;
+  public static final byte TRUE     = (byte) 0xc3;
+  public static final byte BIN8     = (byte) 0xc4;
+  public static final byte BIN16    = (byte) 0xc5;
+  public static final byte BIN32    = (byte) 0xc6;
+  public static final byte VAREXT8  = (byte) 0xc7;
+  public static final byte VAREXT16 = (byte) 0xc8;
+  public static final byte VAREXT32 = (byte) 0xc9;
+  public static final byte FLOAT32  = (byte) 0xca;
+  public static final byte FLOAT64  = (byte) 0xcb;
+  public static final byte UINT8    = (byte) 0xcc;
+  public static final byte UINT16   = (byte) 0xcd;
+  public static final byte UINT32   = (byte) 0xce;
+  public static final byte UINT64   = (byte) 0xcf;
+  public static final byte INT8     = (byte) 0xd0;
+  public static final byte INT16    = (byte) 0xd1;
+  public static final byte INT32    = (byte) 0xd2;
+  public static final byte INT64    = (byte) 0xd3;
+  public static final byte FIXEXT1  = (byte) 0xd4;
+  public static final byte FIXEXT2  = (byte) 0xd5;
+  public static final byte FIXEXT4  = (byte) 0xd6;
+  public static final byte FIXEXT8  = (byte) 0xd7;
+  public static final byte FIXEXT16 = (byte) 0xd8;
+  public static final byte STR8     = (byte) 0xd9;
+  public static final byte STR16    = (byte) 0xda;
+  public static final byte STR32    = (byte) 0xdb;
+  public static final byte ARY16    = (byte) 0xdc;
+  public static final byte ARY32    = (byte) 0xdd;
+  public static final byte MAP16    = (byte) 0xde;
+  public static final byte MAP32    = (byte) 0xdf;
+}

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -1,0 +1,170 @@
+package org.msgpack.jruby;
+
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyString;
+import org.jruby.RubyObject;
+import org.jruby.RubyHash;
+import org.jruby.RubyNumeric;
+import org.jruby.RubyIO;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.util.ByteList;
+import org.jruby.ext.stringio.StringIO;
+
+import static org.jruby.runtime.Visibility.PRIVATE;
+
+
+@JRubyClass(name="MessagePack::Unpacker")
+public class Unpacker extends RubyObject {
+  private IRubyObject stream;
+  private IRubyObject data;
+  private Decoder decoder;
+  private final RubyClass underflowErrorClass;
+
+  public Unpacker(Ruby runtime, RubyClass type) {
+    super(runtime, type);
+    this.underflowErrorClass = runtime.getModule("MessagePack").getClass("UnderflowError");
+  }
+
+  static class UnpackerAllocator implements ObjectAllocator {
+    public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+      return new Unpacker(runtime, klass);
+    }
+  }
+
+  @JRubyMethod(name = "initialize", optional = 1, visibility = PRIVATE)
+  public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
+    if (args.length > 0) {
+      if (args[args.length - 1] instanceof RubyHash) {
+
+      } else if (!(args[0] instanceof RubyHash)) {
+        setStream(ctx, args[0]);
+      }
+    }
+    return this;
+  }
+
+  @JRubyMethod(required = 2)
+  public IRubyObject execute(ThreadContext ctx, IRubyObject data, IRubyObject offset) {
+    return executeLimit(ctx, data, offset, null);
+  }
+
+  @JRubyMethod(name = "execute_limit", required = 3)
+  public IRubyObject executeLimit(ThreadContext ctx, IRubyObject str, IRubyObject off, IRubyObject lim) {
+    RubyString input = str.asString();
+    int offset = RubyNumeric.fix2int(off);
+    int limit = lim == null || lim.isNil() ? -1 : RubyNumeric.fix2int(lim);
+    ByteList byteList = input.getByteList();
+    if (limit == -1) {
+      limit = byteList.length() - offset;
+    }
+    Decoder decoder = new Decoder(ctx.getRuntime(), byteList.unsafeBytes(), byteList.begin() + offset, limit);
+    try {
+      this.data = null;
+      this.data = decoder.next();
+    } catch (RaiseException re) {
+      if (re.getException().getType() != underflowErrorClass) {
+        throw re;
+      }
+    }
+    return ctx.getRuntime().newFixnum(decoder.offset());
+  }
+
+  @JRubyMethod(name = "data")
+  public IRubyObject getData(ThreadContext ctx) {
+    if (data == null) {
+      return ctx.getRuntime().getNil();
+    } else {
+      return data;
+    }
+  }
+
+  @JRubyMethod(name = "finished?")
+  public IRubyObject finished_p(ThreadContext ctx) {
+    return data == null ? ctx.getRuntime().getFalse() : ctx.getRuntime().getTrue();
+  }
+
+  @JRubyMethod(required = 1)
+  public IRubyObject feed(ThreadContext ctx, IRubyObject data) {
+    ByteList byteList = data.asString().getByteList();
+    if (decoder == null) {
+      decoder = new Decoder(ctx.getRuntime(), byteList.unsafeBytes(), byteList.begin(), byteList.length());
+    } else {
+      decoder.feed(byteList.unsafeBytes(), byteList.begin(), byteList.length());
+    }
+    return ctx.getRuntime().getNil();
+  }
+
+  @JRubyMethod(name = "feed_each", required = 1)
+  public IRubyObject feedEach(ThreadContext ctx, IRubyObject data, Block block) {
+    feed(ctx, data);
+    each(ctx, block);
+    return ctx.getRuntime().getNil();
+  }
+
+  @JRubyMethod
+  public IRubyObject each(ThreadContext ctx, Block block) {
+    if (block.isGiven()) {
+      if (decoder != null) {
+        try {
+          while (decoder.hasNext()) {
+            block.yield(ctx, decoder.next());
+          }
+        } catch (RaiseException re) {
+          if (re.getException().getType() != underflowErrorClass) {
+            throw re;
+          }
+        }
+      }
+      return this;
+    } else {
+      return callMethod(ctx, "to_enum");
+    }
+  }
+
+  @JRubyMethod
+  public IRubyObject fill(ThreadContext ctx) {
+    return ctx.getRuntime().getNil();
+  }
+
+  @JRubyMethod
+  public IRubyObject reset(ThreadContext ctx) {
+    if (decoder != null) {
+      decoder.reset();
+    }
+    return ctx.getRuntime().getNil();
+  }
+
+  @JRubyMethod(name = "stream")
+  public IRubyObject getStream(ThreadContext ctx) {
+    if (stream == null) {
+      return ctx.getRuntime().getNil();
+    } else {
+      return stream;
+    }
+  }
+
+  @JRubyMethod(name = "stream=", required = 1)
+  public IRubyObject setStream(ThreadContext ctx, IRubyObject stream) {
+    RubyString str;
+    if (stream instanceof StringIO) {
+      str = stream.callMethod(ctx, "string").asString();
+    } else if (stream instanceof RubyIO) {
+      str = stream.callMethod(ctx, "read").asString();
+    } else {
+      throw ctx.getRuntime().newTypeError(stream, "IO");
+    }
+    ByteList byteList = str.getByteList();
+    this.stream = stream;
+    this.decoder = null;
+    this.decoder = new Decoder(ctx.getRuntime(), byteList.unsafeBytes(), byteList.begin(), byteList.length());
+    return getStream(ctx);
+  }
+}

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -3,7 +3,7 @@ require "msgpack/version"
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
   require 'jruby'
   require 'msgpack/msgpack.jar'
-  org.msgpack.jruby.MessagePackLibrary.new.load(JRuby.runtime, false);
+  org.msgpack.jruby.MessagePackLibrary.new.load(JRuby.runtime, false)
 else
   begin
     require "msgpack/#{RUBY_VERSION[/\d+.\d+/]}/msgpack"

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -1,6 +1,13 @@
 require "msgpack/version"
-begin
-  require "msgpack/#{RUBY_VERSION[/\d+.\d+/]}/msgpack"
-rescue LoadError
-  require "msgpack/msgpack"
+
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+  require 'jruby'
+  require 'msgpack/msgpack.jar'
+  org.msgpack.jruby.MessagePackLibrary.new.load(JRuby.runtime, false);
+else
+  begin
+    require "msgpack/#{RUBY_VERSION[/\d+.\d+/]}/msgpack"
+  rescue LoadError
+    require "msgpack/msgpack"
+  end
 end


### PR DESCRIPTION
_This is not complete, do not merge_

I've been working on integrating the in-progress v2.0 of [msgpack-jruby](https://github.com/iconara/msgpack-jruby) on top of msgpack-ruby. v2.0 does not depend on msgpack-java, like v1.x does, instead it contains its own Java implementation as a JRuby native extension.

I haven't had much time to work on this, but because of msgpack/msgpack-ruby#3 and f912169ecb22162d96c09e235f6f58f53fdc5bb6 I felt I needed to show that there is some progress. Please revert f912169ecb22162d96c09e235f6f58f53fdc5bb6 and the msgpack/jruby-merge branch, that version of msgpack-jruby is old, slower, and has unnecessary dependencies on bundled JAR files.

The work that needs to be done to get this to a mergeable point is to get `Unpacker` working (it's currently compatible with the old `Unpacker` from msgpack-ruby, but not the new one), and to fix some small issues with `Packer`. There are two classes called `Encoder` and `Decoder`, these should probably be merged into `Packer` and `Unpacker`.

I will continue working on this when I have time.

_Please don't merge this until these issues are resolved_