### PR TITLE
Possibility to write 32-bit single precision floats to MessagePack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.1.6
   - 2.2.2
   - ruby-head
-  - rbx-2
   - jruby-19mode
   - jruby-head
 
@@ -28,3 +27,4 @@ matrix:
     - rvm: jruby-head
     - rvm: jruby-19mode
       os: osx
+    - rvm: rbx-2

--- a/doclib/msgpack/packer.rb
+++ b/doclib/msgpack/packer.rb
@@ -110,6 +110,18 @@ module MessagePack
     end
 
     #
+    # Serializes _value_ as 32-bit single precision float into internal buffer.
+    # _value_ will be approximated with the nearest possible single precision float, thus
+    # being potentially lossy. However, the serialized string will only take up 5 bytes
+    # instead of 9 bytes compared to directly serializing a 64-bit double precision Ruby Float.
+    #
+    # @param value [Numeric]
+    # @return [Packer] self
+    #
+    def write_float32(value)
+    end
+
+    #
     # Flushes data in the internal buffer to the internal IO. Same as _buffer.flush.
     # If internal IO is not set, it does nothing.
     #

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -8,6 +8,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyObject;
 import org.jruby.RubyNil;
 import org.jruby.RubyBoolean;
+import org.jruby.RubyNumeric;
 import org.jruby.RubyBignum;
 import org.jruby.RubyInteger;
 import org.jruby.RubyFixnum;
@@ -82,6 +83,11 @@ public class Encoder {
 
   public IRubyObject encodeMapHeader(int size) {
     appendHashHeader(size);
+    return readRubyString();
+  }
+
+  public IRubyObject encodeFloat32(RubyNumeric numeric) {
+    appendFloat32(numeric);
     return readRubyString();
   }
 
@@ -182,8 +188,8 @@ public class Encoder {
 
   private void appendFloat(RubyFloat object) {
     double value = object.getDoubleValue();
-    float f = (float) value;
     //TODO: msgpack-ruby original does encode this value as Double, not float
+    // float f = (float) value;
     // if (Double.compare(f, value) == 0) {
     //   ensureRemainingCapacity(5);
     //   buffer.put(FLOAT32);
@@ -193,6 +199,13 @@ public class Encoder {
       buffer.put(FLOAT64);
       buffer.putDouble(value);
     // }
+  }
+
+  private void appendFloat32(RubyNumeric object) {
+    float value = (float) object.getDoubleValue();
+    ensureRemainingCapacity(5);
+    buffer.put(FLOAT32);
+    buffer.putFloat(value);
   }
 
   private void appendString(RubyString object) {

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -7,6 +7,7 @@ import org.jruby.RubyObject;
 import org.jruby.RubyArray;
 import org.jruby.RubyHash;
 import org.jruby.RubyIO;
+import org.jruby.RubyNumeric;
 import org.jruby.RubyInteger;
 import org.jruby.RubyFixnum;
 import org.jruby.runtime.Block;
@@ -111,6 +112,16 @@ public class Packer extends RubyObject {
   @JRubyMethod(name = "write_nil")
   public IRubyObject writeNil(ThreadContext ctx) {
     write(ctx, null);
+    return this;
+  }
+
+  @JRubyMethod(name = "write_float32")
+  public IRubyObject writeFloat32(ThreadContext ctx, IRubyObject numeric) {
+    Ruby runtime = ctx.runtime;
+    if (!(numeric instanceof RubyNumeric)) {
+      throw runtime.newArgumentError("Expected numeric");
+    }
+    buffer.write(ctx, encoder.encodeFloat32((RubyNumeric) numeric));
     return this;
   }
 

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -255,6 +255,18 @@ static inline void msgpack_packer_write_u64(msgpack_packer_t* pk, uint64_t v)
     }
 }
 
+static inline void msgpack_packer_write_float(msgpack_packer_t* pk, float v)
+{
+    msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 5);
+    union {
+        float f;
+        uint32_t u32;
+        char mem[4];
+    } castbuf = { v };
+    castbuf.u32 = _msgpack_be_float(castbuf.u32);
+    msgpack_buffer_write_byte_and_data(PACKER_BUFFER_(pk), 0xca, castbuf.mem, 4);
+}
+
 static inline void msgpack_packer_write_double(msgpack_packer_t* pk, double v)
 {
     msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), 9);

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -149,6 +149,17 @@ static VALUE Packer_write_map_header(VALUE self, VALUE n)
     return self;
 }
 
+static VALUE Packer_write_float32(VALUE self, VALUE numeric)
+{
+    if(!rb_obj_is_kind_of(numeric, rb_cNumeric)) {
+      rb_raise(rb_eArgError, "Expected numeric");
+    }
+
+    PACKER(self, pk);
+    msgpack_packer_write_float(pk, (float)rb_num2dbl(numeric));
+    return self;
+}
+
 static VALUE Packer_write_ext(VALUE self, VALUE type, VALUE data)
 {
     PACKER(self, pk);
@@ -344,6 +355,7 @@ void MessagePack_Packer_module_init(VALUE mMessagePack)
     rb_define_method(cMessagePack_Packer, "write_array_header", Packer_write_array_header, 1);
     rb_define_method(cMessagePack_Packer, "write_map_header", Packer_write_map_header, 1);
     rb_define_method(cMessagePack_Packer, "write_ext", Packer_write_ext, 2);
+    rb_define_method(cMessagePack_Packer, "write_float32", Packer_write_float32, 1);
     rb_define_method(cMessagePack_Packer, "flush", Packer_flush, 0);
 
     /* delegation methods */

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -57,6 +57,30 @@ describe MessagePack::Packer do
     packer.to_s.should == "\x81"
   end
 
+  describe '#write_float32' do
+    tests = [
+      ['small floats', 3.14, "\xCA\x40\x48\xF5\xC3"],
+      ['big floats', Math::PI * 1_000_000_000_000_000_000, "\xCA\x5E\x2E\x64\xB7"],
+      ['negative floats', -2.1, "\xCA\xC0\x06\x66\x66"],
+      ['integer', 123, "\xCA\x42\xF6\x00\x00"],
+    ]
+
+    tests.each do |ctx, numeric, packed|
+      context("with #{ctx}") do
+        it("encodes #{numeric} as float32") do
+          packer.write_float32(numeric)
+          packer.to_s.should == packed
+        end
+      end
+    end
+
+    context 'with non numeric' do
+      it 'raises argument error' do
+        expect { packer.write_float32('abc') }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   it 'flush' do
     io = StringIO.new
     pk = MessagePack::Packer.new(io)


### PR DESCRIPTION
I was missing a way to pass 32-bit single precision floats to MessagePack since ruby only has 64-bit double precision floats. 

With this change it is possible by simply wrapping any float (or in fact any numeric) ruby value in a new MessagePack::SinglePrecisionFloat instance. Thoughts?

The JRuby implementation is missing for now. Unfortunately I don't have time/experience for that part :/

