### PR TITLE
rename msgpack_unpacker_{init,reset,destroy} functions

### DIFF
--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -52,7 +52,7 @@ void msgpack_unpacker_static_destroy()
 
 #define HEAD_BYTE_REQUIRED 0xc1
 
-void msgpack_unpacker_init(msgpack_unpacker_t* uk)
+void _msgpack_unpacker_init(msgpack_unpacker_t* uk)
 {
     memset(uk, 0, sizeof(msgpack_unpacker_t));
 
@@ -73,7 +73,7 @@ void msgpack_unpacker_init(msgpack_unpacker_t* uk)
     uk->stack_capacity = MSGPACK_UNPACKER_STACK_CAPACITY;
 }
 
-void msgpack_unpacker_destroy(msgpack_unpacker_t* uk)
+void _msgpack_unpacker_destroy(msgpack_unpacker_t* uk)
 {
 #ifdef UNPACKER_STACK_RMEM
     msgpack_rmem_free(&s_stack_rmem, uk->stack);
@@ -101,7 +101,7 @@ void msgpack_unpacker_mark(msgpack_unpacker_t* uk)
     rb_gc_mark(uk->buffer_ref);
 }
 
-void msgpack_unpacker_reset(msgpack_unpacker_t* uk)
+void _msgpack_unpacker_reset(msgpack_unpacker_t* uk)
 {
     msgpack_buffer_clear(UNPACKER_BUFFER_(uk));
 

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -78,13 +78,13 @@ void msgpack_unpacker_static_init();
 
 void msgpack_unpacker_static_destroy();
 
-void msgpack_unpacker_init(msgpack_unpacker_t* uk);
+void _msgpack_unpacker_init(msgpack_unpacker_t* uk);
 
-void msgpack_unpacker_destroy(msgpack_unpacker_t* uk);
+void _msgpack_unpacker_destroy(msgpack_unpacker_t* uk);
 
 void msgpack_unpacker_mark(msgpack_unpacker_t* uk);
 
-void msgpack_unpacker_reset(msgpack_unpacker_t* uk);
+void _msgpack_unpacker_reset(msgpack_unpacker_t* uk);
 
 static inline void msgpack_unpacker_set_symbolized_keys(msgpack_unpacker_t* uk, bool enable)
 {

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -42,14 +42,14 @@ static void Unpacker_free(msgpack_unpacker_t* uk)
     if(uk == NULL) {
         return;
     }
-    msgpack_unpacker_destroy(uk);
+    _msgpack_unpacker_destroy(uk);
     free(uk);
 }
 
 static VALUE Unpacker_alloc(VALUE klass)
 {
     msgpack_unpacker_t* uk = ALLOC_N(msgpack_unpacker_t, 1);
-    msgpack_unpacker_init(uk);
+    _msgpack_unpacker_init(uk);
 
     VALUE self = Data_Wrap_Struct(klass, msgpack_unpacker_mark, Unpacker_free, uk);
 
@@ -292,7 +292,7 @@ static VALUE Unpacker_reset(VALUE self)
 {
     UNPACKER(self, uk);
 
-    msgpack_unpacker_reset(uk);
+    _msgpack_unpacker_reset(uk);
 
     return Qnil;
 }
@@ -318,7 +318,7 @@ VALUE MessagePack_unpack(int argc, VALUE* argv)
 
     VALUE self = Unpacker_alloc(cMessagePack_Unpacker);
     UNPACKER(self, uk);
-    //msgpack_unpacker_reset(s_unpacker);
+    //_msgpack_unpacker_reset(s_unpacker);
     //msgpack_buffer_reset_io(UNPACKER_BUFFER_(s_unpacker));
 
     /* prefer reference than copying; see MessagePack_Unpacker_module_init */


### PR DESCRIPTION
My collegue and me are creating a ruby wrapper for our C library. The library uses https://github.com/msgpack/msgpack-c.git 
We've noticed, that when some program requires both 'msgpack' ruby module and the wrapper, then "Segmentation fault" appears.
The reason - identical names of 3 functions in symbols of msgpack C library and the ruby module.

This patch adds underscores in the names of msgpack_unpacker_{init,reset,destroy} functions. They are used only internally and can't affect any external ruby code.
