### PR TITLE
Improve Buffer compatibility about underlying io objects between cruby and jruby

### DIFF
--- a/ext/java/org/msgpack/jruby/Buffer.java
+++ b/ext/java/org/msgpack/jruby/Buffer.java
@@ -42,8 +42,9 @@ public class Buffer extends RubyObject {
   @JRubyMethod(name = "initialize", optional = 2)
   public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
     if (args.length > 0) {
-      if (args[0].respondsTo("read") && args[0].respondsTo("write")) {
-        this.io = args[0];
+      IRubyObject io = args[0];
+      if (io.respondsTo("close") && (io.respondsTo("read") || (io.respondsTo("write") && io.respondsTo("flush")))) {
+        this.io = io;
       }
     }
     this.buffer = ByteBuffer.allocate(CACHE_LINE_SIZE - ARRAY_HEADER_SIZE);

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -44,21 +44,18 @@ describe MessagePack::Packer do
     dio.rewind
     expect(dio.string).to eql(sample_packed)
 
-    unless defined? JRUBY_VERSION
-      # JRuby seems to have bug not to flush GzipWriter buffer correctly (both of 1.7 and 9.0)
-      dio = StringIO.new
-      writer = Zlib::GzipWriter.new(dio)
-      writer.sync = true
-      p3 = MessagePack::Packer.new(writer)
-      p3.write sample_data
-      p3.flush
-      writer.flush(Zlib::FINISH)
-      writer.close
-      dio.rewind
-      compressed = dio.string
-      str = Zlib::GzipReader.wrap(StringIO.new(compressed)){|gz| gz.read }
-      expect(str).to eql(sample_packed)
-    end
+    dio = StringIO.new
+    writer = Zlib::GzipWriter.new(dio)
+    writer.sync = true
+    p3 = MessagePack::Packer.new(writer)
+    p3.write sample_data
+    p3.flush
+    writer.flush(Zlib::FINISH)
+    writer.close
+    dio.rewind
+    compressed = dio.string
+    str = Zlib::GzipReader.wrap(StringIO.new(compressed)){|gz| gz.read }
+    expect(str).to eql(sample_packed)
 
     class DummyIO
       def initialize
@@ -85,6 +82,9 @@ describe MessagePack::Packer do
         end
       end
       def flush
+        # nop
+      end
+      def close
         # nop
       end
     end


### PR DESCRIPTION
especially for the case used from Packer
* for Packer, Buffer requires #close, #flush and #write
* Buffer#read is not used by Packer/Unpacker, and read-only buffer should have only #read (w/o #write)