### PR TITLE
Support Visual C++ 12 (Visual Studio 2013)

### DIFF
--- a/ext/msgpack/compat.h
+++ b/ext/msgpack/compat.h
@@ -18,6 +18,7 @@
 #ifndef MSGPACK_RUBY_COMPAT_H__
 #define MSGPACK_RUBY_COMPAT_H__
 
+#include <stdbool.h>
 #include "ruby.h"
 
 #if defined(HAVE_RUBY_ST_H)

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -7,7 +7,9 @@ have_func("rb_intern_str", ["ruby.h"])
 have_func("rb_sym2str", ["ruby.h"])
 have_func("rb_str_intern", ["ruby.h"])
 
-$CFLAGS << %[ -I.. -Wall -O3 -g -std=c99]
+unless RUBY_PLATFORM.include? 'mswin'
+  $CFLAGS << %[ -I.. -Wall -O3 -g -std=c99]
+end
 #$CFLAGS << %[ -DDISABLE_RMEM]
 #$CFLAGS << %[ -DDISABLE_RMEM_REUSE_INTERNAL_FRAGMENT]
 #$CFLAGS << %[ -DDISABLE_BUFFER_READ_REFERENCE_OPTIMIZE]


### PR DESCRIPTION
Note that Visual C++ 11 (Visual Studio 2012) doesn't have stdbool.h though it may build msgpack with little effort.