### PR TITLE
Additions to ext type support for JRuby

### DIFF
--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -35,7 +35,7 @@ public class Decoder implements Iterator<IRubyObject> {
   private final RubyClass unexpectedTypeErrorClass;
   private final RubyClass unknownExtTypeErrorClass;
 
-  private Unpacker.ExtensionRegistry registry;
+  private ExtensionRegistry registry;
   private ByteBuffer buffer;
   private boolean symbolizeKeys;
   private boolean allowUnknownExt;
@@ -44,7 +44,7 @@ public class Decoder implements Iterator<IRubyObject> {
     this(runtime, null, new byte[] {}, 0, 0, false, false);
   }
 
-  public Decoder(Ruby runtime, Unpacker.ExtensionRegistry registry) {
+  public Decoder(Ruby runtime, ExtensionRegistry registry) {
     this(runtime, registry, new byte[] {}, 0, 0, false, false);
   }
 
@@ -52,11 +52,11 @@ public class Decoder implements Iterator<IRubyObject> {
     this(runtime, null, bytes, 0, bytes.length, false, false);
   }
 
-  public Decoder(Ruby runtime, Unpacker.ExtensionRegistry registry, byte[] bytes) {
+  public Decoder(Ruby runtime, ExtensionRegistry registry, byte[] bytes) {
     this(runtime, registry, bytes, 0, bytes.length, false, false);
   }
 
-  public Decoder(Ruby runtime, Unpacker.ExtensionRegistry registry, byte[] bytes, int offset, int length, boolean symbolizeKeys, boolean allowUnknownExt) {
+  public Decoder(Ruby runtime, ExtensionRegistry registry, byte[] bytes, int offset, int length, boolean symbolizeKeys, boolean allowUnknownExt) {
     this.runtime = runtime;
     this.registry = registry;
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
@@ -136,7 +136,7 @@ public class Decoder implements Iterator<IRubyObject> {
     byte[] payload = readBytes(size);
 
     if (registry != null) {
-      IRubyObject proc = registry.lookup(type);
+      IRubyObject proc = registry.lookupUnpackerByTypeId(type);
       if (proc != null) {
         ByteList byteList = new ByteList(payload, runtime.getEncodingService().getAscii8bitEncoding());
         return proc.callMethod(runtime.getCurrentContext(), "call", runtime.newString(byteList));

--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -41,22 +41,22 @@ public class Decoder implements Iterator<IRubyObject> {
   private boolean allowUnknownExt;
 
   public Decoder(Ruby runtime) {
-    this(runtime, null, new byte[] {}, 0, 0);
+    this(runtime, null, new byte[] {}, 0, 0, false, false);
   }
 
   public Decoder(Ruby runtime, Unpacker.ExtensionRegistry registry) {
-    this(runtime, registry, new byte[] {}, 0, 0);
+    this(runtime, registry, new byte[] {}, 0, 0, false, false);
   }
 
   public Decoder(Ruby runtime, byte[] bytes) {
-    this(runtime, null, bytes, 0, bytes.length);
+    this(runtime, null, bytes, 0, bytes.length, false, false);
   }
 
   public Decoder(Ruby runtime, Unpacker.ExtensionRegistry registry, byte[] bytes) {
-    this(runtime, registry, bytes, 0, bytes.length);
+    this(runtime, registry, bytes, 0, bytes.length, false, false);
   }
 
-  public Decoder(Ruby runtime, Unpacker.ExtensionRegistry registry, byte[] bytes, int offset, int length) {
+  public Decoder(Ruby runtime, Unpacker.ExtensionRegistry registry, byte[] bytes, int offset, int length, boolean symbolizeKeys, boolean allowUnknownExt) {
     this.runtime = runtime;
     this.registry = registry;
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
@@ -67,15 +67,9 @@ public class Decoder implements Iterator<IRubyObject> {
     this.stackErrorClass = runtime.getModule("MessagePack").getClass("StackError");
     this.unexpectedTypeErrorClass = runtime.getModule("MessagePack").getClass("UnexpectedTypeError");
     this.unknownExtTypeErrorClass = runtime.getModule("MessagePack").getClass("UnknownExtTypeError");
+    this.symbolizeKeys = symbolizeKeys;
+    this.allowUnknownExt = allowUnknownExt;
     feed(bytes, offset, length);
-  }
-
-  public void symbolizeKeys(boolean symbolize) {
-    this.symbolizeKeys = symbolize;
-  }
-
-  public void allowUnknownExt(boolean allow) {
-    this.allowUnknownExt = allow;
   }
 
   public void feed(byte[] bytes) {

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -34,11 +34,11 @@ public class Encoder {
   private final Encoding binaryEncoding;
   private final Encoding utf8Encoding;
   private final boolean compatibilityMode;
-  private final Packer.ExtensionRegistry registry;
+  private final ExtensionRegistry registry;
 
   private ByteBuffer buffer;
 
-  public Encoder(Ruby runtime, boolean compatibilityMode, Packer.ExtensionRegistry registry) {
+  public Encoder(Ruby runtime, boolean compatibilityMode, ExtensionRegistry registry) {
     this.runtime = runtime;
     this.buffer = ByteBuffer.allocate(CACHE_LINE_SIZE - ARRAY_HEADER_SIZE);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -34,19 +34,16 @@ public class Encoder {
   private final Encoding binaryEncoding;
   private final Encoding utf8Encoding;
   private final boolean compatibilityMode;
+  private final Packer.ExtensionRegistry registry;
 
-  private Packer.ExtensionRegistry registry;
   private ByteBuffer buffer;
 
-  public Encoder(Ruby runtime, boolean compatibilityMode) {
+  public Encoder(Ruby runtime, boolean compatibilityMode, Packer.ExtensionRegistry registry) {
     this.runtime = runtime;
     this.buffer = ByteBuffer.allocate(CACHE_LINE_SIZE - ARRAY_HEADER_SIZE);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
     this.utf8Encoding = UTF8Encoding.INSTANCE;
     this.compatibilityMode = compatibilityMode;
-  }
-
-  public void setRegistry(Packer.ExtensionRegistry registry) {
     this.registry = registry;
   }
 

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -350,7 +350,7 @@ public class Encoder {
 
   private void appendOther(IRubyObject object, IRubyObject destination) {
     if (registry != null) {
-      IRubyObject[] pair = registry.lookup(object.getType());
+      IRubyObject[] pair = registry.lookupPackerByClass(object.getType());
       if (pair != null) {
         RubyString bytes = pair[0].callMethod(runtime.getCurrentContext(), "call", object).asString();
         int type = (int) ((RubyFixnum) pair[1]).getLongValue();

--- a/ext/java/org/msgpack/jruby/ExtensionRegistry.java
+++ b/ext/java/org/msgpack/jruby/ExtensionRegistry.java
@@ -1,0 +1,98 @@
+package org.msgpack.jruby;
+
+import org.jruby.Ruby;
+import org.jruby.RubyHash;
+import org.jruby.RubyArray;
+import org.jruby.RubyClass;
+import org.jruby.RubyFixnum;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class ExtensionRegistry {
+  private final Map<RubyClass, ExtensionEntry> extensionsByClass;
+  private final Map<RubyClass, ExtensionEntry> extensionsByAncestor;
+
+  public ExtensionRegistry() {
+    this(new HashMap<RubyClass, ExtensionEntry>());
+  }
+
+  private ExtensionRegistry(Map<RubyClass, ExtensionEntry> extensionsByClass) {
+    this.extensionsByClass = new HashMap<RubyClass, ExtensionEntry>(extensionsByClass);
+    this.extensionsByAncestor = new HashMap<RubyClass, ExtensionEntry>();
+  }
+
+  public ExtensionRegistry dup() {
+    return new ExtensionRegistry(extensionsByClass);
+  }
+
+  public IRubyObject toRubyHash(ThreadContext ctx) {
+    RubyHash hash = RubyHash.newHash(ctx.getRuntime());
+    for (RubyClass extensionClass : extensionsByClass.keySet()) {
+      hash.put(extensionClass, extensionsByClass.get(extensionClass).toTuple(ctx));
+    }
+    return hash;
+  }
+
+  public void put(RubyClass cls, int typeId, IRubyObject proc, IRubyObject arg) {
+    extensionsByClass.put(cls, new ExtensionEntry(cls, typeId, proc, arg));
+    extensionsByAncestor.clear();
+  }
+
+  public IRubyObject[] lookup(RubyClass cls) {
+    ExtensionEntry e = extensionsByClass.get(cls);
+    if (e == null) {
+      e = extensionsByAncestor.get(cls);
+    }
+    if (e == null) {
+      e = findEntryByClassOrAncestor(cls);
+      if (e != null) {
+        extensionsByAncestor.put(e.getExtensionClass(), e);
+      }
+    }
+    if (e == null) {
+      return null;
+    } else {
+      return e.toProcTypePair(cls.getRuntime().getCurrentContext());
+    }
+  }
+
+  private ExtensionEntry findEntryByClassOrAncestor(final RubyClass cls) {
+    ThreadContext ctx = cls.getRuntime().getCurrentContext();
+    for (RubyClass extensionClass : extensionsByClass.keySet()) {
+      RubyArray ancestors = (RubyArray) cls.callMethod(ctx, "ancestors");
+      if (ancestors.callMethod(ctx, "include?", extensionClass).isTrue()) {
+        return extensionsByClass.get(extensionClass);
+      }
+    }
+    return null;
+  }
+
+  private static class ExtensionEntry {
+    private final RubyClass cls;
+    private final int typeId;
+    private final IRubyObject proc;
+    private final IRubyObject arg;
+
+    public ExtensionEntry(RubyClass cls, int typeId, IRubyObject proc, IRubyObject arg) {
+      this.cls = cls;
+      this.typeId = typeId;
+      this.proc = proc;
+      this.arg = arg;
+    }
+
+    public RubyClass getExtensionClass() {
+      return cls;
+    }
+
+    public RubyArray toTuple(ThreadContext ctx) {
+      return RubyArray.newArray(ctx.getRuntime(), new IRubyObject[] {RubyFixnum.newFixnum(ctx.getRuntime(), typeId), proc, arg});
+    }
+
+    public IRubyObject[] toProcTypePair(ThreadContext ctx) {
+      return new IRubyObject[] {proc, RubyFixnum.newFixnum(ctx.getRuntime(), typeId)};
+    }
+  }
+}

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -23,7 +23,7 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 @JRubyClass(name="MessagePack::Factory")
 public class Factory extends RubyObject {
   private Ruby runtime;
-  private Packer.ExtensionRegistry packerExtensionRegistry;
+  private ExtensionRegistry packerExtensionRegistry;
   private Unpacker.ExtensionRegistry unpackerExtensionRegistry;
 
   public Factory(Ruby runtime, RubyClass type) {
@@ -39,12 +39,12 @@ public class Factory extends RubyObject {
 
   @JRubyMethod(name = "initialize")
   public IRubyObject initialize(ThreadContext ctx) {
-    this.packerExtensionRegistry = new Packer.ExtensionRegistry(ctx.getRuntime());
+    this.packerExtensionRegistry = new ExtensionRegistry();
     this.unpackerExtensionRegistry = new Unpacker.ExtensionRegistry(ctx.getRuntime());
     return this;
   }
 
-  public Packer.ExtensionRegistry packerRegistry() {
+  public ExtensionRegistry packerRegistry() {
     return this.packerExtensionRegistry.dup();
   }
 
@@ -72,7 +72,7 @@ public class Factory extends RubyObject {
       }
     }
 
-    IRubyObject[] ary = { packerRegistry().hash, mapping };
+    IRubyObject[] ary = { packerExtensionRegistry.toRubyHash(ctx), mapping };
     return RubyArray.newArray(ctx.getRuntime(), ary);
   }
 

--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -118,12 +118,14 @@ public class MessagePackLibrary implements Library {
     @JRubyMethod(module = true, required = 1, optional = 1, alias = {"load"})
     public static IRubyObject unpack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) {
       Unpacker.ExtensionRegistry registry = MessagePackLibrary.defaultFactory.unpackerRegistry();
-      Decoder decoder = new Decoder(ctx.getRuntime(), registry, args[0].asString().getBytes());
+      boolean symbolizeKeys = false;
       if (args.length > 1 && !args[args.length - 1].isNil()) {
         RubyHash hash = args[args.length - 1].convertToHash();
-        IRubyObject symbolizeKeys = hash.fastARef(ctx.getRuntime().newSymbol("symbolize_keys"));
-        decoder.symbolizeKeys(symbolizeKeys != null && symbolizeKeys.isTrue());
+        IRubyObject symbolizeKeysVal = hash.fastARef(ctx.getRuntime().newSymbol("symbolize_keys"));
+        symbolizeKeys = symbolizeKeysVal != null && symbolizeKeysVal.isTrue();
       }
+      byte[] bytes = args[0].asString().getBytes();
+      Decoder decoder = new Decoder(ctx.getRuntime(), registry, bytes, 0, bytes.length, symbolizeKeys, false);
       return decoder.next();
     }
   }

--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -117,7 +117,7 @@ public class MessagePackLibrary implements Library {
 
     @JRubyMethod(module = true, required = 1, optional = 1, alias = {"load"})
     public static IRubyObject unpack(ThreadContext ctx, IRubyObject recv, IRubyObject[] args) {
-      Unpacker.ExtensionRegistry registry = MessagePackLibrary.defaultFactory.unpackerRegistry();
+      ExtensionRegistry registry = MessagePackLibrary.defaultFactory.extensionRegistry();
       boolean symbolizeKeys = false;
       if (args.length > 1 && !args[args.length - 1].isNil()) {
         RubyHash hash = args[args.length - 1].convertToHash();

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -71,29 +71,33 @@ public class Packer extends RubyObject {
         hit[1] = e.entry(0);
         return hit;
       }
+      IRubyObject[] pair = findEntryByClassOrAncestor(hash, klass);
+      if (pair != null) {
+        cache.fastASet(pair[0], RubyArray.newArray(runtime, pair));
+      }
+      return pair;
+    }
 
+    private IRubyObject[] findEntryByClassOrAncestor(final RubyHash hash, final RubyClass klass) {
       final IRubyObject[] pair = new IRubyObject[2];
-      // check all keys whether it's super class of klass, or not
       hash.visitAll(new RubyHash.Visitor() {
         public void visit(IRubyObject keyValue, IRubyObject value) {
-          if (pair[0] != null) {
-            return;
-          }
-          ThreadContext ctx = runtime.getCurrentContext();
-          RubyArray ancestors = (RubyArray) klass.callMethod(ctx, "ancestors");
-          if (ancestors.callMethod(ctx, "include?", keyValue).isTrue()) {
-            RubyArray hit = (RubyArray) hash.fastARef(keyValue);
-            cache.fastASet(klass, hit);
-            pair[0] = hit.entry(1);
-            pair[1] = hit.entry(0);
+          if (pair[0] == null) {
+            ThreadContext ctx = runtime.getCurrentContext();
+            RubyArray ancestors = (RubyArray) klass.callMethod(ctx, "ancestors");
+            if (ancestors.callMethod(ctx, "include?", keyValue).isTrue()) {
+              RubyArray hit = (RubyArray) hash.fastARef(keyValue);
+              pair[0] = hit.entry(1);
+              pair[1] = hit.entry(0);
+            }
           }
         }
       });
-
       if (pair[0] == null) {
         return null;
+      } else {
+        return pair;
       }
-      return pair;
     }
   }
 

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -66,10 +66,7 @@ public class Packer extends RubyObject {
         e = (RubyArray) cache.fastARef(klass);
       }
       if (e != null) {
-        IRubyObject[] hit = new IRubyObject[2];
-        hit[0] = e.entry(1);
-        hit[1] = e.entry(0);
-        return hit;
+        return new IRubyObject[] {e.entry(1), e.entry(0)};
       }
       IRubyObject[] pair = findEntryByClassOrAncestor(hash, klass);
       if (pair != null) {

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -130,8 +130,6 @@ public class Packer extends RubyObject {
 
   @JRubyMethod(name = "register_type", required = 2, optional = 1)
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args, final Block block) {
-    // register_type(type, Class){|obj| how_to_serialize.... }
-    // register_type(type, Class, :to_msgpack_ext)
     Ruby runtime = ctx.getRuntime();
     IRubyObject type = args[0];
     IRubyObject klass = args[1];

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -64,7 +64,7 @@ public class Packer extends RubyObject {
 
   @JRubyMethod(name = "registered_types_internal", visibility = PRIVATE)
   public IRubyObject registeredTypesInternal(ThreadContext ctx) {
-    return registry.toRubyHash(ctx);
+    return registry.toInternalPackerRegistry(ctx);
   }
 
   @JRubyMethod(name = "register_type", required = 2, optional = 1)
@@ -98,7 +98,7 @@ public class Packer extends RubyObject {
     }
     RubyClass extClass = (RubyClass) klass;
 
-    registry.put(extClass, (int) typeId, proc, arg);
+    registry.put(extClass, (int) typeId, proc, arg, null, null);
     return runtime.getNil();
   }
 

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -25,13 +25,14 @@ public class Packer extends RubyObject {
   private Buffer buffer;
   private Encoder encoder;
 
-  public Packer(Ruby runtime, RubyClass type) {
+  public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry) {
     super(runtime, type);
+    this.registry = registry;
   }
 
   static class PackerAllocator implements ObjectAllocator {
     public IRubyObject allocate(Ruby runtime, RubyClass type) {
-      return new Packer(runtime, type);
+      return new Packer(runtime, type, null);
     }
   }
 
@@ -104,22 +105,16 @@ public class Packer extends RubyObject {
       IRubyObject mode = options.fastARef(ctx.getRuntime().newSymbol("compatibility_mode"));
       compatibilityMode = (mode != null) && mode.isTrue();
     }
-    this.encoder = new Encoder(ctx.getRuntime(), compatibilityMode);
+    this.encoder = new Encoder(ctx.getRuntime(), compatibilityMode, registry);
     this.buffer = new Buffer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Buffer"));
     this.buffer.initialize(ctx, args);
     this.registry = new ExtensionRegistry(ctx.getRuntime());
     return this;
   }
 
-  public void setExtensionRegistry(ExtensionRegistry registry) {
-    this.registry = registry;
-    this.encoder.setRegistry(registry);
-  }
-
   public static Packer newPacker(ThreadContext ctx, ExtensionRegistry extRegistry, IRubyObject[] args) {
-    Packer packer = new Packer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Packer"));
+    Packer packer = new Packer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Packer"), extRegistry);
     packer.initialize(ctx, args);
-    packer.setExtensionRegistry(extRegistry);
     return packer;
   }
 

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -278,10 +278,6 @@ public class Unpacker extends RubyObject {
     }
   }
 
-  /*
-    skip & skip_nil don't exist in JRuby implementation:
-    these depend on CRuby msgpack implemntation too highly.
-   */
   @JRubyMethod(name = "skip")
   public IRubyObject skip(ThreadContext ctx) {
     throw ctx.getRuntime().newNotImplementedError("Not supported yet in JRuby implementation");

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -69,7 +69,6 @@ public class Unpacker extends RubyObject {
       array[typeId + 128] = e;
     }
 
-    // proc, typeId(Fixnum)
     public IRubyObject lookup(int type) {
       RubyArray e = array[type + 128];
       if (e == null) {
@@ -136,8 +135,6 @@ public class Unpacker extends RubyObject {
 
   @JRubyMethod(name = "register_type", required = 1, optional = 2)
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args, final Block block) {
-    // register_type(type){|data| ExtClass.deserialize(...) }
-    // register_type(type, Class, :from_msgpack_ext)
     Ruby runtime = ctx.getRuntime();
     IRubyObject type = args[0];
 

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -184,9 +184,7 @@ public class Unpacker extends RubyObject {
     if (limit == -1) {
       limit = byteList.length() - offset;
     }
-    Decoder decoder = new Decoder(ctx.getRuntime(), registry, byteList.unsafeBytes(), byteList.begin() + offset, limit);
-    decoder.symbolizeKeys(symbolizeKeys);
-    decoder.allowUnknownExt(allowUnknownExt);
+    Decoder decoder = new Decoder(ctx.getRuntime(), registry, byteList.unsafeBytes(), byteList.begin() + offset, limit, symbolizeKeys, allowUnknownExt);
     try {
       data = null;
       data = decoder.next();
@@ -216,9 +214,7 @@ public class Unpacker extends RubyObject {
   public IRubyObject feed(ThreadContext ctx, IRubyObject data) {
     ByteList byteList = data.asString().getByteList();
     if (decoder == null) {
-      decoder = new Decoder(ctx.getRuntime(), registry, byteList.unsafeBytes(), byteList.begin(), byteList.length());
-      decoder.symbolizeKeys(symbolizeKeys);
-      decoder.allowUnknownExt(allowUnknownExt);
+      decoder = new Decoder(ctx.getRuntime(), registry, byteList.unsafeBytes(), byteList.begin(), byteList.length(), symbolizeKeys, allowUnknownExt);
     } else {
       decoder.feed(byteList.unsafeBytes(), byteList.begin(), byteList.length());
     }
@@ -353,9 +349,7 @@ public class Unpacker extends RubyObject {
     ByteList byteList = str.getByteList();
     this.stream = stream;
     this.decoder = null;
-    this.decoder = new Decoder(ctx.getRuntime(), registry, byteList.unsafeBytes(), byteList.begin(), byteList.length());
-    decoder.symbolizeKeys(symbolizeKeys);
-    decoder.allowUnknownExt(allowUnknownExt);
+    this.decoder = new Decoder(ctx.getRuntime(), registry, byteList.unsafeBytes(), byteList.begin(), byteList.length(), symbolizeKeys, allowUnknownExt);
     return getStream(ctx);
   }
 }


### PR DESCRIPTION
I had a hard time explaining what I though must be changed in #91 so I made the changes myself.

* Setters have been removed and replaced with constructor arguments. Adding setters introduces a possibility to change the internals of the objects at any time, something that they don't really support. Since there is no need to change these objects after creation there shouldn't be a way to do it.
* Replace the two extension registries with a single registry. I think this is a design mistake in the C implementation that spills over into everything else. I don't see any point in having separate registries. It complicates everything. The new registry also uses Java collections internally, because using Ruby collections in Java code makes the code very hard to read. The new implementation encapsulates things properly so that the actual implementation is not spread out over three or four different classes.
* I've also removed superflous comments and simplified code.

Unfortunately the tests don't pass in this branch,  `Factory#registered_types_internal`, `Packer#registered_types_internal` and `Unpacker#registered_types_internal` have inconsistent interfaces. The consumers of these methods expect slightly different things in the returned values. This seems to be a consequence of the aforementioned design decision in the C implementation, and I consider it a bug. I can't fix it without changing the C code and the design, something I'm not comfortable doing.

@tagomoris this is how I think the JRuby implementation should work, but as I mentioned it requires changes to the C implementation. It's up to you to decide how to proceed.