### PR TITLE
Release v0.5.12

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,11 @@
 
+2015-05-XX version 0.5.12:
+
+* Added support for JRuby 9K.
+* Added a benchmarking suite.
+* Fixed a bug in the handling of options given to MessagePack.unpack in JRuby.
+
+
 2015-02-04 version 0.5.11:
 
 * Fixed Encoding::CompatibilityError error when serializing a long string


### PR DESCRIPTION
@frsyuki I think it's time for a v0.5.12 release. Could you build and release? I've got very little experience in building Ruby C extensions and relasing gems for multiple platforms so if I were to do it I would most likely screw up.

This pull request just contains an updated `ChangeLog`, feel free to change the changelog or add to it if you feel that it's not on the correct format.

The date in the change log header needs to be set before you release.