### PR TITLE
fix SEGV that will happen with MRI 2.4.0 because of unification of Fixnum and Bignum into Integer

### DIFF
--- a/ext/msgpack/core_ext.c
+++ b/ext/msgpack/core_ext.c
@@ -65,6 +65,17 @@ static VALUE FalseClass_to_msgpack(int argc, VALUE* argv, VALUE self)
     return packer;
 }
 
+static VALUE Integer_to_msgpack(int argc, VALUE* argv, VALUE self)
+{
+    ENSURE_PACKER(argc, argv, packer, pk);
+    if (FIXNUM_P(self)) {
+        msgpack_packer_write_fixnum_value(pk, self);
+    } else {
+        msgpack_packer_write_bignum_value(pk, self);
+    }
+    return packer;
+}
+
 static VALUE Fixnum_to_msgpack(int argc, VALUE* argv, VALUE self)
 {
     ENSURE_PACKER(argc, argv, packer, pk);
@@ -132,8 +143,14 @@ void MessagePack_core_ext_module_init()
     rb_define_method(rb_cNilClass,   "to_msgpack", NilClass_to_msgpack, -1);
     rb_define_method(rb_cTrueClass,  "to_msgpack", TrueClass_to_msgpack, -1);
     rb_define_method(rb_cFalseClass, "to_msgpack", FalseClass_to_msgpack, -1);
-    rb_define_method(rb_cFixnum, "to_msgpack", Fixnum_to_msgpack, -1);
-    rb_define_method(rb_cBignum, "to_msgpack", Bignum_to_msgpack, -1);
+    if (rb_cFixnum == rb_cBignum) {
+        // MRI Ruby >= 2.4 unified Fixnum and Bignum into Integer since Feature #12005
+        // https://github.com/ruby/ruby/commit/f9727c12cc8fbc5f752f5983be1f14bb976e5a13
+        rb_define_method(rb_cFixnum, "to_msgpack", Integer_to_msgpack, -1);
+    } else {
+        rb_define_method(rb_cFixnum, "to_msgpack", Fixnum_to_msgpack, -1);
+        rb_define_method(rb_cBignum, "to_msgpack", Bignum_to_msgpack, -1);
+    }
     rb_define_method(rb_cFloat,  "to_msgpack", Float_to_msgpack, -1);
     rb_define_method(rb_cString, "to_msgpack", String_to_msgpack, -1);
     rb_define_method(rb_cArray,  "to_msgpack", Array_to_msgpack, -1);

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -325,6 +325,34 @@ describe MessagePack::Packer do
     end
   end
 
+  describe "fixnum and bignum" do
+    it "fixnum.to_msgpack" do
+      23.to_msgpack.should == "\x17"
+    end
+
+    it "fixnum.to_msgpack(packer)" do
+      23.to_msgpack(packer)
+      packer.to_s.should == "\x17"
+    end
+
+    it "bignum.to_msgpack" do
+      -4294967296.to_msgpack.should == "\xD3\xFF\xFF\xFF\xFF\x00\x00\x00\x00"
+    end
+
+    it "bignum.to_msgpack(packer)" do
+      -4294967296.to_msgpack(packer)
+      packer.to_s.should == "\xD3\xFF\xFF\xFF\xFF\x00\x00\x00\x00"
+    end
+
+    it "unpack(fixnum)" do
+      MessagePack.unpack("\x17").should == 23
+    end
+
+    it "unpack(bignum)" do
+      MessagePack.unpack("\xD3\xFF\xFF\xFF\xFF\x00\x00\x00\x00").should == -4294967296
+    end
+  end
+
   describe "ext formats" do
     [1, 2, 4, 8, 16].zip([0xd4, 0xd5, 0xd6, 0xd7, 0xd8]).each do |n,b|
       it "msgpack fixext #{n} format" do


### PR DESCRIPTION
MRI 2.4 will unify rb_cFixnum and rb_cBignum into rb_cInteger (rb_cFixnum == rb_cBignum). But underlaying implementation still require different function calls (FIXNUM_P / RBIGNUM_POSITIVE_P) depending on size of the integer. Thus msgpack-ruby needs to check difference using FIXNUM_P on runtime.
https://github.com/ruby/ruby/commit/f9727c12cc8fbc5f752f5983be1f14bb976e5a13