### PR TITLE
Fix incorrect HOST arguments in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,22 +35,22 @@ RUN /home/ubuntu/xbuild/ruby-install 2.0.0-p643 /home/ubuntu/local/ruby-2.0
 
 ENV PATH /home/ubuntu/local/ruby-2.0/bin:$PATH
 RUN gem install rake-compiler
-RUN rake-compiler cross-ruby VERSION=2.0.0-p643 HOST=x86-mingw32 EXTS=--without-extensions
-RUN rake-compiler cross-ruby VERSION=2.0.0-p643 HOST=x64-mingw32 EXTS=--without-extensions
+RUN rake-compiler cross-ruby VERSION=2.0.0-p643 HOST=i686-w64-mingw32 EXTS=--without-extensions
+RUN rake-compiler cross-ruby VERSION=2.0.0-p643 HOST=x86_64-w64-mingw32 EXTS=--without-extensions
 
 RUN /home/ubuntu/xbuild/ruby-install 2.1.5 /home/ubuntu/local/ruby-2.1
 
 ENV PATH /home/ubuntu/local/ruby-2.1/bin:$PATH
 RUN gem install rake-compiler
-RUN rake-compiler cross-ruby VERSION=2.1.5 HOST=x86-mingw32 EXTS=--without-extensions
-RUN rake-compiler cross-ruby VERSION=2.1.5 HOST=x64-mingw32 EXTS=--without-extensions
+RUN rake-compiler cross-ruby VERSION=2.1.5 HOST=i686-w64-mingw32 EXTS=--without-extensions
+RUN rake-compiler cross-ruby VERSION=2.1.5 HOST=x86_64-w64-mingw32 EXTS=--without-extensions
 
 RUN /home/ubuntu/xbuild/ruby-install 2.2.2 /home/ubuntu/local/ruby-2.2
 
 ENV PATH /home/ubuntu/local/ruby-2.2/bin:$PATH
 RUN gem install rake-compiler
-RUN rake-compiler cross-ruby VERSION=2.2.2 HOST=x86-mingw32 EXTS=--without-extensions
-RUN rake-compiler cross-ruby VERSION=2.2.2 HOST=x64-mingw32 EXTS=--without-extensions
+RUN rake-compiler cross-ruby VERSION=2.2.2 HOST=i686-w64-mingw32 EXTS=--without-extensions
+RUN rake-compiler cross-ruby VERSION=2.2.2 HOST=x86_64-w64-mingw32 EXTS=--without-extensions
 
 WORKDIR /home/ubuntu/msgpack-ruby
 


### PR DESCRIPTION
Fix comment https://github.com/msgpack/msgpack-ruby/commit/c97028663cd3440d656f62e6e7b19d9071d23c1c issue.

We use (i686|x86_64)-w64-mingw32 package, so it must specify
HOST=i686-w64-mingw32/HOST=x86_64-w64-mingw32 here.

Because (i686|x86_64)-w64-mingw32 package contains:

(i686|x86_64)-w64-mingw32-gcc
(i686|x86_64)-w64-mingw32-g++
(i686|x86_64)-w64-mingw32-ranlib and so on.

And this value is used in rake-complier cross ruby configure option.

e.g)
HOST=x86_64-w64-mingw32
* * *
rake-compiler specifies following configure option when building
cross ruby:

```log
/home/ubuntu/.rake-compiler/sources/ruby-2.2.2/configure
--host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32
--build=x86_64-unknown-linux-gnu --enable-shared --disable-install-doc
--without-tk --without-tcl
--prefix=/home/ubuntu/.rake-compiler/ruby/x86_64-w64-mingw32/ruby-2.2.2
```