### PR TITLE
Support JRuby 9k

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - ruby-head
   - rbx-2
   - jruby-19mode
+  - jruby-head
 
 os:
   - linux
@@ -23,3 +24,4 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: jruby-head

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -192,7 +192,7 @@ public class Encoder {
     Encoding encoding = object.getEncoding();
     boolean binary = encoding == binaryEncoding;
     if (encoding != utf8Encoding && encoding != binaryEncoding) {
-      object = (RubyString) ((RubyString) object).encode(runtime.getCurrentContext(), RubyEncoding.newEncoding(runtime, utf8Encoding));
+      object = (RubyString) ((RubyString) object).encode(runtime.getCurrentContext(), runtime.getEncodingService().getEncoding(utf8Encoding));
     }
     ByteList bytes = object.getByteList();
     int length = bytes.length();


### PR DESCRIPTION
As JRuby 9k is approaching release, it makes sense to add support for it. Only one tiny code change was required in order to get it up and running (while retaining backwards compatibility). I have verified locally that it works with jruby-head, jruby-1.7.2, and jruby-1.7.6.

I also took the opportunity to add jruby-head to the build matrix (allowing failures) for much the same reason.