### PR TITLE
Add appveyor.yml for ci-tests on Windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+---
+install:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - ruby --version
+  - gem --version
+  - bundle install
+build: off
+test_script:
+  - bundle exec rake -rdevkit
+
+environment:
+  matrix:
+    - ruby_version: "200"
+    - ruby_version: "200-x64"
+    - ruby_version: "21"
+    - ruby_version: "21-x64"
+    - ruby_version: "22"
+    - ruby_version: "22-x64"


### PR DESCRIPTION
The github project needs to be enabled in appveyor, similar to travis-ci. The build and specs runs green, like [here](https://ci.appveyor.com/project/larskanis/msgpack-ruby/build/1.0.3) .

appveyor is slower than travis-ci. That's why I only enabled the most opposed ruby versions, only, for now.