### PR TITLE
Allocate memory using xmalloc and xfree to make them managed under GC

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -74,13 +74,13 @@ static void _msgpack_buffer_chunk_destroy(msgpack_buffer_chunk_t* c)
     if(c->mem != NULL) {
 #ifndef DISABLE_RMEM
         if(!msgpack_rmem_free(&s_rmem, c->mem)) {
-            free(c->mem);
+            xfree(c->mem);
         }
         /* no needs to update rmem_owner because chunks will not be
          * free()ed (left in free_list) and thus *rmem_owner is
          * always valid. */
 #else
-        free(c->mem);
+        xfree(c->mem);
 #endif
     }
     c->first = NULL;
@@ -95,7 +95,7 @@ void msgpack_buffer_destroy(msgpack_buffer_t* b)
     while(c != &b->tail) {
         msgpack_buffer_chunk_t* n = c->next;
         _msgpack_buffer_chunk_destroy(c);
-        free(c);
+        xfree(c);
         c = n;
     }
     _msgpack_buffer_chunk_destroy(c);
@@ -103,7 +103,7 @@ void msgpack_buffer_destroy(msgpack_buffer_t* b)
     c = b->free_list;
     while(c != NULL) {
         msgpack_buffer_chunk_t* n = c->next;
-        free(c);
+        xfree(c);
         c = n;
     }
 }
@@ -259,7 +259,7 @@ static inline msgpack_buffer_chunk_t* _msgpack_buffer_alloc_new_chunk(msgpack_bu
 {
     msgpack_buffer_chunk_t* reuse = b->free_list;
     if(reuse == NULL) {
-        return malloc(sizeof(msgpack_buffer_chunk_t));
+        return xmalloc(sizeof(msgpack_buffer_chunk_t));
     }
     b->free_list = b->free_list->next;
     return reuse;
@@ -403,7 +403,7 @@ static inline void* _msgpack_buffer_chunk_malloc(
 
     // TODO alignment?
     *allocated_size = required_size;
-    void* mem = malloc(required_size);
+    void* mem = xmalloc(required_size);
     c->mem = mem;
     return mem;
 }
@@ -421,7 +421,7 @@ static inline void* _msgpack_buffer_chunk_realloc(
         next_size *= 2;
     }
     *current_size = next_size;
-    mem = realloc(mem, next_size);
+    mem = xrealloc(mem, next_size);
 
     c->mem = mem;
     return mem;

--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -49,7 +49,7 @@ static void Buffer_free(void* data)
     }
     msgpack_buffer_t* b = (msgpack_buffer_t*) data;
     msgpack_buffer_destroy(b);
-    free(b);
+    xfree(b);
 }
 
 static VALUE Buffer_alloc(VALUE klass)

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -48,7 +48,7 @@ static void Factory_free(msgpack_factory_t* fc)
     }
     msgpack_packer_ext_registry_destroy(&fc->pkrg);
     msgpack_unpacker_ext_registry_destroy(&fc->ukrg);
-    free(fc);
+    xfree(fc);
 }
 
 void Factory_mark(msgpack_factory_t* fc)

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -45,7 +45,7 @@ static void Packer_free(msgpack_packer_t* pk)
     }
     msgpack_packer_ext_registry_destroy(&pk->ext_registry);
     msgpack_packer_destroy(pk);
-    free(pk);
+    xfree(pk);
 }
 
 static void Packer_mark(msgpack_packer_t* pk)

--- a/ext/msgpack/rmem.c
+++ b/ext/msgpack/rmem.c
@@ -21,7 +21,7 @@
 void msgpack_rmem_init(msgpack_rmem_t* pm)
 {
     memset(pm, 0, sizeof(msgpack_rmem_t));
-    pm->head.pages = malloc(MSGPACK_RMEM_PAGE_SIZE * 32);
+    pm->head.pages = xmalloc(MSGPACK_RMEM_PAGE_SIZE * 32);
     pm->head.mask = 0xffffffff;  /* all bit is 1 = available */
 }
 
@@ -30,10 +30,10 @@ void msgpack_rmem_destroy(msgpack_rmem_t* pm)
     msgpack_rmem_chunk_t* c = pm->array_first;
     msgpack_rmem_chunk_t* cend = pm->array_last;
     for(; c != cend; c++) {
-        free(c->pages);
+        xfree(c->pages);
     }
-    free(pm->head.pages);
-    free(pm->array_first);
+    xfree(pm->head.pages);
+    xfree(pm->array_first);
 }
 
 void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
@@ -56,7 +56,7 @@ void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
         size_t capacity = c - pm->array_first;
         size_t length = last - pm->array_first;
         capacity = (capacity == 0) ? 8 : capacity * 2;
-        msgpack_rmem_chunk_t* array = realloc(pm->array_first, capacity * sizeof(msgpack_rmem_chunk_t));
+        msgpack_rmem_chunk_t* array = xrealloc(pm->array_first, capacity * sizeof(msgpack_rmem_chunk_t));
         pm->array_first = array;
         pm->array_last = array + length;
         pm->array_end = array + capacity;
@@ -71,7 +71,7 @@ void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
     *c = tmp;
 
     pm->head.mask = 0xffffffff & (~1);  /* "& (~1)" means first chunk is already allocated */
-    pm->head.pages = malloc(MSGPACK_RMEM_PAGE_SIZE * 32);
+    pm->head.pages = xmalloc(MSGPACK_RMEM_PAGE_SIZE * 32);
 
     return pm->head.pages;
 }
@@ -81,7 +81,7 @@ void _msgpack_rmem_chunk_free(msgpack_rmem_t* pm, msgpack_rmem_chunk_t* c)
     if(pm->array_first->mask == 0xffffffff) {
         /* free and move to last */
         pm->array_last--;
-        free(c->pages);
+        xfree(c->pages);
         *c = *pm->array_last;
         return;
     }

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -68,7 +68,7 @@ void _msgpack_unpacker_init(msgpack_unpacker_t* uk)
     /*memset(uk->stack, 0, MSGPACK_UNPACKER_STACK_CAPACITY);*/
 #else
     /*uk->stack = calloc(MSGPACK_UNPACKER_STACK_CAPACITY, sizeof(msgpack_unpacker_stack_t));*/
-    uk->stack = malloc(MSGPACK_UNPACKER_STACK_CAPACITY * sizeof(msgpack_unpacker_stack_t));
+    uk->stack = xmalloc(MSGPACK_UNPACKER_STACK_CAPACITY * sizeof(msgpack_unpacker_stack_t));
 #endif
     uk->stack_capacity = MSGPACK_UNPACKER_STACK_CAPACITY;
 }
@@ -78,7 +78,7 @@ void _msgpack_unpacker_destroy(msgpack_unpacker_t* uk)
 #ifdef UNPACKER_STACK_RMEM
     msgpack_rmem_free(&s_stack_rmem, uk->stack);
 #else
-    free(uk->stack);
+    xfree(uk->stack);
 #endif
 
     msgpack_buffer_destroy(UNPACKER_BUFFER_(uk));

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -47,7 +47,7 @@ static void Unpacker_free(msgpack_unpacker_t* uk)
     }
     msgpack_unpacker_ext_registry_destroy(&uk->ext_registry);
     _msgpack_unpacker_destroy(uk);
-    free(uk);
+    xfree(uk);
 }
 
 static void Unpacker_mark(msgpack_unpacker_t* uk)


### PR DESCRIPTION
Ruby VM triggers GC at certain timing depending on current memory
consumption. But if native extension uses directly malloc(), bacause
those allocated memories are not tracked by Ruby VM, GC won't be
triggered. This change replace malloc, free, and realloc with xmalloc,
xfree and xrealloc so that Ruby VM can track memory usage.

Memory consumption comparing malloc and xmalloc is here:
https://gist.github.com/frsyuki/bf64e710d666e629b10a