### PR TITLE
Symbol has encoding

### DIFF
--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -404,17 +404,11 @@ static inline void msgpack_packer_write_symbol_value(msgpack_packer_t* pk, VALUE
     /* rb_sym2str is added since MRI 2.2.0 */
     msgpack_packer_write_string_value(pk, rb_sym2str(v));
 #else
-    VALUE name = rb_id2str(SYM2ID(v));
-    if (!name) {
-       rb_raise(rb_eRuntimeError, "could not find str by id");
+    VALUE str = rb_id2str(SYM2ID(v));
+    if (!str) {
+       rb_raise(rb_eRuntimeError, "could not convert a symbol to string");
     }
-    unsigned long len = RSTRING_LEN(name);
-    if(len > 0xffffffffUL) {
-        // TODO rb_eArgError?
-        rb_raise(rb_eArgError, "size of symbol is too long to pack: %lu bytes should be <= %lu", len, 0xffffffffUL);
-    }
-    msgpack_packer_write_raw_header(pk, (unsigned int)len);
-    msgpack_buffer_append(PACKER_BUFFER_(pk), RSTRING_PTR(name), len);
+    msgpack_packer_write_string_value(pk, str);
 #endif
 }
 

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -126,6 +126,18 @@ describe MessagePack do
     v.should == "\xE3\x81\x82".force_encoding('UTF-8')
   end
 
+  it "symbol to str" do
+    v = pack_unpack(:a)
+    v.should == "a".force_encoding('UTF-8')
+  end
+
+  it "symbol to str with encoding" do
+    a = "\xE3\x81\x82".force_encoding('UTF-8')
+    v = pack_unpack(a.encode('Shift_JIS').to_sym)
+    v.encoding.should == Encoding::UTF_8
+    v.should == a
+  end
+
   it "bin 8" do
     check_bin 2, (1<<8)-1
   end

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -138,6 +138,13 @@ describe MessagePack do
     v.should == a
   end
 
+  it "symbol to bin" do
+    a = "\xE3\x81\x82".force_encoding('ASCII-8BIT')
+    v = pack_unpack(a.to_sym)
+    v.encoding.should == Encoding::ASCII_8BIT
+    v.should == a
+  end
+
   it "bin 8" do
     check_bin 2, (1<<8)-1
   end


### PR DESCRIPTION
`"あ".encode('Shift_JIS') != "あ"`
Follow-up pull-request of #75.