### PR TITLE
Add support for ActiveSupport's TimeWithZone class

### DIFF
--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -1,4 +1,6 @@
 require "msgpack/version"
+require "msgpack/active_support/time_with_zone"
+
 begin
   require "msgpack/#{RUBY_VERSION[/\d+.\d+/]}/msgpack"
 rescue LoadError

--- a/lib/msgpack/active_support/time_with_zone.rb
+++ b/lib/msgpack/active_support/time_with_zone.rb
@@ -1,0 +1,12 @@
+begin
+  require 'active_support/time_with_zone'
+
+  ActiveSupport::TimeWithZone.class_eval do
+    def to_msgpack(out='')
+      self.to_s.to_msgpack(out)
+    end
+  end
+
+rescue LoadError
+  # Do nothing if ActiveSupport is not available.
+end

--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', ['~> 2.11']
   s.add_development_dependency 'json', ['~> 1.7']
   s.add_development_dependency 'yard', ['~> 0.8.2']
+  s.add_development_dependency 'activesupport'
 end

--- a/spec/time_with_zone_spec.rb
+++ b/spec/time_with_zone_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'active_support/core_ext/numeric/time'
+
+describe ActiveSupport::TimeWithZone do
+  it 'should correctly pack a TimeWithZone object, including timezone' do
+    Time.zone = 'Pacific Time (US & Canada)'
+    initial_time = Time.zone.local(2014, 8, 21, 15, 30, 0)
+
+    packed_time = MessagePack.pack(initial_time)
+    packed_time.should == "\xB92014-08-21 15:30:00 -0700"
+
+    unpacked_time = MessagePack.unpack(packed_time)
+    unpacked_time.should == "2014-08-21 15:30:00 -0700"
+
+    parsed_time = Time.zone.parse(unpacked_time)
+    parsed_time.should == initial_time
+  end
+end


### PR DESCRIPTION
This ensures that TZ data is not stripped. Users will still need to parse the time from the string, but at least it will be serialized correctly.