### PR TITLE
Unpacker can work with object non-IO but has #write

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.1.6
   - 2.2.2
   - ruby-head
-  - rbx-2
   - jruby-19mode
   - jruby-head
 
@@ -28,3 +27,4 @@ matrix:
     - rvm: jruby-head
     - rvm: jruby-19mode
       os: osx
+    - rvm: rbx-2

--- a/Rakefile
+++ b/Rakefile
@@ -37,14 +37,6 @@ if RUBY_PLATFORM =~ /java/
     ext.source_version = '1.6'
     ext.target_version = '1.6'
   end
-
-  RSpec::Core::RakeTask.new(:spec) do |t|
-    t.rspec_opts = ["-c", "-f progress"]
-    t.rspec_opts << "-Ilib"
-    t.pattern = 'spec/{,jruby/}*_spec.rb'
-    t.verbose = true
-  end
-
 else
   require 'rake/extensiontask'
 
@@ -55,13 +47,18 @@ else
     # cross_platform names are of MRI's platform name
     ext.cross_platform = ['x86-mingw32', 'x64-mingw32']
   end
+end
 
-  RSpec::Core::RakeTask.new(:spec) do |t|
-    t.rspec_opts = ["-c", "-f progress"]
-    t.rspec_opts << "-Ilib"
-    t.pattern = 'spec/{,cruby/}*_spec.rb'
-    t.verbose = true
-  end
+test_pattern = case
+               when RUBY_PLATFORM =~ /java/ then 'spec/{,jruby/}*_spec.rb'
+               when RUBY_ENGINE =~ /rbx/ then 'spec/*_spec.rb'
+               else 'spec/{,cruby/}*_spec.rb' # MRI
+               end
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = ["-c", "-f progress"]
+  t.rspec_opts << "-Ilib"
+  t.pattern = test_pattern
+  t.verbose = true
 end
 
 namespace :build do

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -297,6 +297,8 @@ public class Unpacker extends RubyObject {
       str = stream.callMethod(ctx, "string").asString();
     } else if (stream instanceof RubyIO) {
       str = stream.callMethod(ctx, "read").asString();
+    } else if (stream.respondsTo("read")) {
+      str = stream.callMethod(ctx, "read").asString();
     } else {
       throw ctx.getRuntime().newTypeError(stream, "IO");
     }

--- a/lib/msgpack/version.rb
+++ b/lib/msgpack/version.rb
@@ -1,3 +1,3 @@
 module MessagePack
-  VERSION = "0.7.1"
+  VERSION = "0.7.2dev1"
 end

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -26,7 +26,7 @@ describe MessagePack::Packer do
     sample_data = {"message" => "morning!", "num" => 1}
     sample_packed = MessagePack.pack(sample_data)
 
-    Tempfile.create("for_io") do |file|
+    Tempfile.open("for_io") do |file|
       file.sync = true
       p1 = MessagePack::Packer.new(file)
       p1.write sample_data
@@ -34,6 +34,7 @@ describe MessagePack::Packer do
 
       file.rewind
       expect(file.read).to eql(sample_packed)
+      file.unlink
     end
 
     dio = StringIO.new

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -29,7 +29,7 @@ describe MessagePack::Unpacker do
     sample_data = {"message" => "morning!", "num" => 1}
     sample_packed = MessagePack.pack(sample_data).force_encoding('ASCII-8BIT')
 
-    Tempfile.create("for_io") do |file|
+    Tempfile.open("for_io") do |file|
       file.sync = true
       file.write sample_packed
       file.rewind
@@ -38,6 +38,7 @@ describe MessagePack::Unpacker do
       u1.each do |obj|
         expect(obj).to eql(sample_data)
       end
+      file.unlink
     end
 
     sio = StringIO.new(sample_packed)

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -2,6 +2,7 @@
 
 require 'stringio'
 require 'tempfile'
+require 'zlib'
 
 require 'spec_helper'
 
@@ -22,6 +23,72 @@ describe MessagePack::Unpacker do
     u2 = MessagePack::Unpacker.new(symbolize_keys: true, allow_unknown_ext: true)
     u2.symbolize_keys?.should == true
     u2.allow_unknown_ext?.should == true
+  end
+
+  it 'gets IO or object which has #read to read data from it' do
+    sample_data = {"message" => "morning!", "num" => 1}
+    sample_packed = MessagePack.pack(sample_data).force_encoding('ASCII-8BIT')
+
+    Tempfile.create("for_io") do |file|
+      file.sync = true
+      file.write sample_packed
+      file.rewind
+
+      u1 = MessagePack::Unpacker.new(file)
+      u1.each do |obj|
+        expect(obj).to eql(sample_data)
+      end
+    end
+
+    sio = StringIO.new(sample_packed)
+    u2 = MessagePack::Unpacker.new(sio)
+    u2.each do |obj|
+      expect(obj).to eql(sample_data)
+    end
+
+    dio = StringIO.new
+    Zlib::GzipWriter.wrap(dio){|gz| gz.write sample_packed }
+    reader = Zlib::GzipReader.new(StringIO.new(dio.string))
+    u3 = MessagePack::Unpacker.new(reader)
+    u3.each do |obj|
+      expect(obj).to eql(sample_data)
+    end
+
+    class DummyIO
+      def initialize
+        @buf = "".force_encoding('ASCII-8BIT')
+        @pos = 0
+      end
+      def write(val)
+        @buf << val.to_s
+      end
+      def read(length=nil,outbuf="")
+        if @pos == @buf.size
+          nil
+        elsif length.nil?
+          val = @buf[@pos..(@buf.size)]
+          @pos = @buf.size
+          outbuf << val
+          outbuf
+        else
+          val = @buf[@pos..(@pos + length)]
+          @pos += val.size
+          @pos = @buf.size if @pos > @buf.size
+          outbuf << val
+          outbuf
+        end
+      end
+      def flush
+        # nop
+      end
+    end
+
+    dio = DummyIO.new
+    dio.write sample_packed
+    u4 = MessagePack::Unpacker.new(dio)
+    u4.each do |obj|
+      expect(obj).to eql(sample_data)
+    end
   end
 
   it 'read_array_header succeeds' do


### PR DESCRIPTION
In ruby way, Packer/Unpacker argument checks should be done only by `io.respond_to?("read")` and/or `io.respond_to?("write")`.