### PR TITLE
v0.7.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2015-10-24 version 0.7.0:
+
+* Add extention types support.
+* Fix to share almost all test cases between CRuby and JRuby implementations.
+* Fixed JRuby implementation to raise UnknownExtTypeError for unregistered ext type ids
+  instead to generate MessagePack::ExtensionValue instances.
+  (Specify `allow_unknown_ext: true` as unpacker option for v0.6.x behavior.)
+
 2015-07-22 version 0.6.2:
 
 * Fix release workflow: Ruby 2.1 and 2.2 are supported for Windows (2.0 is omitted)

--- a/README.rdoc
+++ b/README.rdoc
@@ -36,7 +36,6 @@ or build msgpack-ruby and install:
 * Exchange objects between software components written in different languages
   * You'll need a flexible but efficient format so that components exchange objects while keeping compatibility
 
-
 = Portability
 
 MessagePack for Ruby should run on x86, ARM, PowerPC, SPARC and other CPU architectures.
@@ -92,6 +91,32 @@ or event-driven style which works well with EventMachine:
 
 See {API reference}[http://ruby.msgpack.org/MessagePack/Unpacker.html] for details.
 
+= Extension Types
+
+Packer and Unpacker support {Extension types of MessagePack}[https://github.com/msgpack/msgpack/blob/master/spec.md#types-extension-type].
+
+    # register how to serialize custom class at first
+    pk = MessagePack::Packer.new(io)
+    pk.register_type(0x01, MyClass1, :to_msgpack_ext) # equal to pk.register_type(0x01, MyClass)
+    pk.register_type(0x02, MyClass2){|obj| obj.how_to_serialize() } # blocks also available
+    
+    # almost same API for unpacker
+    uk = MessagePack::Unpacker.new()
+    uk.register_type(0x01, MyClass1, :from_msgpack_ext)
+    uk.register_type(0x02){|data| MyClass2.create_from_serialized_data(data) }
+
+MessagePack::Factory is to create packer and unpacker which have same extention types.
+
+    factory = MessagePack::Factory.new
+    factory.register_type(0x01, MyClass1) # same with next line
+    factory.register_type(0x01, MyClass1, packer: :to_msgpack_ext, unpacker: :from_msgpack_ext)
+    pk = factory.packer(options_for_packer)
+    uk = factory.unpacker(options_for_unpacker)
+
+For *MessagePack.pack* and *MessagePack.unpack*, default packer/unpacker refer *MessagePack::DefaultFactory*. Call *MessagePack::DefaultFactory.register_type* to enable types process globally.
+
+    MessagePack::DefaultFactory.register_type(0x03, MyClass3)
+    MessagePack.unpack(data_with_ext_typeid_03) #=> MyClass3 instance
 
 = Buffer API
 
@@ -132,6 +157,6 @@ Once this step successes, target gems exist in pkg/msgpack-*-{x86,x64}-mingw32.g
 = Copyright
 
 Author::    Sadayuki Furuhashi <frsyuki@gmail.com>
-Copyright:: Copyright (c) 2008-2013 Sadayuki Furuhashi
+Copyright:: Copyright (c) 2008-2015 Sadayuki Furuhashi
 License::   Apache License, Version 2.0
 

--- a/lib/msgpack/version.rb
+++ b/lib/msgpack/version.rb
@@ -1,3 +1,3 @@
 module MessagePack
-	VERSION = "0.6.2"
+  VERSION = "0.7.0"
 end

--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.version = MessagePack::VERSION
   s.summary = "MessagePack, a binary-based efficient data interchange format."
   s.description = %q{MessagePack is a binary-based efficient object serialization library. It enables to exchange structured objects between many languages like JSON. But unlike JSON, it is very fast and small.}
-  s.authors = ["Sadayuki Furuhashi", "Theo Hultberg"]
-  s.email = ["frsyuki@gmail.com", "theo@iconara.net"]
+  s.authors = ["Sadayuki Furuhashi", "Theo Hultberg", "Satoshi Tagomori"]
+  s.email = ["frsyuki@gmail.com", "theo@iconara.net", "tagomoris@gmail.com"]
   s.license = "Apache 2.0"
   s.homepage = "http://msgpack.org/"
   s.rubyforge_project = "msgpack"


### PR DESCRIPTION
I will release msgpack.gem new major version `v0.7.0` with extension type support, for all environments.
* Add description about v0.7.0 to ChangeLog
* Add short section how to use extension types in README.rdoc
* Add me to authors :P 

@frsyuki I found that MessagePack Ruby API Reference isn't updated. How can we update it with latest `doclib` contents?

And, any thoughts about this? @frsyuki @iconara 