### PR TITLE
Msgpack custom types

### DIFF
--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -188,6 +188,12 @@ static inline void msgpack_buffer_write_2(msgpack_buffer_t* b, int byte1, unsign
     *(b->tail.last++) = (char) byte2;
 }
 
+static inline void msgpack_buffer_write_data(msgpack_buffer_t* b, const void* data, size_t length)
+{
+    memcpy(b->tail.last, data, length);
+    b->tail.last += length;
+}
+
 static inline void msgpack_buffer_write_byte_and_data(msgpack_buffer_t* b, int byte, const void* data, size_t length)
 {
     (*b->tail.last++) = (char) byte;

--- a/ext/msgpack/core_ext.c
+++ b/ext/msgpack/core_ext.c
@@ -20,29 +20,6 @@
 #include "packer.h"
 #include "packer_class.h"
 
-static inline VALUE delegete_to_pack(int argc, VALUE* argv, VALUE self)
-{
-    if(argc == 0) {
-        return MessagePack_pack(1, &self);
-    } else if(argc == 1) {
-        /* write to io */
-        VALUE argv2[2];
-        argv2[0] = self;
-        argv2[1] = argv[0];
-        return MessagePack_pack(2, argv2);
-    } else {
-        rb_raise(rb_eArgError, "wrong number of arguments (%d for 0..1)", argc);
-    }
-}
-
-#define ENSURE_PACKER(argc, argv, packer, pk) \
-    if(argc != 1 || rb_class_of(argv[0]) != cMessagePack_Packer) { \
-        return delegete_to_pack(argc, argv, self); \
-    } \
-    VALUE packer = argv[0]; \
-    msgpack_packer_t *pk; \
-    Data_Get_Struct(packer, msgpack_packer_t, pk);
-
 static VALUE NilClass_to_msgpack(int argc, VALUE* argv, VALUE self)
 {
     ENSURE_PACKER(argc, argv, packer, pk);

--- a/ext/msgpack/core_ext.h
+++ b/ext/msgpack/core_ext.h
@@ -19,6 +19,31 @@
 #define MSGPACK_RUBY_CORE_EXT_H__
 
 #include "compat.h"
+#include "packer_class.h"
+
+static inline VALUE delegete_to_pack(int argc, VALUE* argv, VALUE self)
+{
+    if(argc == 0) {
+        return MessagePack_pack(1, &self);
+    } else if(argc == 1) {
+        /* write to io */
+        VALUE argv2[2];
+        argv2[0] = self;
+        argv2[1] = argv[0];
+        return MessagePack_pack(2, argv2);
+    } else {
+        rb_raise(rb_eArgError, "wrong number of arguments (%d for 0..1)", argc);
+    }
+}
+
+#define ENSURE_PACKER(argc, argv, packer, pk) \
+    if(argc != 1 || rb_class_of(argv[0]) != cMessagePack_Packer) { \
+        return delegete_to_pack(argc, argv, self); \
+    } \
+    VALUE packer = argv[0]; \
+    msgpack_packer_t *pk; \
+    Data_Get_Struct(packer, msgpack_packer_t, pk);
+
 
 void MessagePack_core_ext_module_init();
 

--- a/ext/msgpack/custom.c
+++ b/ext/msgpack/custom.c
@@ -26,6 +26,9 @@ static ID s___to_msgpack;
 static ID s_from_msgpack;
 static ID s_dump;
 static ID s_load;
+static ID s_instance_method;
+static ID s_arity;
+
 static VALUE mMarshal;
 static VALUE ePackError;
 
@@ -148,6 +151,12 @@ static VALUE custom_to_msgpack(int argc, VALUE* argv, VALUE self)
     return packer;
 }
 
+static int get_instance_method_arity(VALUE cls, ID method_id)
+{
+    VALUE method = rb_funcall(cls, s_instance_method, 1, ID2SYM(method_id));
+    return FIX2INT(rb_funcall(method, s_arity, 0));
+}
+
 static VALUE MessagePack_register_type_module_method(VALUE self, VALUE cls)
 {
     const char * clsname;
@@ -168,7 +177,7 @@ static VALUE MessagePack_register_type_module_method(VALUE self, VALUE cls)
              * we need to alias it to `__to_msgpack` and it will be called
              * by our `to_msgpack`.
              */
-            if (rb_mod_method_arity(cls, s_to_msgpack) == 0) {
+            if (get_instance_method_arity(cls, s_to_msgpack) == 0) {
                 rb_define_alias(cls, "__to_msgpack", "to_msgpack");
                 define_to_msgpack = has_custom_to_msgpack = true;
             }
@@ -198,6 +207,8 @@ void MessagePack_custom_module_init(VALUE mMessagePack)
     s_from_msgpack = rb_intern("from_msgpack");
     s_dump = rb_intern("dump");
     s_load = rb_intern("load");
+    s_instance_method = rb_intern("instance_method");
+    s_arity = rb_intern("arity");
 
     mMarshal = rb_define_module("Marshal");
 

--- a/ext/msgpack/custom.c
+++ b/ext/msgpack/custom.c
@@ -1,0 +1,149 @@
+/*
+ * MessagePack for Ruby
+ *
+ * Copyright (C) 2008-2015 Sadayuki Furuhashi, Scott Francis
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "custom.h"
+#include "packer.h"
+#include "packer_class.h"
+#include "core_ext.h"
+
+static ID s_to_msgpack;
+static ID s_dump;
+static ID s_load;
+static VALUE mMarshal;
+static VALUE ePackError;
+
+static st_table *msgpack_custom_types;
+
+#define MSGPACK_EXT_TYPE_RUBY 1
+
+VALUE msgpack_custom_unpack_type(char *buffer, size_t sz)
+{
+    return Qnil;
+}
+
+static unsigned char get_ext_byte(size_t sz)
+{
+    if (sz >= 16 && sz < 256)
+        return 0xc7;
+    else if (sz >= 256 && sz < (1UL << 16))
+        return 0xc8;
+    else if (sz <= 4)
+        return 0xd6;
+    else if (sz > 4 && sz <= 8)
+        return 0xd7;
+    else if (sz > 8 && sz <= 16)
+        return 0xd8;
+    else if (sz >= (1UL << 16) && sz < (1UL << 32))
+        return 0xc9;
+    else
+        rb_raise(rb_eArgError, "cannot serialize %zu byte object", sz);
+
+    return 0;
+}
+
+static VALUE custom_to_msgpack(int argc, VALUE* argv, VALUE self)
+{
+    const char * clsname;
+    VALUE data;
+    unsigned char ext;
+    size_t header_sz = 0, body_sz = 0, data_sz = 0, clsname_sz;
+
+    ENSURE_PACKER(argc, argv, packer, pk);
+
+    clsname = rb_obj_classname(self);
+    clsname_sz = strlen(clsname);
+    data = rb_funcall(mMarshal, s_dump, 1, self);
+    Check_Type(data, T_STRING);
+
+    /*
+     * see https://github.com/msgpack/msgpack/blob/master/spec.md#formats-ext
+     *
+     * format of the packed object is class_name\0marshal_data
+     */
+    data_sz = body_sz = clsname_sz + 1 + RSTRING_LEN(data);
+    ext = get_ext_byte(body_sz);
+    switch (ext & 0xf0) {
+    case 0xd0:
+        header_sz = 3;
+        body_sz = 1 << (ext - 0xd4);
+        break;
+    case 0xc0:
+        header_sz = 2 + (1 << (ext - 0xc7));
+        break;
+    default:
+        rb_raise(ePackError, "cannot serialize %s class", clsname);
+    }
+
+    msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), header_sz + body_sz);
+    msgpack_buffer_write_1(PACKER_BUFFER_(pk), ext);
+
+    if (ext == 0xc7) {
+        msgpack_buffer_write_1(PACKER_BUFFER_(pk), (uint8_t) data_sz);
+    } else if (ext == 0xc8) {
+        uint16_t be = _msgpack_be16((uint16_t) data_sz);
+        msgpack_buffer_write_data(PACKER_BUFFER_(pk), (void *) &be, 2);
+    } else if (ext == 0xc9) {
+        uint32_t be = _msgpack_be32((uint32_t) data_sz);
+        msgpack_buffer_write_data(PACKER_BUFFER_(pk), (void *) &be, 4);
+    }
+
+    msgpack_buffer_write_1(PACKER_BUFFER_(pk), MSGPACK_EXT_TYPE_RUBY);
+    msgpack_buffer_write_data(PACKER_BUFFER_(pk), (void *) clsname, clsname_sz);
+    msgpack_buffer_write_1(PACKER_BUFFER_(pk), '\0');
+    msgpack_buffer_write_data(PACKER_BUFFER_(pk), RSTRING_PTR(data), RSTRING_LEN(data));
+
+    if ((ext & 0xf0) == 0xd0) {
+        /* pad the rest of the data */
+        for (size_t i = 0; i < body_sz - data_sz; i++) {
+            msgpack_buffer_write_1(PACKER_BUFFER_(pk), '\0');
+        }
+    }
+
+    return packer;
+}
+
+static VALUE MessagePack_register_type_module_method(VALUE self, VALUE cls)
+{
+    const char * clsname;
+
+    Check_Type(cls, T_CLASS);
+
+    clsname = rb_class2name(cls);
+    if (!st_lookup(msgpack_custom_types, (st_data_t) clsname, NULL)) {
+        if (!rb_method_boundp(cls, s_to_msgpack, 0)) {
+            rb_define_method(cls, "to_msgpack", custom_to_msgpack, -1);
+        }
+        st_insert(msgpack_custom_types, (st_data_t) clsname, 1);
+    }
+
+    return Qnil;
+}
+
+void MessagePack_custom_module_init(VALUE mMessagePack)
+{
+    s_to_msgpack = rb_intern("to_msgpack");
+    s_dump = rb_intern("dump");
+    s_load = rb_intern("load");
+
+    mMarshal = rb_define_module("Marshal");
+
+    msgpack_custom_types = st_init_strtable();
+
+    ePackError = rb_define_class_under(mMessagePack, "PackError", rb_eStandardError);
+    rb_define_module_function(mMessagePack, "register_type", MessagePack_register_type_module_method, 1);
+}

--- a/ext/msgpack/custom.h
+++ b/ext/msgpack/custom.h
@@ -1,7 +1,7 @@
 /*
  * MessagePack for Ruby
  *
- * Copyright (C) 2008-2013 Sadayuki Furuhashi
+ * Copyright (C) 2008-2015 Sadayuki Furuhashi, Scott Francis
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,21 +15,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#ifndef MSGPACK_RUBY_CUSTOM_H__
+#define MSGPACK_RUBY_CUSTOM_H__
 
-#include "buffer_class.h"
-#include "packer_class.h"
-#include "unpacker_class.h"
-#include "core_ext.h"
-#include "custom.h"
+#include "compat.h"
 
-void Init_msgpack(void)
-{
-    VALUE mMessagePack = rb_define_module("MessagePack");
+void MessagePack_custom_module_init(VALUE mMessagePack);
 
-    MessagePack_Buffer_module_init(mMessagePack);
-    MessagePack_Packer_module_init(mMessagePack);
-    MessagePack_Unpacker_module_init(mMessagePack);
-    MessagePack_custom_module_init(mMessagePack);
-    MessagePack_core_ext_module_init();
-}
+VALUE msgpack_custom_unpack_type(char *buffer, size_t sz);
+
+#endif
 

--- a/ext/msgpack/custom.h
+++ b/ext/msgpack/custom.h
@@ -22,7 +22,7 @@
 
 void MessagePack_custom_module_init(VALUE mMessagePack);
 
-VALUE msgpack_custom_unpack_type(char *buffer, size_t sz);
+VALUE msgpack_custom_unpack_type(const char *buffer, size_t sz);
 
 #endif
 

--- a/spec/cruby/custom_spec.rb
+++ b/spec/cruby/custom_spec.rb
@@ -6,10 +6,35 @@ class UnregisteredCustomMessagePackExtension; end
 
 class Z; end
 
+class CustomMessagePackExtensionWithSerializer
+  class << self
+    attr_accessor :serialized, :deserialized
+
+    def reset
+      @deserialized = @serialized = false
+    end
+  end
+
+  def to_msgpack
+    self.class.serialized = true
+    "1"
+  end
+
+  def self.from_msgpack(data)
+    @deserialized = data
+    self.new
+  end
+end
+
 describe MessagePack do
   before(:all) do
     MessagePack.register_type CustomMessagePackExtension
     MessagePack.register_type Z
+    MessagePack.register_type CustomMessagePackExtensionWithSerializer
+  end
+
+  before(:each) do
+    CustomMessagePackExtensionWithSerializer.reset
   end
 
   it 'serializes custom types' do
@@ -36,5 +61,17 @@ describe MessagePack do
     z = Z.new
     packed = MessagePack.pack(z)
     expect(packed.size).to be == 18 # fixext 16
+  end
+
+  it 'should support custom serialization' do
+    expect(CustomMessagePackExtensionWithSerializer.serialized).to be false
+    expect(CustomMessagePackExtensionWithSerializer.deserialized).to be false
+
+    packed = MessagePack.pack(CustomMessagePackExtensionWithSerializer.new)
+    expect(CustomMessagePackExtensionWithSerializer.serialized).to be true
+
+    obj = MessagePack.unpack(packed)
+    expect(CustomMessagePackExtensionWithSerializer.deserialized).to be == "1"
+    expect(obj.class).to be CustomMessagePackExtensionWithSerializer
   end
 end

--- a/spec/cruby/custom_spec.rb
+++ b/spec/cruby/custom_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+class CustomMessagePackExtension; end
+
+class UnregisteredCustomMessagePackExtension; end
+
+describe MessagePack do
+  before(:all) do
+    MessagePack.register_type CustomMessagePackExtension
+  end
+
+  it 'serializes custom types' do
+    o = CustomMessagePackExtension.new
+    expect {
+      MessagePack.pack(o).should_not be_nil
+    }.to_not raise_error
+  end
+
+  it 'should raise for unregistered types' do
+    expect {
+      MessagePack.pack(UnregisteredCustomMessagePackExtension.new)
+    }.to raise_error
+  end
+end

--- a/spec/cruby/custom_spec.rb
+++ b/spec/cruby/custom_spec.rb
@@ -4,9 +4,12 @@ class CustomMessagePackExtension; end
 
 class UnregisteredCustomMessagePackExtension; end
 
+class Z; end
+
 describe MessagePack do
   before(:all) do
     MessagePack.register_type CustomMessagePackExtension
+    MessagePack.register_type Z
   end
 
   it 'serializes custom types' do
@@ -20,5 +23,18 @@ describe MessagePack do
     expect {
       MessagePack.pack(UnregisteredCustomMessagePackExtension.new)
     }.to raise_error
+  end
+
+  it 'should unpack a custom type' do
+    o = CustomMessagePackExtension.new
+    expect {
+      MessagePack.unpack(MessagePack.pack(o))
+    }.to_not raise_error
+  end
+
+  it 'should unpack a fixext type' do
+    z = Z.new
+    packed = MessagePack.pack(z)
+    expect(packed.size).to be == 18 # fixext 16
   end
 end

--- a/spec/cruby/custom_spec.rb
+++ b/spec/cruby/custom_spec.rb
@@ -26,6 +26,10 @@ class CustomMessagePackExtensionWithSerializer
   end
 end
 
+class CustomMessagePackExtensionWithSerializerNoFrom
+  def to_msgpack; end
+end
+
 describe MessagePack do
   before(:all) do
     MessagePack.register_type CustomMessagePackExtension
@@ -73,5 +77,18 @@ describe MessagePack do
     obj = MessagePack.unpack(packed)
     expect(CustomMessagePackExtensionWithSerializer.deserialized).to be == "1"
     expect(obj.class).to be CustomMessagePackExtensionWithSerializer
+  end
+
+  it 'should support custom types in collections' do
+    a = [ CustomMessagePackExtension.new ]
+    packed = MessagePack.pack(a)
+    a = MessagePack.unpack(packed)
+    expect(a[0].class).to be CustomMessagePackExtension
+  end
+
+  it 'should raise when a custom serializer does not implement from_msgpack' do
+    expect {
+      MessagePack.register_type CustomMessagePackExtensionWithSerializerNoFrom
+    }.to raise_error
   end
 end


### PR DESCRIPTION
This is an attempt at resolving #42.

The idea here is to add the ability to serialize custom types using [MessagePack’s extension mechanism](https://github.com/msgpack/msgpack/blob/master/spec.md#types-extension-type). Basic usage is very simple:

```ruby
MessagePack.register_type Time
MessagePack.register_type Date
MessagePack.register_type DateTime
```

By default, the implementation serializes the type using Ruby’s `Marshal`. The upside of this is that it allows for the serialization of any Ruby type, but the downside is that it’s serialized data (Marshal) within serialized data (MessagePack), which has a negative impact on performance.

It’s possible to provide custom serialization for any Ruby type, instead of using `Marshal`. To do this, define a `to_msgpack` instance method on a class which returns a string:
```ruby
class Time
  def to_msgpack
    # pack a Time instance into 12 bytes
    “#{[tv_sec].pack(‘Q>’)}#{[tv_nsec / 1000].pack(‘L>’)}"
  end
end
```

If using custom serialization with `to_msgpack` you must also provide a custom `from_msgpack` class method:
```ruby
class Time
  def self.from_msgpack(data)
    Time.at(*data.unpack(‘Q>L>’))
  end
end
```
If using `to_msgpack` and `from_msgpack` for custom serialization, you must define those methods *before* registering the type with `MessagePack.register_type`.

/cc: @byroot, @fbogsany