### PR TITLE
fixed a bug that feed_each returns no data enumerator

### DIFF
--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -283,6 +283,13 @@ static VALUE Unpacker_each(VALUE self)
 
 static VALUE Unpacker_feed_each(VALUE self, VALUE data)
 {
+#ifdef RETURN_ENUMERATOR
+    {
+        VALUE argv[] = { data };
+        RETURN_ENUMERATOR(self, sizeof(argv) / sizeof(VALUE), argv);
+    }
+#endif
+
     // TODO optimize
     Unpacker_feed(self, data);
     return Unpacker_each(self);

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -134,6 +134,12 @@ describe Unpacker do
     objects.should == [sample_object] * 4
   end
 
+  it 'feed_each enumerator' do
+    raw = sample_object.to_msgpack.to_s * 4
+
+    unpacker.feed_each(raw).to_a.should == [sample_object] * 4
+  end
+
   it 'reset clears internal buffer' do
     # 1-element array
     unpacker.feed("\x91")


### PR DESCRIPTION
`unpacker.feed_each(data).each` raises the following error:

    ArgumentError: wrong number of arguments (0 for 1)