### PR TITLE
Add support for ActiveSupport's TimeWithZone class

### DIFF
--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -1,4 +1,5 @@
 require "msgpack/version"
+require "msgpack/active_support/time_with_zone"
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby" # This is same with `/java/ =~ RUBY_VERSION`
   require "java"

--- a/lib/msgpack/active_support/time_with_zone.rb
+++ b/lib/msgpack/active_support/time_with_zone.rb
@@ -1,0 +1,12 @@
+begin
+  require 'active_support/time_with_zone'
+
+  ActiveSupport::TimeWithZone.class_eval do
+    def to_msgpack(out='')
+      self.to_s.to_msgpack(out)
+    end
+  end
+
+rescue LoadError
+  # Do nothing if ActiveSupport is not available.
+end

--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', ['~> 3.3']
   s.add_development_dependency 'yard', ['~> 0.8.2']
   s.add_development_dependency 'json'
+  s.add_development_dependency 'activesupport'
 end

--- a/spec/time_with_zone_spec.rb
+++ b/spec/time_with_zone_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'active_support/core_ext/numeric/time'
+
+describe ActiveSupport::TimeWithZone do
+  it 'should correctly pack a TimeWithZone object, including timezone' do
+    Time.zone = 'Pacific Time (US & Canada)'
+    initial_time = Time.zone.local(2014, 8, 21, 15, 30, 0)
+
+    packed_time = MessagePack.pack(initial_time)
+    packed_time.should == "\xB92014-08-21 15:30:00 -0700".b
+
+    unpacked_time = MessagePack.unpack(packed_time)
+    unpacked_time.should == "2014-08-21 15:30:00 -0700"
+
+    parsed_time = Time.zone.parse(unpacked_time)
+    parsed_time.should == initial_time
+  end
+end

--- a/spec/time_with_zone_spec.rb
+++ b/spec/time_with_zone_spec.rb
@@ -7,7 +7,7 @@ describe ActiveSupport::TimeWithZone do
     initial_time = Time.zone.local(2014, 8, 21, 15, 30, 0)
 
     packed_time = MessagePack.pack(initial_time)
-    packed_time.should == "\xB92014-08-21 15:30:00 -0700".b
+    packed_time.should == "\xB92014-08-21 15:30:00 -0700".force_encoding("binary")
 
     unpacked_time = MessagePack.unpack(packed_time)
     unpacked_time.should == "2014-08-21 15:30:00 -0700"


### PR DESCRIPTION
So that TZ data is not stripped

Original author is Nathan Broadbent <nathan.f77@gmail.com>.

See also #37