### PR TITLE
Allow JRuby Unpacker to accept both a stream and options

### DIFF
--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -51,7 +51,7 @@ public class Unpacker extends RubyObject {
     }
   }
 
-  @JRubyMethod(name = "initialize", optional = 1, visibility = PRIVATE)
+  @JRubyMethod(name = "initialize", optional = 2, visibility = PRIVATE)
   public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
     symbolizeKeys = false;
     allowUnknownExt = false;
@@ -66,7 +66,8 @@ public class Unpacker extends RubyObject {
         if (au != null) {
           allowUnknownExt = au.isTrue();
         }
-      } else if (!(args[0] instanceof RubyHash)) {
+      }
+      if (!(args[0] instanceof RubyHash)) {
         setStream(ctx, args[0]);
       }
     }

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -564,6 +564,17 @@ describe MessagePack::Unpacker do
         objects.should == [{'foo' => 'bar'}, {'hello' => {'world' => [1, 2, 3]}}, {'x' => 'y'}]
       end
     end
+
+    context 'with a stream and symbolize_keys passed to the constructor' do
+      it 'yields each object in the stream, with symbolized keys' do
+        objects = []
+        unpacker = described_class.new(StringIO.new(buffer1 + buffer2 + buffer3), symbolize_keys: true)
+        unpacker.each do |obj|
+          objects << obj
+        end
+        objects.should == [{:foo => 'bar'}, {:hello => {:world => [1, 2, 3]}}, {:x => 'y'}]
+      end
+    end
   end
 
   describe '#feed_each' do


### PR DESCRIPTION
I found an inconsistency between the MRI and JRuby implementations:

```ruby
MessagePack::Unpacker.new(stream, symbolize_keys: true)
```

This code runs as expected on MRI/C implementation, but on JRuby it fails with an Unexpected number of arguments (2 for 1).

I've added a test case, and a fix.

(relevant failed test run on our gem https://circleci.com/gh/brightbytes/msgpack_rpc_client/11)