### PR TITLE
Handle the case when a Bignum in JRuby contains a small value

### DIFF
--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -3,6 +3,7 @@ package org.msgpack.jruby;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import org.jruby.Ruby;
 import org.jruby.RubyObject;
@@ -131,6 +132,12 @@ public class Encoder {
     ensureRemainingCapacity(9);
     buffer.put(value.signum() < 0 ? INT64 : UINT64);
     byte[] b = value.toByteArray();
+    if (b.length < 8) {
+      byte[] bb = b;
+      b = new byte[8];
+      Arrays.fill(b, (byte) (value.signum() < 0 ? 255 : 0));
+      System.arraycopy(bb, 0, b, 8 - bb.length, bb.length);
+    }
     buffer.put(b, b.length - 8, 8);
   }
 

--- a/spec/msgpack_spec.rb
+++ b/spec/msgpack_spec.rb
@@ -159,4 +159,32 @@ describe MessagePack do
       packed.should start_with("\xDA\x00\x20")
     end
   end
+
+  if java?
+    context 'when a Bignum has a small positive value' do
+      it 'encodes it as a INT64' do
+        bignum = Java::OrgJruby::RubyBignum.long2big(1)
+        MessagePack.pack(bignum).should eq("\xCF\x00\x00\x00\x00\x00\x00\x00\x01".force_encoding(Encoding::BINARY))
+      end
+
+      it 'decodes it to a Fixnum' do
+        n = MessagePack.unpack("\xCF\x00\x00\x00\x00\x00\x00\x00\x01".force_encoding(Encoding::BINARY))
+        n.should be_a(Fixnum)
+        n.should eq(1)
+      end
+    end
+
+    context 'when a Bignum has a small negative value' do
+      it 'encodes it as a UINT64' do
+        bignum = Java::OrgJruby::RubyBignum.long2big(-2)
+        MessagePack.pack(bignum).should eq("\xD3\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE".force_encoding(Encoding::BINARY))
+      end
+
+      it 'decodes it to a Fixnum' do
+        n = MessagePack.unpack("\xD3\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE".force_encoding(Encoding::BINARY))
+        n.should be_a(Fixnum)
+        n.should eq(-2)
+      end
+    end
+  end
 end

--- a/spec/msgpack_spec.rb
+++ b/spec/msgpack_spec.rb
@@ -160,31 +160,29 @@ describe MessagePack do
     end
   end
 
-  if java?
-    context 'when a Bignum has a small positive value' do
-      it 'encodes it as a INT64' do
-        bignum = Java::OrgJruby::RubyBignum.long2big(1)
-        MessagePack.pack(bignum).should eq("\xCF\x00\x00\x00\x00\x00\x00\x00\x01".force_encoding(Encoding::BINARY))
-      end
-
-      it 'decodes it to a Fixnum' do
-        n = MessagePack.unpack("\xCF\x00\x00\x00\x00\x00\x00\x00\x01".force_encoding(Encoding::BINARY))
-        n.should be_a(Fixnum)
-        n.should eq(1)
-      end
+  context 'when a Bignum has a small positive value' do
+    it 'encodes it as a INT64' do
+      bignum = (1 << 64).coerce(1)[0]
+      MessagePack.pack(bignum).should eq("\xCF\x00\x00\x00\x00\x00\x00\x00\x01".force_encoding(Encoding::BINARY))
     end
 
-    context 'when a Bignum has a small negative value' do
-      it 'encodes it as a UINT64' do
-        bignum = Java::OrgJruby::RubyBignum.long2big(-2)
-        MessagePack.pack(bignum).should eq("\xD3\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE".force_encoding(Encoding::BINARY))
-      end
+    it 'decodes it to a Fixnum' do
+      n = MessagePack.unpack("\xCF\x00\x00\x00\x00\x00\x00\x00\x01".force_encoding(Encoding::BINARY))
+      n.should be_a(Fixnum)
+      n.should eq(1)
+    end
+  end
 
-      it 'decodes it to a Fixnum' do
-        n = MessagePack.unpack("\xD3\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE".force_encoding(Encoding::BINARY))
-        n.should be_a(Fixnum)
-        n.should eq(-2)
-      end
+  context 'when a Bignum has a small negative value' do
+    it 'encodes it as a UINT64' do
+      bignum = (1 << 64).coerce(-2)[0]
+      MessagePack.pack(bignum).should eq("\xD3\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE".force_encoding(Encoding::BINARY))
+    end
+
+    it 'decodes it to a Fixnum' do
+      n = MessagePack.unpack("\xD3\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE".force_encoding(Encoding::BINARY))
+      n.should be_a(Fixnum)
+      n.should eq(-2)
     end
   end
 end

--- a/spec/msgpack_spec.rb
+++ b/spec/msgpack_spec.rb
@@ -160,29 +160,12 @@ describe MessagePack do
     end
   end
 
-  context 'when a Bignum has a small positive value' do
-    it 'encodes it as a INT64' do
-      bignum = (1 << 64).coerce(1)[0]
-      MessagePack.pack(bignum).should eq("\xCF\x00\x00\x00\x00\x00\x00\x00\x01".force_encoding(Encoding::BINARY))
-    end
-
-    it 'decodes it to a Fixnum' do
-      n = MessagePack.unpack("\xCF\x00\x00\x00\x00\x00\x00\x00\x01".force_encoding(Encoding::BINARY))
-      n.should be_a(Fixnum)
-      n.should eq(1)
-    end
-  end
-
-  context 'when a Bignum has a small negative value' do
-    it 'encodes it as a UINT64' do
-      bignum = (1 << 64).coerce(-2)[0]
-      MessagePack.pack(bignum).should eq("\xD3\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE".force_encoding(Encoding::BINARY))
-    end
-
-    it 'decodes it to a Fixnum' do
-      n = MessagePack.unpack("\xD3\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE".force_encoding(Encoding::BINARY))
-      n.should be_a(Fixnum)
-      n.should eq(-2)
+  context 'when a Bignum has a small value' do
+    tests['numbers'].take(10).each do |desc, unpacked, packed|
+      it("encodes #{desc} to the smallest representation") do
+        bignum = (1 << 64).coerce(unpacked)[0]
+        MessagePack.pack(bignum).should eq(packed)
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes #112.

In JRuby a Java extension can create a `Bignum` with any value, which our current implementation doesn't expect.

Ensure that the code handles byte arrays from Java's `BigInteger#toByteArray` that are less than 8 bytes – and make sure the top bytes are filled with either `0x00` or `0xFF` depending on the sign of the value.

I've included tests for this in `spec/msgpack_spec.rb`, but guarded so that they run only in JRuby, is this the right place for these kinds of platform-specific tests?

Can the same thing happen in MRI by the way? I assume there's a way to construct a `Bignum` with small values there too?

It would be possible to optimize the case when a `Bignum` has a small value and encode it as an `INT32`/`UINT32` or even smaller, but I don't know if we want to do that. `Bignum`s aren't supposed to contain numbers small enough to fit in an `INT32`, so optimizing that case might lead to confusing results, what do you think?