### PR TITLE
Update rake-compiler-dock version to 0.5.0

### DIFF
--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', ['~> 0.9.2']
   s.add_development_dependency 'rake-compiler', ['~> 0.9.4']
   if /java/ !~ RUBY_PLATFORM
-    s.add_development_dependency 'rake-compiler-dock', ['~> 0.4.3']
+    s.add_development_dependency 'rake-compiler-dock', ['~> 0.5.0']
   end
   s.add_development_dependency 'rspec', ['~> 3.3']
   s.add_development_dependency 'yard', ['~> 0.8.2']


### PR DESCRIPTION
`rake-compiler-dock` supports cross compiling against CRuby 2.3.0.
`rake-compiler-dock` pulls latest Docker image automatically.