### PR TITLE
Fixed RDoc about to_msgpack that actually requires packer

### DIFF
--- a/doclib/msgpack/core_ext.rb
+++ b/doclib/msgpack/core_ext.rb
@@ -1,101 +1,101 @@
 
 class NilClass
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class TrueClass
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class FalseClass
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class Fixnum < Integer
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class Bignum < Integer
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class Float < Numeric
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class String
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class Array
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class Hash
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 
 class Symbol
   #
-  # Same as MessagePack.to_msgpack(self[, io]).
+  # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(io=nil)
+  def to_msgpack(packer=nil)
   end
 end
 


### PR DESCRIPTION
IO is still supported for backward compatibility but they actually use
packer. This is because Packer has internal buffer and using IO as the
interface will require Packer to flush the buffer to IO every time.