### PR TITLE
Ensure that JRuby symbolize_keys default is consistent

### DIFF
--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -96,16 +96,10 @@ public class MessagePackLibrary implements Library {
     @JRubyMethod(module = true, required = 1, optional = 1, alias = {"load"})
     public static IRubyObject unpack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) {
       Decoder decoder = new Decoder(ctx.getRuntime(), args[0].asString().getBytes());
-      if (args.length > 1) {
-        if (args[args.length - 1] instanceof RubyHash) {
-          Ruby runtime = ctx.getRuntime();
-          IRubyObject symbolizeKeys = ((RubyHash) args[args.length - 1]).fastARef((IRubyObject) runtime.getSymbolTable().getSymbol("symbolize_keys"));
-          if (symbolizeKeys instanceof RubyNil || symbolizeKeys instanceof RubyBoolean.False) {
-            decoder.symbolizeKeys(false);
-          } else {
-            decoder.symbolizeKeys(true);
-          }
-        }
+      if (args.length > 1 && !args[args.length - 1].isNil()) {
+        RubyHash hash = args[args.length - 1].convertToHash();
+        IRubyObject symbolizeKeys = hash.fastARef(ctx.getRuntime().newSymbol("symbolize_keys"));
+        decoder.symbolizeKeys(symbolizeKeys != null && symbolizeKeys.isTrue());
       }
       return decoder.next();
     }

--- a/spec/jruby/msgpack_spec.rb
+++ b/spec/jruby/msgpack_spec.rb
@@ -122,6 +122,12 @@ describe MessagePack do
       unpacked.should == {:hello => 'world', :nested => ['object', {:structure => true}]}
     end
 
+    it 'does not symbolize keys even if other options are present' do
+      packed = MessagePack.pack({'hello' => 'world', 'nested' => ['object', {'structure' => true}]})
+      unpacked = MessagePack.unpack(packed, :other_option => false)
+      unpacked.should == {'hello' => 'world', 'nested' => ['object', {'structure' => true}]}
+    end
+
     it 'can unpack strings with a specified encoding', :encodings do
       packed = MessagePack.pack({utf8enc('hello') => utf8enc('world')})
       unpacked = MessagePack.unpack(packed)


### PR DESCRIPTION
The use of fastARef means that a Java null will be returned in the event that a Hash was provided, but without the symbolize_keys key, which resulted in symbolizeKeys to be turned on even though it wasn't requested.