### PR TITLE
Unpacker is expected to raise UnpackeError

### DIFF
--- a/doclib/msgpack/error.rb
+++ b/doclib/msgpack/error.rb
@@ -9,9 +9,6 @@ module MessagePack
   class StackError < UnpackError
   end
 
-  module TypeError
-  end
-
   class UnexpectedTypeError < UnpackError
     include TypeError
   end

--- a/doclib/msgpack/error.rb
+++ b/doclib/msgpack/error.rb
@@ -12,4 +12,8 @@ module MessagePack
   class UnexpectedTypeError < UnpackError
     include TypeError
   end
+
+  class UnknownExtTypeError < UnpackError
+    include TypeError
+  end
 end

--- a/doclib/msgpack/error.rb
+++ b/doclib/msgpack/error.rb
@@ -9,6 +9,10 @@ module MessagePack
   class StackError < UnpackError
   end
 
-  class TypeError < StandardError
+  module TypeError
+  end
+
+  class UnexpectedTypeError < UnpackError
+    include TypeError
   end
 end

--- a/doclib/msgpack/unpacker.rb
+++ b/doclib/msgpack/unpacker.rb
@@ -19,7 +19,7 @@ module MessagePack
     # Supported options:
     #
     # * *:symbolize_keys* deserialize keys of Hash objects as Symbol instead of String
-    # * *:allow_unknown_ext* allow to deserialize ext type object with unknown type id as ExtensionValue instance
+    # * *:allow_unknown_ext* allow to deserialize ext type object with unknown type id as ExtensionValue instance. Otherwise (by default), unpacker throws UnknownExtTypeError.
     #
     # See also Buffer#initialize for other options.
     #

--- a/doclib/msgpack/unpacker.rb
+++ b/doclib/msgpack/unpacker.rb
@@ -114,7 +114,7 @@ module MessagePack
     # Read a header of an array and returns its size.
     # It converts a serialized array into a stream of elements.
     #
-    # If the serialized object is not an array, it raises MessagePack::TypeError.
+    # If the serialized object is not an array, it raises MessagePack::UnexpectedTypeError.
     # If there're not enough data, this method raises EOFError.
     #
     # @return [Integer] size of the array
@@ -126,7 +126,7 @@ module MessagePack
     # Reads a header of an map and returns its size.
     # It converts a serialized map into a stream of key-value pairs.
     #
-    # If the serialized object is not a map, it raises MessagePack::TypeError.
+    # If the serialized object is not a map, it raises MessagePack::UnexpectedTypeError.
     # If there're not enough data, this method raises EOFError.
     #
     # @return [Integer] size of the map

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -29,7 +29,8 @@ VALUE cMessagePack_Unpacker;
 static VALUE eUnpackError;
 static VALUE eMalformedFormatError;
 static VALUE eStackError;
-static VALUE eTypeError;
+static VALUE eUnexpectedTypeError;
+static VALUE mTypeError;
 
 #define UNPACKER(from, name) \
     msgpack_unpacker_t *name = NULL; \
@@ -124,7 +125,7 @@ static void raise_unpacker_error(int r)
     case PRIMITIVE_STACK_TOO_DEEP:
         rb_raise(eStackError, "stack level too deep");
     case PRIMITIVE_UNEXPECTED_TYPE:
-        rb_raise(eTypeError, "unexpected type");
+        rb_raise(eUnexpectedTypeError, "unexpected type");
     case PRIMITIVE_UNEXPECTED_EXT_TYPE:
         rb_raise(eTypeError, "unexpected extension type");
     default:
@@ -427,6 +428,8 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
     msgpack_unpacker_static_init();
     msgpack_unpacker_ext_registry_static_init();
 
+    mTypeError = rb_define_module_under(mMessagePack, "TypeError");
+
     cMessagePack_Unpacker = rb_define_class_under(mMessagePack, "Unpacker", rb_cObject);
 
     eUnpackError = rb_define_class_under(mMessagePack, "UnpackError", rb_eStandardError);
@@ -435,7 +438,8 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
 
     eStackError = rb_define_class_under(mMessagePack, "StackError", eUnpackError);
 
-    eTypeError = rb_define_class_under(mMessagePack, "TypeError", rb_eStandardError);
+    eUnexpectedTypeError = rb_define_class_under(mMessagePack, "UnexpectedTypeError", eUnpackError);
+    rb_include_module(eUnexpectedTypeError, mTypeError);
 
     rb_define_alloc_func(cMessagePack_Unpacker, MessagePack_Unpacker_alloc);
 

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -30,7 +30,7 @@ static VALUE eUnpackError;
 static VALUE eMalformedFormatError;
 static VALUE eStackError;
 static VALUE eUnexpectedTypeError;
-static VALUE mTypeError;
+static VALUE mTypeError;  // obsoleted. only for backward compatibility. See #86.
 
 #define UNPACKER(from, name) \
     msgpack_unpacker_t *name = NULL; \

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -30,6 +30,7 @@ static VALUE eUnpackError;
 static VALUE eMalformedFormatError;
 static VALUE eStackError;
 static VALUE eUnexpectedTypeError;
+static VALUE eUnknownExtTypeError;
 static VALUE mTypeError;  // obsoleted. only for backward compatibility. See #86.
 
 #define UNPACKER(from, name) \
@@ -127,7 +128,7 @@ static void raise_unpacker_error(int r)
     case PRIMITIVE_UNEXPECTED_TYPE:
         rb_raise(eUnexpectedTypeError, "unexpected type");
     case PRIMITIVE_UNEXPECTED_EXT_TYPE:
-        rb_raise(eTypeError, "unexpected extension type");
+        rb_raise(eUnknownExtTypeError, "unexpected extension type");
     default:
         rb_raise(eUnpackError, "logically unknown error %d", r);
     }
@@ -440,6 +441,8 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
 
     eUnexpectedTypeError = rb_define_class_under(mMessagePack, "UnexpectedTypeError", eUnpackError);
     rb_include_module(eUnexpectedTypeError, mTypeError);
+
+    eUnknownExtTypeError = rb_define_class_under(mMessagePack, "UnknownExtTypeError", eUnpackError);
 
     rb_define_alloc_func(cMessagePack_Unpacker, MessagePack_Unpacker_alloc);
 

--- a/spec/cruby/unpacker_spec.rb
+++ b/spec/cruby/unpacker_spec.rb
@@ -21,7 +21,10 @@ describe Unpacker do
     unpacker.feed("\x81")
     lambda {
       unpacker.read_array_header
-    }.should raise_error(MessagePack::TypeError)
+    }.should raise_error(MessagePack::TypeError)  # TypeError is included in UnexpectedTypeError
+    lambda {
+      unpacker.read_array_header
+    }.should raise_error(MessagePack::UnexpectedTypeError)
   end
 
   it 'read_map_header converts an map to key-value sequence' do
@@ -55,7 +58,10 @@ describe Unpacker do
     unpacker.feed("\x91")
     lambda {
       unpacker.read_map_header
-    }.should raise_error(MessagePack::TypeError)
+    }.should raise_error(MessagePack::TypeError)  # TypeError is included in UnexpectedTypeError
+    lambda {
+      unpacker.read_map_header
+    }.should raise_error(MessagePack::UnexpectedTypeError)
   end
 
   it 'skip_nil succeeds' do

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -42,7 +42,7 @@ describe MessagePack::Factory do
     it 'creates unpacker without allow_unknown_ext option' do
       unpacker = subject.unpacker
       unpacker.feed(MessagePack::ExtensionValue.new(1, 'a').to_msgpack)
-      expect{ unpacker.read }.to raise_error(MessagePack::TypeError)
+      expect{ unpacker.read }.to raise_error(MessagePack::UnknownExtTypeError)
     end
   end
 


### PR DESCRIPTION
This change adds `MessagePack::UnexpectedTypeError` which extends `MessagePack::UnpackError`. Unpacker raises it instead of TypeError.

This doesn't take alternative idea which changes TypeError to extends UnpackError for 2 reasons:

* For backward compatibility with existent code which expects that rescuing TypeError doesn't rescue UnpackError.
* Name of `TypeError` is confusing with Ruby's standard `::TypeError`.

For backward compatibility, TypeError is changed to Module and UnexpectedTypeError includes it.

Fixes #83 and #85.