### PR TITLE
Serializing symbols using an ext type

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -91,6 +91,36 @@ or event-driven style which works well with EventMachine:
 
 See {API reference}[http://ruby.msgpack.org/MessagePack/Unpacker.html] for details.
 
+= Serializing and deserializing symbols
+
+By default, symbols are serialized as strings:
+
+    packed = :symbol.to_msgpack     # => "\xA6symbol"
+    MessagePack.unpack(packed)      # => "symbol"
+
+This can be customized by registering an extension type for them:
+
+    MessagePack::DefaultFactory.register_type(0x00, Symbol)
+
+    # symbols now survive round trips
+    packed = :symbol.to_msgpack     # => "\xc7\x06\x00symbol"
+    MessagePack.unpack(packed)      # => :symbol
+
+The extension type for symbols is configurable like any other extension type.
+For example, to customize how symbols are packed you can just redefine
+Symbol#to_msgpack_ext. Doing this gives you an option to prevent symbols from
+being serialized altogether by throwing an exception:
+
+    class Symbol
+        def to_msgpack_ext
+            raise "Serialization of symbols prohibited"
+        end
+    end
+
+    MessagePack::DefaultFactory.register_type(0x00, Symbol)
+
+    [1, :symbol, 'string'].to_msgpack  # => RuntimeError: Serialization of symbols prohibited
+
 = Extension Types
 
 Packer and Unpacker support {Extension types of MessagePack}[https://github.com/msgpack/msgpack/blob/master/spec.md#types-extension-type].

--- a/bench/pack_symbols.rb
+++ b/bench/pack_symbols.rb
@@ -1,0 +1,28 @@
+require 'viiite'
+require 'msgpack'
+
+data = :symbol
+
+Viiite.bench do |b|
+  b.variation_point :branch, `git rev-parse --abbrev-ref HEAD`
+
+  b.range_over([:symbol, :none], :reg_type) do |reg_type|
+    packer = MessagePack::Packer.new
+    packer.register_type(0x00, Symbol, :to_msgpack_ext) if reg_type == :symbol
+
+    b.range_over([100_000, 1_000_000, 10_000_000], :count) do |count|
+      packer.clear
+      b.report(:multi_run) do
+        count.times do
+          packer.pack(data)
+        end
+      end
+
+      packer.clear
+      items_data = [].fill(data, 0, count)
+      b.report(:large_run) do
+        packer.pack(items_data)
+      end
+    end
+  end
+end

--- a/bench/run_symbols.sh
+++ b/bench/run_symbols.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# so master and this branch have the benchmark file in any case
+cp bench/pack_symbols.rb bench/pack_symbols_tmp.rb
+
+benchmark=""
+current_branch=`git rev-parse --abbrev-ref HEAD`
+
+for branch in master $current_branch; do
+    echo "Testing branch $branch"
+    git checkout $branch
+
+    echo "Installing gem..."
+    rake install
+
+    echo "Running benchmark..."
+    if [ "$benchmark" ]; then
+        benchmark+=$'\n'
+    fi
+    benchmark+=$(viiite run bench/pack_symbols_tmp.rb)
+    echo
+done
+
+rm bench/pack_symbols_tmp.rb
+
+echo "$benchmark" | viiite report --regroup bench,reg_type,count,branch

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -32,6 +32,7 @@ typedef struct msgpack_factory_t msgpack_factory_t;
 struct msgpack_factory_t {
     msgpack_packer_ext_registry_t pkrg;
     msgpack_unpacker_ext_registry_t ukrg;
+    bool has_symbol_ext_type;
 };
 
 #define FACTORY(from, name) \
@@ -72,6 +73,8 @@ static VALUE Factory_initialize(int argc, VALUE* argv, VALUE self)
 {
     FACTORY(self, fc);
 
+    fc->has_symbol_ext_type = false;
+
     switch (argc) {
     case 0:
         break;
@@ -95,6 +98,7 @@ VALUE MessagePack_Factory_packer(int argc, VALUE* argv, VALUE self)
 
     msgpack_packer_ext_registry_destroy(&pk->ext_registry);
     msgpack_packer_ext_registry_dup(&fc->pkrg, &pk->ext_registry);
+    pk->has_symbol_ext_type = fc->has_symbol_ext_type;
 
     return packer;
 }
@@ -187,6 +191,10 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
     }
 
     msgpack_packer_ext_registry_put(&fc->pkrg, ext_class, ext_type, packer_proc, packer_arg);
+
+    if (ext_class == rb_cSymbol) {
+        fc->has_symbol_ext_type = true;
+    }
 
     msgpack_unpacker_ext_registry_put(&fc->ukrg, ext_class, ext_type, unpacker_proc, unpacker_arg);
 

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -121,7 +121,7 @@ void msgpack_packer_write_hash_value(msgpack_packer_t* pk, VALUE v)
 #endif
 }
 
-static void _msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
+void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
 {
     int ext_type;
     VALUE proc = msgpack_packer_ext_registry_lookup(&pk->ext_registry,
@@ -169,7 +169,7 @@ void msgpack_packer_write_value(msgpack_packer_t* pk, VALUE v)
         msgpack_packer_write_float_value(pk, v);
         break;
     default:
-        _msgpack_packer_write_other_value(pk, v);
+        msgpack_packer_write_other_value(pk, v);
     }
 }
 

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -32,6 +32,7 @@ struct msgpack_packer_t {
     msgpack_buffer_t buffer;
 
     bool compatibility_mode;
+    bool has_symbol_ext_type;
 
     ID to_msgpack_method;
     VALUE to_msgpack_arg;
@@ -448,7 +449,7 @@ static inline void msgpack_packer_write_string_value(msgpack_packer_t* pk, VALUE
 #endif
 }
 
-static inline void msgpack_packer_write_symbol_value(msgpack_packer_t* pk, VALUE v)
+static inline void msgpack_packer_write_symbol_string_value(msgpack_packer_t* pk, VALUE v)
 {
 #ifdef HAVE_RB_SYM2STR
     /* rb_sym2str is added since MRI 2.2.0 */
@@ -460,6 +461,17 @@ static inline void msgpack_packer_write_symbol_value(msgpack_packer_t* pk, VALUE
     }
     msgpack_packer_write_string_value(pk, str);
 #endif
+}
+
+void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v);
+
+static inline void msgpack_packer_write_symbol_value(msgpack_packer_t* pk, VALUE v)
+{
+    if (pk->has_symbol_ext_type) {
+        msgpack_packer_write_other_value(pk, v);
+    } else {
+        msgpack_packer_write_symbol_string_value(pk, v);
+    }
 }
 
 static inline void msgpack_packer_write_fixnum_value(msgpack_packer_t* pk, VALUE v)

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -286,6 +286,10 @@ static VALUE Packer_register_type(int argc, VALUE* argv, VALUE self)
 
     msgpack_packer_ext_registry_put(&pk->ext_registry, ext_class, ext_type, proc, arg);
 
+    if (ext_class == rb_cSymbol) {
+        pk->has_symbol_ext_type = true;
+    }
+
     return Qnil;
 }
 

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -15,3 +15,4 @@ end
 require "msgpack/packer"
 require "msgpack/unpacker"
 require "msgpack/factory"
+require "msgpack/symbol"

--- a/lib/msgpack/symbol.rb
+++ b/lib/msgpack/symbol.rb
@@ -1,0 +1,9 @@
+class Symbol
+  def to_msgpack_ext
+    [to_s].pack('A*')
+  end
+
+  def self.from_msgpack_ext(data)
+    data.unpack('A*').first.to_sym
+  end
+end

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -323,6 +323,14 @@ describe MessagePack::Packer do
       expect(two[:class]).to eq(ValueTwo)
       expect(two[:packer]).to eq(:to_msgpack_ext)
     end
+
+    context 'when registering a type for symbols' do
+      before { packer.register_type(0x00, ::Symbol, :to_msgpack_ext) }
+
+      it 'packs symbols in an ext type' do
+        expect(packer.pack(:symbol).to_s).to eq "\xc7\x06\x00symbol"
+      end
+    end
   end
 
   describe "ext formats" do


### PR DESCRIPTION
re #110 

### How it's implementend

1. Packers and Factorys got a flag `has_symbol_ext_type`.
2. `has_symbol_ext_type` is set to `true` once an ext type for class `Symbol` is registered in their ext registry.
3. When encountering a symbol during serialization, the `has_symbol_ext_type` flag is checked. If it's `false` the symbol is serialized as string. If it's `true` its serialized as ext type.
4. `Symbol` got a default `#to_msgpack_ext` and `.from_msgpack_ext` so it does not need to be defined manually.

### Performance

This below benchmark compares the *master* branch with the *[preserve_symbols](https://github.com/christopheraue/msgpack-ruby/tree/preserve_symbols)* branch. With no ext type registered both have identical run times. Once the symbol ext type is registered, the custom serialization kicks in on the *preserve_symbols* branch and drags down performance:

Columns:

* bench:
  * `large_run`: 1 pack of an array of *count* symbols
  * `multi_run`: *count* packs of 1 symbol
* reg_type:
  * `none`: packers has no ext type registered
  * `symbol`: packer has an ext type registered for symbols

Benchmark:

    +------------+-----------+----------+------------------+-----------+----------+-----------+-----------+
    | :bench     | :reg_type | :count   | :branch          | :user     | :system  | :total    | :real     |
    +------------+-----------+----------+------------------+-----------+----------+-----------+-----------+
    | :large_run | :none     |   100000 | master           |  0.000000 | 0.000000 |  0.000000 |  0.002413 |
    | :large_run | :none     |   100000 | preserve_symbols |  0.000000 | 0.000000 |  0.000000 |  0.002356 |
    | :large_run | :none     |  1000000 | master           |  0.030000 | 0.000000 |  0.030000 |  0.031178 |
    | :large_run | :none     |  1000000 | preserve_symbols |  0.030000 | 0.000000 |  0.030000 |  0.029986 |
    | :large_run | :none     | 10000000 | master           |  0.820000 | 0.000000 |  0.820000 |  0.820698 |
    | :large_run | :none     | 10000000 | preserve_symbols |  0.810000 | 0.010000 |  0.820000 |  0.805589 |
    | :large_run | :symbol   |   100000 | master           |  0.000000 | 0.000000 |  0.000000 |  0.004980 |
    | :large_run | :symbol   |   100000 | preserve_symbols |  0.070000 | 0.000000 |  0.070000 |  0.070618 |
    | :large_run | :symbol   |  1000000 | master           |  0.030000 | 0.000000 |  0.030000 |  0.033774 |
    | :large_run | :symbol   |  1000000 | preserve_symbols |  0.670000 | 0.010000 |  0.680000 |  0.671461 |
    | :large_run | :symbol   | 10000000 | master           |  0.890000 | 0.000000 |  0.890000 |  0.896243 |
    | :large_run | :symbol   | 10000000 | preserve_symbols |  9.960000 | 0.000000 |  9.960000 |  9.954431 |
    | :multi_run | :none     |   100000 | master           |  0.010000 | 0.000000 |  0.010000 |  0.007190 |
    | :multi_run | :none     |   100000 | preserve_symbols |  0.010000 | 0.000000 |  0.010000 |  0.007214 |
    | :multi_run | :none     |  1000000 | master           |  0.080000 | 0.000000 |  0.080000 |  0.078755 |
    | :multi_run | :none     |  1000000 | preserve_symbols |  0.080000 | 0.000000 |  0.080000 |  0.079481 |
    | :multi_run | :none     | 10000000 | master           |  2.040000 | 0.000000 |  2.040000 |  2.038135 |
    | :multi_run | :none     | 10000000 | preserve_symbols |  2.050000 | 0.000000 |  2.050000 |  2.043865 |
    | :multi_run | :symbol   |   100000 | master           |  0.010000 | 0.000000 |  0.010000 |  0.017638 |
    | :multi_run | :symbol   |   100000 | preserve_symbols |  0.080000 | 0.010000 |  0.090000 |  0.083361 |
    | :multi_run | :symbol   |  1000000 | master           |  0.110000 | 0.000000 |  0.110000 |  0.110694 |
    | :multi_run | :symbol   |  1000000 | preserve_symbols |  0.830000 | 0.000000 |  0.830000 |  0.829279 |
    | :multi_run | :symbol   | 10000000 | master           |  2.180000 | 0.010000 |  2.190000 |  2.186607 |
    | :multi_run | :symbol   | 10000000 | preserve_symbols | 11.130000 | 0.030000 | 11.160000 | 11.167616 |
    +------------+-----------+----------+------------------+-----------+----------+-----------+-----------+

To run this, check out the [preserve_symbols](https://github.com/christopheraue/msgpack-ruby/tree/preserve_symbols) branch and execute `bench/run_symbols.sh`.