### PR TITLE
Bin 8 bit support for Ruby ASCII-8BIT data type 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.gem
 *.class
 *.jar
+doc
+.yardoc
 .bundle
 Gemfile*
 pkg

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -49,6 +49,12 @@
 
 #define NO_MAPPED_STRING ((VALUE)0)
 
+#ifdef COMPAT_HAVE_ENCODING  /* see compat.h*/
+extern int msgpack_rb_encindex_utf8;
+extern int msgpack_rb_encindex_usascii;
+extern int msgpack_rb_encindex_ascii8bit;
+#endif
+
 struct msgpack_buffer_chunk_t;
 typedef struct msgpack_buffer_chunk_t msgpack_buffer_chunk_t;
 

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -346,7 +346,8 @@ static inline bool msgpack_packer_is_utf8_compat_string(VALUE v, int encindex)
 {
     return encindex == msgpack_rb_encindex_utf8 ||
         encindex == msgpack_rb_encindex_usascii ||
-        rb_enc_str_asciionly_p(v);
+        (rb_enc_asciicompat(rb_enc_from_index(encindex)) && ENC_CODERANGE(str) == ENC_CODERANGE_7BIT);
+    /* ENC_CODERANGE may return ENC_CODERANGE_UNKNOWN unlike rb_enc_str_asciionly_p */
 }
 #endif
 

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -344,10 +344,15 @@ static inline bool msgpack_packer_is_binary(VALUE v, int encindex)
 
 static inline bool msgpack_packer_is_utf8_compat_string(VALUE v, int encindex)
 {
-    return encindex == msgpack_rb_encindex_utf8 ||
-        encindex == msgpack_rb_encindex_usascii ||
-        (rb_enc_asciicompat(rb_enc_from_index(encindex)) && ENC_CODERANGE(str) == ENC_CODERANGE_7BIT);
-    /* ENC_CODERANGE may return ENC_CODERANGE_UNKNOWN unlike rb_enc_str_asciionly_p */
+    return encindex == msgpack_rb_encindex_utf8
+        || encindex == msgpack_rb_encindex_usascii
+#ifdef ENC_CODERANGE_ASCIIONLY
+        /* Because ENC_CODERANGE_ASCIIONLY does not scan string, it may return ENC_CODERANGE_UNKNOWN unlike */
+        /* rb_enc_str_asciionly_p. It is always faster than rb_str_encode if it is available. */
+        /* Very old Rubinius (< v1.3.1) doesn't have ENC_CODERANGE_ASCIIONLY. */
+        || (rb_enc_asciicompat(rb_enc_from_index(encindex)) && ENC_CODERANGE_ASCIIONLY(v))
+#endif
+        ;
 }
 #endif
 

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -28,20 +28,10 @@
 static msgpack_rmem_t s_stack_rmem;
 #endif
 
-#ifdef COMPAT_HAVE_ENCODING  /* see compat.h*/
-static int s_enc_utf8;
-static int s_enc_ascii_8bit;
-#endif
-
 void msgpack_unpacker_static_init()
 {
 #ifdef UNPACKER_STACK_RMEM
     msgpack_rmem_init(&s_stack_rmem);
-#endif
-
-#ifdef COMPAT_HAVE_ENCODING
-    s_enc_utf8 = rb_utf8_encindex();
-    s_enc_ascii_8bit = rb_ascii8bit_encindex();
 #endif
 }
 
@@ -152,16 +142,16 @@ static inline int object_complete(msgpack_unpacker_t* uk, VALUE object)
 static inline int object_complete_string(msgpack_unpacker_t* uk, VALUE str)
 {
 #ifdef COMPAT_HAVE_ENCODING
-    ENCODING_SET(str, s_enc_utf8);
+    ENCODING_SET(str, msgpack_rb_encindex_utf8);
 #endif
     return object_complete(uk, str);
 }
 
-static inline int object_complete_byte_array(msgpack_unpacker_t* uk, VALUE str)
+static inline int object_complete_binary(msgpack_unpacker_t* uk, VALUE str)
 {
 #ifdef COMPAT_HAVE_ENCODING
     // TODO ruby 2.0 has String#b method
-    ENCODING_SET(str, s_enc_ascii_8bit);
+    ENCODING_SET(str, msgpack_rb_encindex_ascii8bit);
 #endif
     return object_complete(uk, str);
 }
@@ -271,7 +261,7 @@ static inline int read_raw_body_begin(msgpack_unpacker_t* uk, bool str)
         if(str == true) {
             object_complete_string(uk, string);
         } else {
-            object_complete_byte_array(uk, string);
+            object_complete_binary(uk, string);
         }
         if(will_freeze) {
             rb_obj_freeze(string);
@@ -458,7 +448,7 @@ static int read_primitive(msgpack_unpacker_t* uk)
                 READ_CAST_BLOCK_OR_RETURN_EOF(cb, uk, 1);
                 uint8_t count = cb->u8;
                 if(count == 0) {
-                    return object_complete_byte_array(uk, rb_str_buf_new(0));
+                    return object_complete_binary(uk, rb_str_buf_new(0));
                 }
                 /* read_raw_body_begin sets uk->reading_raw */
                 uk->reading_raw_remaining = count;
@@ -470,7 +460,7 @@ static int read_primitive(msgpack_unpacker_t* uk)
                 READ_CAST_BLOCK_OR_RETURN_EOF(cb, uk, 2);
                 uint16_t count = _msgpack_be16(cb->u16);
                 if(count == 0) {
-                    return object_complete_byte_array(uk, rb_str_buf_new(0));
+                    return object_complete_binary(uk, rb_str_buf_new(0));
                 }
                 /* read_raw_body_begin sets uk->reading_raw */
                 uk->reading_raw_remaining = count;
@@ -482,7 +472,7 @@ static int read_primitive(msgpack_unpacker_t* uk)
                 READ_CAST_BLOCK_OR_RETURN_EOF(cb, uk, 4);
                 uint32_t count = _msgpack_be32(cb->u32);
                 if(count == 0) {
-                    return object_complete_byte_array(uk, rb_str_buf_new(0));
+                    return object_complete_binary(uk, rb_str_buf_new(0));
                 }
                 /* read_raw_body_begin sets uk->reading_raw */
                 uk->reading_raw_remaining = count;

--- a/spec/cruby/unpacker_spec.rb
+++ b/spec/cruby/unpacker_spec.rb
@@ -262,36 +262,42 @@ describe Unpacker do
 
   it "msgpack str 8 type" do
     MessagePack.unpack([0xd9, 0x00].pack('C*')).should == ""
+    MessagePack.unpack([0xd9, 0x00].pack('C*')).encoding.should == Encoding::UTF_8
     MessagePack.unpack([0xd9, 0x01].pack('C*') + 'a').should == "a"
     MessagePack.unpack([0xd9, 0x02].pack('C*') + 'aa').should == "aa"
   end
 
   it "msgpack str 16 type" do
     MessagePack.unpack([0xda, 0x00, 0x00].pack('C*')).should == ""
+    MessagePack.unpack([0xda, 0x00, 0x00].pack('C*')).encoding.should == Encoding::UTF_8
     MessagePack.unpack([0xda, 0x00, 0x01].pack('C*') + 'a').should == "a"
     MessagePack.unpack([0xda, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
   end
 
   it "msgpack str 32 type" do
     MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ""
+    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x00].pack('C*')).encoding.should == Encoding::UTF_8
     MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == "a"
     MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
   end
 
   it "msgpack bin 8 type" do
     MessagePack.unpack([0xc4, 0x00].pack('C*')).should == ""
+    MessagePack.unpack([0xc4, 0x00].pack('C*')).encoding.should == Encoding::ASCII_8BIT
     MessagePack.unpack([0xc4, 0x01].pack('C*') + 'a').should == "a"
     MessagePack.unpack([0xc4, 0x02].pack('C*') + 'aa').should == "aa"
   end
 
   it "msgpack bin 16 type" do
     MessagePack.unpack([0xc5, 0x00, 0x00].pack('C*')).should == ""
+    MessagePack.unpack([0xc5, 0x00, 0x00].pack('C*')).encoding.should == Encoding::ASCII_8BIT
     MessagePack.unpack([0xc5, 0x00, 0x01].pack('C*') + 'a').should == "a"
     MessagePack.unpack([0xc5, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
   end
 
   it "msgpack bin 32 type" do
     MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ""
+    MessagePack.unpack([0xc6, 0x0, 0x00, 0x00, 0x000].pack('C*')).encoding.should == Encoding::ASCII_8BIT
     MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == "a"
     MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
   end

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -84,11 +84,12 @@ describe MessagePack do
   end
 
   it "raw 8" do
-    check_raw 2, (1<<8)-1
+    check_raw 2, (1 << 5)
+    check_raw 2, (1 << 8)-1
   end
 
   it "raw 16" do
-    check_raw 3, (1 << 5)
+    check_raw 3, (1 << 8)
     check_raw 3, (1 << 16)-1
   end
 
@@ -98,7 +99,25 @@ describe MessagePack do
   end
 
   it "str encoding is UTF_8" do
-    pack_unpack('string'.force_encoding(Encoding::UTF_8)).encoding.should == Encoding::UTF_8
+    v = pack_unpack('string'.force_encoding(Encoding::UTF_8))
+    v.encoding.should == Encoding::UTF_8
+  end
+
+  it "str transcode US-ASCII" do
+    v = pack_unpack('string'.force_encoding(Encoding::US_ASCII))
+    v.encoding.should == Encoding::UTF_8
+  end
+
+  it "str transcode EUC-JP 7bit safe" do
+    v = pack_unpack('string'.force_encoding(Encoding::EUC_JP))
+    v.encoding.should == Encoding::UTF_8
+    v.should == 'string'
+  end
+
+  it "str transcode EUC-JP 7bit unsafe" do
+    v = pack_unpack([0xa4, 0xa2].pack('C*').force_encoding(Encoding::EUC_JP))
+    v.encoding.should == Encoding::UTF_8
+    v.should == "\xE3\x81\x82".force_encoding('UTF-8')
   end
 
   it "bin 8" do

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -108,6 +108,12 @@ describe MessagePack do
     v.encoding.should == Encoding::UTF_8
   end
 
+  it "str transcode UTF-16" do
+    v = pack_unpack('string'.encode(Encoding::UTF_16))
+    v.encoding.should == Encoding::UTF_8
+    v.should == 'string'
+  end
+
   it "str transcode EUC-JP 7bit safe" do
     v = pack_unpack('string'.force_encoding(Encoding::EUC_JP))
     v.encoding.should == Encoding::UTF_8

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -83,6 +83,10 @@ describe MessagePack do
     check_raw 1, (1 << 5)-1
   end
 
+  it "raw 8" do
+    check_raw 2, (1<<8)-1
+  end
+
   it "raw 16" do
     check_raw 3, (1 << 5)
     check_raw 3, (1 << 16)-1
@@ -91,6 +95,26 @@ describe MessagePack do
   it "raw 32" do
     check_raw 5, (1 << 16)
     #check_raw 5, (1 << 32)-1  # memory error
+  end
+
+  it "str encoding is UTF_8" do
+    pack_unpack('string'.force_encoding(Encoding::UTF_8)).encoding.should == Encoding::UTF_8
+  end
+
+  it "bin 8" do
+    check_bin 2, (1<<8)-1
+  end
+
+  it "bin 16" do
+    check_bin 3, (1<<16)-1
+  end
+
+  it "bin 32" do
+    check_bin 5, (1<<16)
+  end
+
+  it "bin encoding is ASCII_8BIT" do
+    pack_unpack('string'.force_encoding(Encoding::ASCII_8BIT)).encoding.should == Encoding::ASCII_8BIT
   end
 
   it "fixarray" do
@@ -210,9 +234,11 @@ describe MessagePack do
   end
 
   def check_raw(overhead, num)
-    rawstr = " "*num
-    rawstr.force_encoding("UTF-8")
-    check num+overhead, rawstr
+    check num+overhead, (" "*num).force_encoding(Encoding::UTF_8)
+  end
+
+  def check_bin(overhead, num)
+    check num+overhead, (" "*num).force_encoding(Encoding::ASCII_8BIT)
   end
 
   def check_array(overhead, num)
@@ -222,6 +248,10 @@ describe MessagePack do
   def match(obj, buf)
     raw = obj.to_msgpack.to_s
     raw.should == buf
+  end
+
+  def pack_unpack(obj)
+    MessagePack.unpack(obj.to_msgpack)
   end
 end
 


### PR DESCRIPTION
This pull-request adds encoding transcoding to #45. If string is not encoded in ASCII-compatible encoding such as UTF-16, or the string includes 7bit unsafe characters, Packer transcoders the string into UTF-8.