### PR TITLE
travis: Add jruby-9.0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,6 @@ matrix:
     - rvm: jruby-head
     - rvm: jruby-19mode
       os: osx
+    - rvm: jruby-9.0.5.0
+      os: osx
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3.0
   - ruby-head
   - jruby-19mode
+  - jruby-9.0.5.0
   - jruby-head
 
 os:


### PR DESCRIPTION
JRuby encoding bug has been fixed.
It seems that this bug seems to be included JRuby 9.0.4.0 or earlier
major 9 versions.
jruby-9.0.0.0 and jruby-9.0.3.0 are also affected.