### PR TITLE
Add benchmarks and long-running test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org/'
 
 gemspec
+gem "viiite"

--- a/bench/pack.rb
+++ b/bench/pack.rb
@@ -1,0 +1,23 @@
+require 'viiite'
+require 'msgpack'
+
+data = { 'hello' => 'world', 'nested' => ['structure', {value: 42}] }
+data_sym = { hello: 'world', nested: ['structure', {value: 42}] }
+
+data = MessagePack.pack(:hello => 'world', :nested => ['structure', {:value => 42}])
+
+Viiite.bench do |b|
+  b.range_over([10_000, 100_000, 1000_000], :runs) do |runs|
+    b.report(:strings) do
+      runs.times do
+        MessagePack.pack(data)
+      end
+    end
+
+    b.report(:symbols) do
+      runs.times do
+        MessagePack.pack(data_sym)
+      end
+    end
+  end
+end

--- a/bench/pack_log.rb
+++ b/bench/pack_log.rb
@@ -1,0 +1,33 @@
+require 'viiite'
+require 'msgpack'
+
+data_plain = { 'message' => '127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"' }
+data_structure = {
+  'remote_host' => '127.0.0.1',
+  'remote_user' => '-',
+  'date' => '10/Oct/2000:13:55:36 -0700',
+  'request' => 'GET /apache_pb.gif HTTP/1.0',
+  'method' => 'GET',
+  'path' => '/apache_pb.gif',
+  'protocol' => 'HTTP/1.0',
+  'status' => 200,
+  'bytes' => 2326,
+  'referer' => 'http://www.example.com/start.html',
+  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
+}
+
+Viiite.bench do |b|
+  b.range_over([10_000, 100_000, 1000_000], :runs) do |runs|
+    b.report(:plain) do
+      runs.times do
+        MessagePack.pack(data_plain)
+      end
+    end
+
+    b.report(:structure) do
+      runs.times do
+        MessagePack.pack(data_structure)
+      end
+    end
+  end
+end

--- a/bench/pack_log_long.rb
+++ b/bench/pack_log_long.rb
@@ -1,0 +1,65 @@
+# viiite report --regroup bench,threads bench/pack_log_long.rb
+
+require 'viiite'
+require 'msgpack'
+
+data_plain = { 'message' => '127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"' }
+data_structure = {
+  'remote_host' => '127.0.0.1',
+  'remote_user' => '-',
+  'date' => '10/Oct/2000:13:55:36 -0700',
+  'request' => 'GET /apache_pb.gif HTTP/1.0',
+  'method' => 'GET',
+  'path' => '/apache_pb.gif',
+  'protocol' => 'HTTP/1.0',
+  'status' => 200,
+  'bytes' => 2326,
+  'referer' => 'http://www.example.com/start.html',
+  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
+}
+
+seconds = 5 # 3600 # 1 hour
+
+Viiite.bench do |b|
+  b.range_over([2, 4, 8, 16], :threads) do |threads|
+    b.report(:plain) do
+      ths = []
+      end_at = Time.now + seconds
+      threads.times do
+        t = Thread.new do
+          packs = 0
+          while Time.now < end_at
+            10000.times do
+              MessagePack.pack(data_plain)
+            end
+            packs += 10000
+          end
+          packs
+        end
+        ths.push t
+      end
+      sum = ths.reduce(0){|r,t| r + t.value }
+      puts "MessagePack.pack, plain, #{threads} threads: #{sum} times, #{sum / seconds} times/second."
+    end
+
+    b.report(:structure) do
+      ths = []
+      end_at = Time.now + seconds
+      threads.times do
+        t = Thread.new do
+          packs = 0
+          while Time.now < end_at
+            10000.times do
+              MessagePack.pack(data_structure)
+            end
+            packs += 10000
+          end
+          packs
+        end
+        ths.push t
+      end
+      sum = ths.reduce(0){|r,t| r + t.value }
+      puts "MessagePack.pack, structured, #{threads} threads: #{sum} times, #{sum / seconds} times/second."
+    end
+  end
+end

--- a/bench/pack_log_long.rb
+++ b/bench/pack_log_long.rb
@@ -18,10 +18,10 @@ data_structure = {
   'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
 }
 
-seconds = 5 # 3600 # 1 hour
+seconds = 3600 # 1 hour
 
 Viiite.bench do |b|
-  b.range_over([2, 4, 8, 16], :threads) do |threads|
+  b.range_over([1, 2, 4, 8, 16], :threads) do |threads|
     b.report(:plain) do
       ths = []
       end_at = Time.now + seconds

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-# execute `rbenv shell 2.2.1`(or jruby-x.x.x or ...) and `bundle install`
+# prerequisites
+# $ rbenv shell 2.2.1 (or jruby-x.x.x or ...)
+# $ rake install
 
 echo "pack"
 viiite report --regroup bench,runs bench/pack.rb 

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# execute `rbenv shell 2.2.1`(or jruby-x.x.x or ...) and `bundle install`
+
+echo "pack"
+viiite report --regroup bench,runs bench/pack.rb 
+echo "unpack"
+viiite report --regroup bench,runs bench/unpack.rb 
+echo "pack log"
+viiite report --regroup bench,runs bench/pack_log.rb 
+echo "unpack log"
+viiite report --regroup bench,runs bench/unpack_log.rb 

--- a/bench/run_long.sh
+++ b/bench/run_long.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# prerequisites
+# $ sudo apt-get install sysstat
+# $ rbenv shell 2.2.1 (or jruby-x.x.x or ...)
+# $ rake install
+
+echo "pack log long"
+viiite report --regroup bench,threads bench/pack.rb &
+sar -r 60 60 > pack_log_long.sar &
+
+sleep 3700
+
+echo "unpack log long"
+viiite report --regroup bench,threads bench/unpack.rb &
+sar -r 60 60 > unpack_log_long.sar & &
+
+sleep 3700

--- a/bench/run_long.sh
+++ b/bench/run_long.sh
@@ -6,13 +6,14 @@
 # $ rake install
 
 echo "pack log long"
-viiite report --regroup bench,threads bench/pack.rb &
+viiite report --regroup bench,threads bench/pack_log_long.rb &
 sar -r 60 60 > pack_log_long.sar &
 
-sleep 3700
+sleep 36060 # 60*60 * 5[threads] * 2[bench] + 60 (cool down)
 
 echo "unpack log long"
-viiite report --regroup bench,threads bench/unpack.rb &
+viiite report --regroup bench,threads bench/unpack_log_long.rb &
 sar -r 60 60 > unpack_log_long.sar & &
 
-sleep 3700
+sleep 36060 # 60*60 * 5[threads] * 2[bench] + 60 (cool down)
+

--- a/bench/run_long.sh
+++ b/bench/run_long.sh
@@ -7,13 +7,13 @@
 
 echo "pack log long"
 viiite report --regroup bench,threads bench/pack_log_long.rb &
-sar -r 60 600 > pack_log_long.sar &
+sar -o pack_log_long.sar -r 60 600 > /dev/null 2>&1 &
 
 sleep 36060 # 60*60 * 5[threads] * 2[bench] + 60 (cool down)
 
 echo "unpack log long"
 viiite report --regroup bench,threads bench/unpack_log_long.rb &
-sar -r 60 600 > unpack_log_long.sar & &
+sar -o unpack_log_long.sar -r 60 600 > /dev/null 2>&1 &
 
 sleep 36060 # 60*60 * 5[threads] * 2[bench] + 60 (cool down)
 

--- a/bench/run_long.sh
+++ b/bench/run_long.sh
@@ -7,13 +7,13 @@
 
 echo "pack log long"
 viiite report --regroup bench,threads bench/pack_log_long.rb &
-sar -r 60 60 > pack_log_long.sar &
+sar -r 60 600 > pack_log_long.sar &
 
 sleep 36060 # 60*60 * 5[threads] * 2[bench] + 60 (cool down)
 
 echo "unpack log long"
 viiite report --regroup bench,threads bench/unpack_log_long.rb &
-sar -r 60 60 > unpack_log_long.sar & &
+sar -r 60 600 > unpack_log_long.sar & &
 
 sleep 36060 # 60*60 * 5[threads] * 2[bench] + 60 (cool down)
 

--- a/bench/run_long.sh
+++ b/bench/run_long.sh
@@ -5,15 +5,31 @@
 # $ rbenv shell 2.2.1 (or jruby-x.x.x or ...)
 # $ rake install
 
+# 60 * 600 : 60*60 * 5[threads] * 2[bench]
+
+ruby -v
+
 echo "pack log long"
 viiite report --regroup bench,threads bench/pack_log_long.rb &
 sar -o pack_log_long.sar -r 60 600 > /dev/null 2>&1 &
 
-sleep 36060 # 60*60 * 5[threads] * 2[bench] + 60 (cool down)
+declare -i i=0
+while [ $i -lt 600 ]; do
+    ps auxww | grep ruby | grep -v grep | awk '{print $5,$6;}' >> pack_log_long.mem.txt
+    i=i+1
+    sleep 60
+done
+
+sleep 120 # cool down
 
 echo "unpack log long"
 viiite report --regroup bench,threads bench/unpack_log_long.rb &
 sar -o unpack_log_long.sar -r 60 600 > /dev/null 2>&1 &
 
-sleep 36060 # 60*60 * 5[threads] * 2[bench] + 60 (cool down)
+i=0
+while [ $i -lt 600 ]; do
+    ps auxww | grep ruby | grep -v grep | awk '{print $5,$6;}' >> pack_log_long.mem.txt
+    i=i+1
+    sleep 60
+done
 

--- a/bench/unpack.rb
+++ b/bench/unpack.rb
@@ -1,0 +1,21 @@
+require 'viiite'
+require 'msgpack'
+
+data = MessagePack.pack(:hello => 'world', :nested => ['structure', {:value => 42}])
+
+Viiite.bench do |b|
+  b.range_over([10_000, 100_000, 1000_000], :runs) do |runs|
+    b.report(:strings) do
+      runs.times do
+        MessagePack.unpack(data)
+      end
+    end
+
+    b.report(:symbols) do
+      options = {:symbolize_keys => true}
+      runs.times do
+        MessagePack.unpack(data, options)
+      end
+    end
+  end
+end

--- a/bench/unpack_log.rb
+++ b/bench/unpack_log.rb
@@ -1,0 +1,34 @@
+require 'viiite'
+require 'msgpack'
+
+data_plain = MessagePack.pack({ 'message' => '127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"' })
+
+data_structure = MessagePack.pack({
+  'remote_host' => '127.0.0.1',
+  'remote_user' => '-',
+  'date' => '10/Oct/2000:13:55:36 -0700',
+  'request' => 'GET /apache_pb.gif HTTP/1.0',
+  'method' => 'GET',
+  'path' => '/apache_pb.gif',
+  'protocol' => 'HTTP/1.0',
+  'status' => 200,
+  'bytes' => 2326,
+  'referer' => 'http://www.example.com/start.html',
+  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
+})
+
+Viiite.bench do |b|
+  b.range_over([10_000, 100_000, 1000_000], :runs) do |runs|
+    b.report(:plain) do
+      runs.times do
+        MessagePack.unpack(data_plain)
+      end
+    end
+
+    b.report(:structure) do
+      runs.times do
+        MessagePack.unpack(data_structure)
+      end
+    end
+  end
+end

--- a/bench/unpack_log_long.rb
+++ b/bench/unpack_log_long.rb
@@ -1,0 +1,67 @@
+# viiite report --regroup bench,threads bench/pack_log_long.rb
+
+require 'viiite'
+require 'msgpack'
+
+data_plain = MessagePack.pack({
+    'message' => '127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"'
+})
+data_structure = MessagePack.pack({
+  'remote_host' => '127.0.0.1',
+  'remote_user' => '-',
+  'date' => '10/Oct/2000:13:55:36 -0700',
+  'request' => 'GET /apache_pb.gif HTTP/1.0',
+  'method' => 'GET',
+  'path' => '/apache_pb.gif',
+  'protocol' => 'HTTP/1.0',
+  'status' => 200,
+  'bytes' => 2326,
+  'referer' => 'http://www.example.com/start.html',
+  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
+})
+
+seconds = 5 # 3600 # 1 hour
+
+Viiite.bench do |b|
+  b.range_over([2, 4, 8, 16], :threads) do |threads|
+    b.report(:plain) do
+      ths = []
+      end_at = Time.now + seconds
+      threads.times do
+        t = Thread.new do
+          packs = 0
+          while Time.now < end_at
+            10000.times do
+              MessagePack.unpack(data_plain)
+            end
+            packs += 10000
+          end
+          packs
+        end
+        ths.push t
+      end
+      sum = ths.reduce(0){|r,t| r + t.value }
+      puts "MessagePack.unpack, plain, #{threads} threads: #{sum} times, #{sum / seconds} times/second."
+    end
+
+    b.report(:structure) do
+      ths = []
+      end_at = Time.now + seconds
+      threads.times do
+        t = Thread.new do
+          packs = 0
+          while Time.now < end_at
+            10000.times do
+              MessagePack.unpack(data_structure)
+            end
+            packs += 10000
+          end
+          packs
+        end
+        ths.push t
+      end
+      sum = ths.reduce(0){|r,t| r + t.value }
+      puts "MessagePack.unpack, structured, #{threads} threads: #{sum} times, #{sum / seconds} times/second."
+    end
+  end
+end

--- a/bench/unpack_log_long.rb
+++ b/bench/unpack_log_long.rb
@@ -20,10 +20,10 @@ data_structure = MessagePack.pack({
   'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
 })
 
-seconds = 5 # 3600 # 1 hour
+seconds = 3600 # 1 hour
 
 Viiite.bench do |b|
-  b.range_over([2, 4, 8, 16], :threads) do |threads|
+  b.range_over([1, 2, 4, 8, 16], :threads) do |threads|
     b.report(:plain) do
       ths = []
       end_at = Time.now + seconds


### PR DESCRIPTION
Add benchmark script, mainly runs on Linux, to compare CRuby and JRuby.
* benchmark to pack/unpack plain/structured data (bench/run.sh)
* benchmark to test long running workload and check its memory usage (bench/run_long.sh)

This script is to check whether there are performance regressions or not between cruby and jruby.
