### PR TITLE
Serializing symbols using an ext type

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -91,6 +91,36 @@ or event-driven style which works well with EventMachine:
 
 See {API reference}[http://ruby.msgpack.org/MessagePack/Unpacker.html] for details.
 
+= Serializing and deserializing symbols
+
+By default, symbols are serialized as strings:
+
+    packed = :symbol.to_msgpack     # => "\xA6symbol"
+    MessagePack.unpack(packed)      # => "symbol"
+
+This can be customized by registering an extension type for them:
+
+    MessagePack::DefaultFactory.register_type(0x00, Symbol)
+
+    # symbols now survive round trips
+    packed = :symbol.to_msgpack     # => "\xc7\x06\x00symbol"
+    MessagePack.unpack(packed)      # => :symbol
+
+The extension type for symbols is configurable like any other extension type.
+For example, to customize how symbols are packed you can just redefine
+Symbol#to_msgpack_ext. Doing this gives you an option to prevent symbols from
+being serialized altogether by throwing an exception:
+
+    class Symbol
+        def to_msgpack_ext
+            raise "Serialization of symbols prohibited"
+        end
+    end
+
+    MessagePack::DefaultFactory.register_type(0x00, Symbol)
+
+    [1, :symbol, 'string'].to_msgpack  # => RuntimeError: Serialization of symbols prohibited
+
 = Extension Types
 
 Packer and Unpacker support {Extension types of MessagePack}[https://github.com/msgpack/msgpack/blob/master/spec.md#types-extension-type].

--- a/bench/pack_symbols.rb
+++ b/bench/pack_symbols.rb
@@ -1,0 +1,28 @@
+require 'viiite'
+require 'msgpack'
+
+data = :symbol
+
+Viiite.bench do |b|
+  b.variation_point :branch, `git rev-parse --abbrev-ref HEAD`
+
+  b.range_over([:symbol, :none], :reg_type) do |reg_type|
+    packer = MessagePack::Packer.new
+    packer.register_type(0x00, Symbol, :to_msgpack_ext) if reg_type == :symbol
+
+    b.range_over([100_000, 1_000_000, 10_000_000], :count) do |count|
+      packer.clear
+      b.report(:multi_run) do
+        count.times do
+          packer.pack(data)
+        end
+      end
+
+      packer.clear
+      items_data = [].fill(data, 0, count)
+      b.report(:large_run) do
+        packer.pack(items_data)
+      end
+    end
+  end
+end

--- a/bench/run_symbols.sh
+++ b/bench/run_symbols.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# so master and this branch have the benchmark file in any case
+cp bench/pack_symbols.rb bench/pack_symbols_tmp.rb
+
+benchmark=""
+current_branch=`git rev-parse --abbrev-ref HEAD`
+
+for branch in master $current_branch; do
+    echo "Testing branch $branch"
+    git checkout $branch
+
+    echo "Installing gem..."
+    rake install
+
+    echo "Running benchmark..."
+    if [ "$benchmark" ]; then
+        benchmark+=$'\n'
+    fi
+    benchmark+=$(viiite run bench/pack_symbols_tmp.rb)
+    echo
+done
+
+rm bench/pack_symbols_tmp.rb
+
+echo "$benchmark" | viiite report --regroup bench,reg_type,count,branch

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -38,15 +38,18 @@ public class Encoder {
   private final boolean compatibilityMode;
   private final ExtensionRegistry registry;
 
+  public boolean hasSymbolExtType;
+
   private ByteBuffer buffer;
 
-  public Encoder(Ruby runtime, boolean compatibilityMode, ExtensionRegistry registry) {
+  public Encoder(Ruby runtime, boolean compatibilityMode, ExtensionRegistry registry, boolean hasSymbolExtType) {
     this.runtime = runtime;
     this.buffer = ByteBuffer.allocate(CACHE_LINE_SIZE - ARRAY_HEADER_SIZE);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
     this.utf8Encoding = UTF8Encoding.INSTANCE;
     this.compatibilityMode = compatibilityMode;
     this.registry = registry;
+    this.hasSymbolExtType = hasSymbolExtType;
   }
 
   public boolean isCompatibilityMode() {
@@ -112,7 +115,11 @@ public class Encoder {
     } else if (object instanceof RubyString) {
       appendString((RubyString) object);
     } else if (object instanceof RubySymbol) {
-      appendString(((RubySymbol) object).asString());
+      if (hasSymbolExtType) {
+        appendOther(object, destination);
+      } else {
+        appendString(((RubySymbol) object).asString());
+      }
     } else if (object instanceof RubyArray) {
       appendArray((RubyArray) object);
     } else if (object instanceof RubyHash) {

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -24,11 +24,13 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 public class Factory extends RubyObject {
   private final Ruby runtime;
   private final ExtensionRegistry extensionRegistry;
+  private boolean hasSymbolExtType;
 
   public Factory(Ruby runtime, RubyClass type) {
     super(runtime, type);
     this.runtime = runtime;
     this.extensionRegistry = new ExtensionRegistry();
+    this.hasSymbolExtType = false;
   }
 
   static class FactoryAllocator implements ObjectAllocator {
@@ -48,7 +50,7 @@ public class Factory extends RubyObject {
 
   @JRubyMethod(name = "packer", optional = 1)
   public Packer packer(ThreadContext ctx, IRubyObject[] args) {
-    return Packer.newPacker(ctx, extensionRegistry(), args);
+    return Packer.newPacker(ctx, extensionRegistry(), hasSymbolExtType, args);
   }
 
   @JRubyMethod(name = "unpacker", optional = 1)
@@ -111,6 +113,10 @@ public class Factory extends RubyObject {
     }
 
     extensionRegistry.put(extClass, (int) typeId, packerProc, packerArg, unpackerProc, unpackerArg);
+
+    if (extClass == runtime.getSymbol()) {
+      hasSymbolExtType = true;
+    }
 
     return runtime.getNil();
   }

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -25,15 +25,17 @@ public class Packer extends RubyObject {
   public ExtensionRegistry registry;
   private Buffer buffer;
   private Encoder encoder;
+  private boolean hasSymbolExtType;
 
-  public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry) {
+  public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry, boolean hasSymbolExtType) {
     super(runtime, type);
     this.registry = registry;
+    this.hasSymbolExtType = hasSymbolExtType;
   }
 
   static class PackerAllocator implements ObjectAllocator {
     public IRubyObject allocate(Ruby runtime, RubyClass type) {
-      return new Packer(runtime, type, null);
+      return new Packer(runtime, type, null, false);
     }
   }
 
@@ -56,8 +58,8 @@ public class Packer extends RubyObject {
     return this;
   }
 
-  public static Packer newPacker(ThreadContext ctx, ExtensionRegistry extRegistry, IRubyObject[] args) {
-    Packer packer = new Packer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Packer"), extRegistry);
+  public static Packer newPacker(ThreadContext ctx, ExtensionRegistry extRegistry, boolean hasSymbolExtType, IRubyObject[] args) {
+    Packer packer = new Packer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Packer"), extRegistry, hasSymbolExtType);
     packer.initialize(ctx, args);
     return packer;
   }
@@ -104,6 +106,11 @@ public class Packer extends RubyObject {
     RubyClass extClass = (RubyClass) klass;
 
     registry.put(extClass, (int) typeId, proc, arg, null, null);
+
+    if (extClass == runtime.getSymbol()) {
+      encoder.hasSymbolExtType = true;
+    }
+
     return runtime.getNil();
   }
 

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -45,10 +45,14 @@ public class Packer extends RubyObject {
       IRubyObject mode = options.fastARef(ctx.getRuntime().newSymbol("compatibility_mode"));
       compatibilityMode = (mode != null) && mode.isTrue();
     }
-    this.encoder = new Encoder(ctx.getRuntime(), compatibilityMode, registry);
+    if (registry == null) {
+        // registry is null when allocate -> initialize
+        // registry is already initialized (and somthing might be registered) when newPacker from Factory
+        this.registry = new ExtensionRegistry();
+    }
+    this.encoder = new Encoder(ctx.getRuntime(), compatibilityMode, registry, hasSymbolExtType);
     this.buffer = new Buffer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Buffer"));
     this.buffer.initialize(ctx, args);
-    this.registry = new ExtensionRegistry();
     return this;
   }
 

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -32,6 +32,7 @@ typedef struct msgpack_factory_t msgpack_factory_t;
 struct msgpack_factory_t {
     msgpack_packer_ext_registry_t pkrg;
     msgpack_unpacker_ext_registry_t ukrg;
+    bool has_symbol_ext_type;
 };
 
 #define FACTORY(from, name) \
@@ -72,6 +73,8 @@ static VALUE Factory_initialize(int argc, VALUE* argv, VALUE self)
 {
     FACTORY(self, fc);
 
+    fc->has_symbol_ext_type = false;
+
     switch (argc) {
     case 0:
         break;
@@ -95,6 +98,7 @@ VALUE MessagePack_Factory_packer(int argc, VALUE* argv, VALUE self)
 
     msgpack_packer_ext_registry_destroy(&pk->ext_registry);
     msgpack_packer_ext_registry_dup(&fc->pkrg, &pk->ext_registry);
+    pk->has_symbol_ext_type = fc->has_symbol_ext_type;
 
     return packer;
 }
@@ -187,6 +191,10 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
     }
 
     msgpack_packer_ext_registry_put(&fc->pkrg, ext_class, ext_type, packer_proc, packer_arg);
+
+    if (ext_class == rb_cSymbol) {
+        fc->has_symbol_ext_type = true;
+    }
 
     msgpack_unpacker_ext_registry_put(&fc->ukrg, ext_class, ext_type, unpacker_proc, unpacker_arg);
 

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -121,7 +121,7 @@ void msgpack_packer_write_hash_value(msgpack_packer_t* pk, VALUE v)
 #endif
 }
 
-static void _msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
+void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
 {
     int ext_type;
     VALUE proc = msgpack_packer_ext_registry_lookup(&pk->ext_registry,
@@ -169,7 +169,7 @@ void msgpack_packer_write_value(msgpack_packer_t* pk, VALUE v)
         msgpack_packer_write_float_value(pk, v);
         break;
     default:
-        _msgpack_packer_write_other_value(pk, v);
+        msgpack_packer_write_other_value(pk, v);
     }
 }
 

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -32,6 +32,7 @@ struct msgpack_packer_t {
     msgpack_buffer_t buffer;
 
     bool compatibility_mode;
+    bool has_symbol_ext_type;
 
     ID to_msgpack_method;
     VALUE to_msgpack_arg;
@@ -448,7 +449,7 @@ static inline void msgpack_packer_write_string_value(msgpack_packer_t* pk, VALUE
 #endif
 }
 
-static inline void msgpack_packer_write_symbol_value(msgpack_packer_t* pk, VALUE v)
+static inline void msgpack_packer_write_symbol_string_value(msgpack_packer_t* pk, VALUE v)
 {
 #ifdef HAVE_RB_SYM2STR
     /* rb_sym2str is added since MRI 2.2.0 */
@@ -460,6 +461,17 @@ static inline void msgpack_packer_write_symbol_value(msgpack_packer_t* pk, VALUE
     }
     msgpack_packer_write_string_value(pk, str);
 #endif
+}
+
+void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v);
+
+static inline void msgpack_packer_write_symbol_value(msgpack_packer_t* pk, VALUE v)
+{
+    if (pk->has_symbol_ext_type) {
+        msgpack_packer_write_other_value(pk, v);
+    } else {
+        msgpack_packer_write_symbol_string_value(pk, v);
+    }
 }
 
 static inline void msgpack_packer_write_fixnum_value(msgpack_packer_t* pk, VALUE v)

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -286,6 +286,10 @@ static VALUE Packer_register_type(int argc, VALUE* argv, VALUE self)
 
     msgpack_packer_ext_registry_put(&pk->ext_registry, ext_class, ext_type, proc, arg);
 
+    if (ext_class == rb_cSymbol) {
+        pk->has_symbol_ext_type = true;
+    }
+
     return Qnil;
 }
 

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -15,3 +15,4 @@ end
 require "msgpack/packer"
 require "msgpack/unpacker"
 require "msgpack/factory"
+require "msgpack/symbol"

--- a/lib/msgpack/symbol.rb
+++ b/lib/msgpack/symbol.rb
@@ -1,0 +1,9 @@
+class Symbol
+  def to_msgpack_ext
+    [to_s].pack('A*')
+  end
+
+  def self.from_msgpack_ext(data)
+    data.unpack('A*').first.to_sym
+  end
+end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -239,14 +239,14 @@ describe MessagePack::Factory do
           class Symbol
             alias_method :to_msgpack_ext_orig, :to_msgpack_ext
             def to_msgpack_ext
-              [object_id].pack('l')
+              self.to_s.codepoints.pack('n*')
             end
           end
 
           class << Symbol
             alias_method :from_msgpack_ext_orig, :from_msgpack_ext
             def from_msgpack_ext(data)
-              ObjectSpace._id2ref data.unpack('l').first
+              data.unpack('n*').map(&:chr).join.to_sym
             end
           end
         end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -239,7 +239,7 @@ describe MessagePack::Factory do
           class Symbol
             alias_method :to_msgpack_ext_orig, :to_msgpack_ext
             def to_msgpack_ext
-              self.to_s.codepoints.pack('n*')
+              self.to_s.codepoints.to_a.pack('n*')
             end
           end
 

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -323,6 +323,14 @@ describe MessagePack::Packer do
       expect(two[:class]).to eq(ValueTwo)
       expect(two[:packer]).to eq(:to_msgpack_ext)
     end
+
+    context 'when registering a type for symbols' do
+      before { packer.register_type(0x00, ::Symbol, :to_msgpack_ext) }
+
+      it 'packs symbols in an ext type' do
+        expect(packer.pack(:symbol).to_s).to eq "\xc7\x06\x00symbol"
+      end
+    end
   end
 
   describe "fixnum and bignum" do


### PR DESCRIPTION
This change follows #114, to add JRuby implementation.

I added two more fixes which is required to pass specs.
* Wrong spec to use ObjSpace to serialize/deserialize symbols: it's unsafe and unportable
* Bugfix to initialize ExtensionRegistry before setting it to Encoder: it's found by spec newly added by #114 
