### PR TITLE
fixed a bug that feed_each returns no data enumerator (revised)

### DIFF
--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -294,6 +294,13 @@ static VALUE Unpacker_each(VALUE self)
 
 static VALUE Unpacker_feed_each(VALUE self, VALUE data)
 {
+#ifdef RETURN_ENUMERATOR
+    {
+        VALUE argv[] = { data };
+        RETURN_ENUMERATOR(self, sizeof(argv) / sizeof(VALUE), argv);
+    }
+#endif
+
     // TODO optimize
     Unpacker_feed(self, data);
     return Unpacker_each(self);

--- a/spec/cruby/unpacker_spec.rb
+++ b/spec/cruby/unpacker_spec.rb
@@ -140,6 +140,12 @@ describe Unpacker do
     objects.should == [sample_object] * 4
   end
 
+  it 'feed_each enumerator' do
+    raw = sample_object.to_msgpack.to_s * 4
+
+    unpacker.feed_each(raw).to_a.should == [sample_object] * 4
+  end
+
   it 'reset clears internal buffer' do
     # 1-element array
     unpacker.feed("\x91")


### PR DESCRIPTION
Revised #41.
I resolved conflict and rebased with latest master.

`unpacker.feed_each(data).each` raises the following error:

    ArgumentError: wrong number of arguments (0 for 1)