### PR TITLE
Compatibility mode

### DIFF
--- a/ext/java/org/msgpack/jruby/Buffer.java
+++ b/ext/java/org/msgpack/jruby/Buffer.java
@@ -21,7 +21,6 @@ import org.jcodings.Encoding;
 
 @JRubyClass(name="MessagePack::Buffer")
 public class Buffer extends RubyObject {
-  private RubyHash options;
   private IRubyObject io;
   private ByteBuffer buffer;
   private boolean writeMode;
@@ -45,9 +44,6 @@ public class Buffer extends RubyObject {
     if (args.length > 0) {
       if (args[0].respondsTo("read") && args[0].respondsTo("write")) {
         this.io = args[0];
-      }
-      if (args[args.length - 1] instanceof RubyHash) {
-        this.options = (RubyHash) args[args.length - 1];
       }
     }
     this.buffer = ByteBuffer.allocate(CACHE_LINE_SIZE - ARRAY_HEADER_SIZE);

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -32,7 +32,12 @@ public class Packer extends RubyObject {
 
   @JRubyMethod(name = "initialize", optional = 2)
   public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
-    this.encoder = new Encoder(ctx.getRuntime());
+    boolean compatibilityMode = false;
+    if (args.length > 0 && args[args.length - 1] instanceof RubyHash) {
+      RubyHash options = (RubyHash) args[args.length - 1];
+      compatibilityMode = options.fastARef(ctx.getRuntime().newSymbol("compatibility_mode")).isTrue();
+    }
+    this.encoder = new Encoder(ctx.getRuntime(), compatibilityMode);
     this.buffer = new Buffer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Buffer"));
     this.buffer.initialize(ctx, args);
     return this;

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -221,6 +221,11 @@ VALUE MessagePack_pack(int argc, VALUE* argv)
 
     VALUE self = Packer_alloc(cMessagePack_Packer);
     PACKER(self, pk);
+
+    if (options != Qnil) {
+      pk->compatibility_mode = RTEST(rb_hash_aref(options, ID2SYM(rb_intern("compatibility_mode"))));
+    }
+
     //msgpack_packer_reset(s_packer);
     //msgpack_buffer_reset_io(PACKER_BUFFER_(s_packer));
 

--- a/spec/cruby/packer_spec.rb
+++ b/spec/cruby/packer_spec.rb
@@ -116,5 +116,19 @@ describe Packer do
     CustomPack02.new.to_msgpack(s04)
     s04.string.should == [1,2].to_msgpack
   end
+
+  context 'in compatibility mode' do
+    it 'does not use the bin types' do
+      packed = MessagePack.pack('hello'.force_encoding(Encoding::BINARY), compatibility_mode: true)
+      packed.should eq("\xA5hello")
+      packed = MessagePack.pack(('hello' * 100).force_encoding(Encoding::BINARY), compatibility_mode: true)
+      packed.should start_with("\xDA\x01\xF4")
+    end
+
+    it 'does not use the str8 type' do
+      packed = MessagePack.pack('x' * 32, compatibility_mode: true)
+      packed.should start_with("\xDA\x00\x20")
+    end
+  end
 end
 

--- a/spec/jruby/msgpack_spec.rb
+++ b/spec/jruby/msgpack_spec.rb
@@ -139,4 +139,18 @@ describe MessagePack do
       packed.index("w\xC3\xA5rld").should_not be_nil
     end
   end
+
+  context 'in compatibility mode' do
+    it 'does not use the bin types' do
+      packed = MessagePack.pack('hello'.force_encoding(Encoding::BINARY), compatibility_mode: true)
+      packed.should eq("\xA5hello")
+      packed = MessagePack.pack(('hello' * 100).force_encoding(Encoding::BINARY), compatibility_mode: true)
+      packed.should start_with("\xDA\x01\xF4")
+    end
+
+    it 'does not use the str8 type' do
+      packed = MessagePack.pack('x' * 32, compatibility_mode: true)
+      packed.should start_with("\xDA\x00\x20")
+    end
+  end
 end

--- a/spec/jruby/msgpack_spec.rb
+++ b/spec/jruby/msgpack_spec.rb
@@ -36,8 +36,14 @@ describe MessagePack do
       ['negative floats', -2.1, "\xCB\xC0\x00\xCC\xCC\xCC\xCC\xCC\xCD"]
     ],
     'strings' => [
-      ['strings', utf8enc('hello world'), "\xABhello world"],
+      ['tiny strings', utf8enc('hello world'), "\xABhello world"],
+      ['short strings', utf8enc('hello' * 5), "\xB9hellohellohellohellohello"],
       ['empty strings', utf8enc(''), "\xA0"]
+    ],
+    'binary strings' => [
+      ['tiny strings', asciienc('hello world'), "\xC4\vhello world"],
+      ['short strings', asciienc('hello' * 5), "\xC4\x19hellohellohellohellohello"],
+      ['empty strings', asciienc(''), "\xC4\x00"]
     ],
     'arrays' => [
       ['empty arrays', [], "\x90"],


### PR DESCRIPTION
This adds an option to `MessagePack.pack` and `MessagePack::Packer.new` that makes the packer work in what the [MessagePack specification calls "compatibility mode"](https://github.com/msgpack/msgpack/blob/master/spec.md#upgrading-messagepack-specification) – it disables the bin and str8 types.

This should solve #67.

Please note that I know next to nothing about writing Ruby C extensions. Someone, perhaps @tagomoris, should look at that and give me hints to how to do it properly.

I'm not super happy about calling the option `:compatibility_mode`, so if there are any other suggestions I would be happy to change it.