### PR TITLE
fixes endian conversion of unpacking ext 16 and 32

### DIFF
--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -236,8 +236,8 @@ public class Decoder implements Iterator<IRubyObject> {
         case BIN8:     return consumeString(buffer.get() & 0xff, binaryEncoding);
         case BIN16:    return consumeString(buffer.getShort() & 0xffff, binaryEncoding);
         case BIN32:    return consumeString(buffer.getInt(), binaryEncoding);
-        case VAREXT8:  return consumeExtension(buffer.get());
-        case VAREXT16: return consumeExtension(buffer.getShort());
+        case VAREXT8:  return consumeExtension(buffer.get() & 0xff);
+        case VAREXT16: return consumeExtension(buffer.getShort() & 0xffff);
         case VAREXT32: return consumeExtension(buffer.getInt());
         case FLOAT32:  return runtime.newFloat(buffer.getFloat());
         case FLOAT64:  return runtime.newFloat(buffer.getDouble());

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -364,7 +364,7 @@ static inline void msgpack_packer_write_ext(msgpack_packer_t* pk, int ext_type, 
         msgpack_buffer_write_2(PACKER_BUFFER_(pk), 0xd8, ext_type);
         break;
     default:
-        if(len < 255) {
+        if(len < 256) {
             msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 3);
             msgpack_buffer_write_2(PACKER_BUFFER_(pk), 0xc7, len);
             msgpack_buffer_write_1(PACKER_BUFFER_(pk), ext_type);

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -380,7 +380,7 @@ static int read_primitive(msgpack_unpacker_t* uk)
         case 0xc8: // ext 16
             {
                 READ_CAST_BLOCK_OR_RETURN_EOF(cb, uk, 3);
-                uint16_t length = cb->u16;
+                uint16_t length = _msgpack_be16(cb->u16);
                 int ext_type = cb->buffer[2];
                 if(length == 0) {
                     return object_complete_ext(uk, ext_type, rb_str_buf_new(0));
@@ -392,7 +392,7 @@ static int read_primitive(msgpack_unpacker_t* uk)
         case 0xc9: // ext 32
             {
                 READ_CAST_BLOCK_OR_RETURN_EOF(cb, uk, 5);
-                uint32_t length = cb->u32;
+                uint32_t length = _msgpack_be32(cb->u32);
                 int ext_type = cb->buffer[4];
                 if(length == 0) {
                     return object_complete_ext(uk, ext_type, rb_str_buf_new(0));

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -223,4 +223,34 @@ describe MessagePack::Packer do
       expect(two[:packer]).to eq(:to_msgpack_ext)
     end
   end
+
+  describe "ext formats" do
+    [1, 2, 4, 8, 16].zip([0xd4, 0xd5, 0xd6, 0xd7, 0xd8]).each do |n,b|
+      it "msgpack fixext #{n} format" do
+        MessagePack::ExtensionValue.new(1, "a"*n).to_msgpack.should ==
+          [b, 1].pack('CC') + "a"*n
+      end
+    end
+
+    it "msgpack ext 8 format" do
+      MessagePack::ExtensionValue.new(1, "").to_msgpack.should ==
+        [0xc7, 0, 1].pack('CCC') + ""
+      MessagePack::ExtensionValue.new(-1, "a"*255).to_msgpack.should ==
+        [0xc7, 255, -1].pack('CCC') + "a"*255
+    end
+
+    it "msgpack ext 16 format" do
+      MessagePack::ExtensionValue.new(1, "a"*256).to_msgpack.should ==
+        [0xc8, 256, 1].pack('CnC') + "a"*256
+      MessagePack::ExtensionValue.new(-1, "a"*65535).to_msgpack.should ==
+        [0xc8, 65535, -1].pack('CnC') + "a"*65535
+    end
+
+    it "msgpack ext 32 format" do
+      MessagePack::ExtensionValue.new(1, "a"*65536).to_msgpack.should ==
+        [0xc9, 65536, 1].pack('CNC') + "a"*65536
+      MessagePack::ExtensionValue.new(-1, "a"*65538).to_msgpack.should ==
+        [0xc9, 65538, -1].pack('CNC') + "a"*65538
+    end
+  end
 end


### PR DESCRIPTION
This fixes:

* unpacker doesn't convert endian of length part of ext 16 format
* unpacker doesn't convert endian of length part of ext 32 format
* packer uses ext 16 format when a length of body is 255 bytes

Fixes [#99].