### PR TITLE
Enabled extension types for modules

### DIFF
--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 
 import org.jruby.Ruby;
 import org.jruby.RubyObject;
+import org.jruby.RubyModule;
 import org.jruby.RubyNil;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyNumeric;
@@ -375,7 +376,15 @@ public class Encoder {
 
   private void appendOther(IRubyObject object, IRubyObject destination) {
     if (registry != null) {
-      IRubyObject[] pair = registry.lookupPackerByModule(object.getType());
+      RubyModule lookupClass;
+
+      if (object.getType() == runtime.getSymbol()) {
+        lookupClass = object.getType();
+      } else {
+        lookupClass = object.getSingletonClass();
+      }
+
+      IRubyObject[] pair = registry.lookupPackerByModule(lookupClass);
       if (pair != null) {
         RubyString bytes = pair[0].callMethod(runtime.getCurrentContext(), "call", object).asString();
         int type = (int) ((RubyFixnum) pair[1]).getLongValue();

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -375,7 +375,7 @@ public class Encoder {
 
   private void appendOther(IRubyObject object, IRubyObject destination) {
     if (registry != null) {
-      IRubyObject[] pair = registry.lookupPackerByClass(object.getType());
+      IRubyObject[] pair = registry.lookupPackerByModule(object.getType());
       if (pair != null) {
         RubyString bytes = pair[0].callMethod(runtime.getCurrentContext(), "call", object).asString();
         int type = (int) ((RubyFixnum) pair[1]).getLongValue();

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -2,6 +2,7 @@ package org.msgpack.jruby;
 
 
 import org.jruby.Ruby;
+import org.jruby.RubyModule;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.RubyArray;
@@ -70,7 +71,7 @@ public class Factory extends RubyObject {
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args) {
     Ruby runtime = ctx.getRuntime();
     IRubyObject type = args[0];
-    IRubyObject klass = args[1];
+    IRubyObject mod = args[1];
 
     IRubyObject packerArg;
     IRubyObject unpackerArg;
@@ -94,10 +95,10 @@ public class Factory extends RubyObject {
       throw runtime.newRangeError(String.format("integer %d too big to convert to `signed char'", typeId));
     }
 
-    if (!(klass instanceof RubyClass)) {
-      throw runtime.newArgumentError(String.format("expected Class but found %s.", klass.getType().getName()));
+    if (!(mod instanceof RubyModule)) {
+      throw runtime.newArgumentError(String.format("expected Module/Class but found %s.", mod.getType().getName()));
     }
-    RubyClass extClass = (RubyClass) klass;
+    RubyModule extModule = (RubyModule) mod;
 
     IRubyObject packerProc = runtime.getNil();
     IRubyObject unpackerProc = runtime.getNil();
@@ -106,15 +107,15 @@ public class Factory extends RubyObject {
     }
     if (unpackerArg != null) {
       if (unpackerArg instanceof RubyString || unpackerArg instanceof RubySymbol) {
-        unpackerProc = extClass.method(unpackerArg.callMethod(ctx, "to_sym"));
+        unpackerProc = extModule.method(unpackerArg.callMethod(ctx, "to_sym"));
       } else {
         unpackerProc = unpackerArg.callMethod(ctx, "method", runtime.newSymbol("call"));
       }
     }
 
-    extensionRegistry.put(extClass, (int) typeId, packerProc, packerArg, unpackerProc, unpackerArg);
+    extensionRegistry.put(extModule, (int) typeId, packerProc, packerArg, unpackerProc, unpackerArg);
 
-    if (extClass == runtime.getSymbol()) {
+    if (extModule == runtime.getSymbol()) {
       hasSymbolExtType = true;
     }
 

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -2,6 +2,7 @@ package org.msgpack.jruby;
 
 
 import org.jruby.Ruby;
+import org.jruby.RubyModule;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.RubyArray;
@@ -78,7 +79,7 @@ public class Packer extends RubyObject {
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args, final Block block) {
     Ruby runtime = ctx.getRuntime();
     IRubyObject type = args[0];
-    IRubyObject klass = args[1];
+    IRubyObject mod = args[1];
 
     IRubyObject arg;
     IRubyObject proc;
@@ -100,14 +101,14 @@ public class Packer extends RubyObject {
       throw runtime.newRangeError(String.format("integer %d too big to convert to `signed char'", typeId));
     }
 
-    if (!(klass instanceof RubyClass)) {
-      throw runtime.newArgumentError(String.format("expected Class but found %s.", klass.getType().getName()));
+    if (!(mod instanceof RubyModule)) {
+      throw runtime.newArgumentError(String.format("expected Module/Class but found %s.", mod.getType().getName()));
     }
-    RubyClass extClass = (RubyClass) klass;
+    RubyModule extModule = (RubyModule) mod;
 
-    registry.put(extClass, (int) typeId, proc, arg, null, null);
+    registry.put(extModule, (int) typeId, proc, arg, null, null);
 
-    if (extClass == runtime.getSymbol()) {
+    if (extModule == runtime.getSymbol()) {
       encoder.hasSymbolExtType = true;
     }
 

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -3,6 +3,7 @@ package org.msgpack.jruby;
 import java.util.Arrays;
 
 import org.jruby.Ruby;
+import org.jruby.RubyModule;
 import org.jruby.RubyClass;
 import org.jruby.RubyString;
 import org.jruby.RubyObject;
@@ -100,7 +101,7 @@ public class Unpacker extends RubyObject {
     Ruby runtime = ctx.getRuntime();
     IRubyObject type = args[0];
 
-    RubyClass extClass;
+    RubyModule extModule;
     IRubyObject arg;
     IRubyObject proc;
     if (args.length == 1) {
@@ -111,11 +112,11 @@ public class Unpacker extends RubyObject {
       if (proc == null)
         System.err.println("proc from Block is null");
       arg = proc;
-      extClass = null;
+      extModule = null;
     } else if (args.length == 3) {
-      extClass = (RubyClass) args[1];
+      extModule = (RubyModule) args[1];
       arg = args[2];
-      proc = extClass.method(arg);
+      proc = extModule.method(arg);
     } else {
       throw runtime.newArgumentError(String.format("wrong number of arguments (%d for 1 or 3)", 2 + args.length));
     }
@@ -125,7 +126,7 @@ public class Unpacker extends RubyObject {
       throw runtime.newRangeError(String.format("integer %d too big to convert to `signed char'", typeId));
     }
 
-    registry.put(extClass, (int) typeId, null, null, proc, arg);
+    registry.put(extModule, (int) typeId, null, null, proc, arg);
     return runtime.getNil();
   }
 

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -141,7 +141,7 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
     FACTORY(self, fc);
 
     int ext_type;
-    VALUE ext_class;
+    VALUE ext_module;
     VALUE options;
     VALUE packer_arg, unpacker_arg;
     VALUE packer_proc, unpacker_proc;
@@ -170,9 +170,9 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
         rb_raise(rb_eRangeError, "integer %d too big to convert to `signed char'", ext_type);
     }
 
-    ext_class = argv[1];
-    if(rb_type(ext_class) != T_CLASS) {
-        rb_raise(rb_eArgError, "expected Class but found %s.", rb_obj_classname(ext_class));
+    ext_module = argv[1];
+    if(rb_type(ext_module) != T_MODULE && rb_type(ext_module) != T_CLASS) {
+        rb_raise(rb_eArgError, "expected Module/Class but found %s.", rb_obj_classname(ext_module));
     }
 
     packer_proc = Qnil;
@@ -184,19 +184,19 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
 
     if(unpacker_arg != Qnil) {
         if(rb_type(unpacker_arg) == T_SYMBOL || rb_type(unpacker_arg) == T_STRING) {
-            unpacker_proc = rb_obj_method(ext_class, unpacker_arg);
+            unpacker_proc = rb_obj_method(ext_module, unpacker_arg);
         } else {
             unpacker_proc = rb_funcall(unpacker_arg, rb_intern("method"), 1, ID2SYM(rb_intern("call")));
         }
     }
 
-    msgpack_packer_ext_registry_put(&fc->pkrg, ext_class, ext_type, packer_proc, packer_arg);
+    msgpack_packer_ext_registry_put(&fc->pkrg, ext_module, ext_type, packer_proc, packer_arg);
 
-    if (ext_class == rb_cSymbol) {
+    if (ext_module == rb_cSymbol) {
         fc->has_symbol_ext_type = true;
     }
 
-    msgpack_unpacker_ext_registry_put(&fc->ukrg, ext_class, ext_type, unpacker_proc, unpacker_arg);
+    msgpack_unpacker_ext_registry_put(&fc->ukrg, ext_module, ext_type, unpacker_proc, unpacker_arg);
 
     return Qnil;
 }

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -124,8 +124,18 @@ void msgpack_packer_write_hash_value(msgpack_packer_t* pk, VALUE v)
 void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
 {
     int ext_type;
-    VALUE proc = msgpack_packer_ext_registry_lookup(&pk->ext_registry,
-            rb_obj_class(v), &ext_type);
+
+    VALUE lookup_class;
+
+    if (SYMBOL_P(v)) { /* Symbols have no singleton class */
+      lookup_class = rb_obj_class(v);
+    } else {
+      lookup_class = rb_singleton_class(v);
+    }
+
+    VALUE proc = msgpack_packer_ext_registry_lookup(&pk->ext_registry, lookup_class,
+      &ext_type);
+
     if(proc != Qnil) {
         VALUE payload = rb_funcall(proc, s_call, 1, v);
         StringValue(payload);

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -127,7 +127,16 @@ void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
 
     VALUE lookup_class;
 
-    if (SYMBOL_P(v)) { /* Symbols have no singleton class */
+    /*
+     * Objects of type Integer (Fixnum, Bignum), Float, Symbol and frozen
+     * String have no singleton class and raise a TypeError when trying to get
+     * it. See implementation of #singleton_class in ruby's source code:
+     * VALUE rb_singleton_class(VALUE obj);
+     *
+     * Since all but symbols are already filtered out when reaching this code
+     * only symbols are checked here.
+     */
+    if (SYMBOL_P(v)) {
       lookup_class = rb_obj_class(v);
     } else {
       lookup_class = rb_singleton_class(v);

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -249,7 +249,7 @@ static VALUE Packer_register_type(int argc, VALUE* argv, VALUE self)
     PACKER(self, pk);
 
     int ext_type;
-    VALUE ext_class;
+    VALUE ext_module;
     VALUE proc;
     VALUE arg;
 
@@ -279,14 +279,14 @@ static VALUE Packer_register_type(int argc, VALUE* argv, VALUE self)
         rb_raise(rb_eRangeError, "integer %d too big to convert to `signed char'", ext_type);
     }
 
-    ext_class = argv[1];
-    if(rb_type(ext_class) != T_CLASS) {
-        rb_raise(rb_eArgError, "expected Class but found %s.", rb_obj_classname(ext_class));
+    ext_module = argv[1];
+    if(rb_type(ext_module) != T_MODULE && rb_type(ext_module) != T_CLASS) {
+        rb_raise(rb_eArgError, "expected Module/Class but found %s.", rb_obj_classname(ext_module));
     }
 
-    msgpack_packer_ext_registry_put(&pk->ext_registry, ext_class, ext_type, proc, arg);
+    msgpack_packer_ext_registry_put(&pk->ext_registry, ext_module, ext_type, proc, arg);
 
-    if (ext_class == rb_cSymbol) {
+    if (ext_module == rb_cSymbol) {
         pk->has_symbol_ext_type = true;
     }
 

--- a/ext/msgpack/packer_ext_registry.c
+++ b/ext/msgpack/packer_ext_registry.c
@@ -64,7 +64,7 @@ __rb_hash_clear_clear_i(key, value, dummy)
 #endif
 
 VALUE msgpack_packer_ext_registry_put(msgpack_packer_ext_registry_t* pkrg,
-        VALUE ext_class, int ext_type, VALUE proc, VALUE arg)
+        VALUE ext_module, int ext_type, VALUE proc, VALUE arg)
 {
     VALUE e = rb_ary_new3(3, INT2FIX(ext_type), proc, arg);
     /* clear lookup cache not to miss added type */
@@ -75,5 +75,5 @@ VALUE msgpack_packer_ext_registry_put(msgpack_packer_ext_registry_t* pkrg,
         rb_hash_foreach(pkrg->cache, __rb_hash_clear_clear_i, 0);
     }
 #endif
-    return rb_hash_aset(pkrg->hash, ext_class, e);
+    return rb_hash_aset(pkrg->hash, ext_module, e);
 }

--- a/ext/msgpack/packer_ext_registry.h
+++ b/ext/msgpack/packer_ext_registry.h
@@ -44,7 +44,7 @@ void msgpack_packer_ext_registry_dup(msgpack_packer_ext_registry_t* src,
         msgpack_packer_ext_registry_t* dst);
 
 VALUE msgpack_packer_ext_registry_put(msgpack_packer_ext_registry_t* pkrg,
-        VALUE ext_class, int ext_type, VALUE proc, VALUE arg);
+        VALUE ext_module, int ext_type, VALUE proc, VALUE arg);
 
 static int msgpack_packer_ext_find_superclass(VALUE key, VALUE value, VALUE arg)
 {
@@ -61,32 +61,32 @@ static int msgpack_packer_ext_find_superclass(VALUE key, VALUE value, VALUE arg)
 
 
 static inline VALUE msgpack_packer_ext_registry_lookup(msgpack_packer_ext_registry_t* pkrg,
-        VALUE ext_class, int* ext_type_result)
+        VALUE ext_module, int* ext_type_result)
 {
-    VALUE type = rb_hash_lookup(pkrg->hash, ext_class);
+    VALUE type = rb_hash_lookup(pkrg->hash, ext_module);
     if(type != Qnil) {
         *ext_type_result = FIX2INT(rb_ary_entry(type, 0));
         return rb_ary_entry(type, 1);
     }
 
-    VALUE type_inht = rb_hash_lookup(pkrg->cache, ext_class);
+    VALUE type_inht = rb_hash_lookup(pkrg->cache, ext_module);
     if(type_inht != Qnil) {
         *ext_type_result = FIX2INT(rb_ary_entry(type_inht, 0));
         return rb_ary_entry(type_inht, 1);
     }
 
     /*
-     * check all keys whether it is super class of ext_class, or not
+     * check all keys whether it is an ancestor of ext_module, or not
      */
     VALUE args[2];
-    args[0] = ext_class;
+    args[0] = ext_module;
     args[1] = Qnil;
     rb_hash_foreach(pkrg->hash, msgpack_packer_ext_find_superclass, (VALUE) args);
 
     VALUE superclass = args[1];
     if(superclass != Qnil) {
         VALUE superclass_type = rb_hash_lookup(pkrg->hash, superclass);
-        rb_hash_aset(pkrg->cache, ext_class, superclass_type);
+        rb_hash_aset(pkrg->cache, ext_module, superclass_type);
         *ext_type_result = FIX2INT(rb_ary_entry(superclass_type, 0));
         return rb_ary_entry(superclass_type, 1);
     }

--- a/ext/msgpack/packer_ext_registry.h
+++ b/ext/msgpack/packer_ext_registry.h
@@ -61,32 +61,32 @@ static int msgpack_packer_ext_find_superclass(VALUE key, VALUE value, VALUE arg)
 
 
 static inline VALUE msgpack_packer_ext_registry_lookup(msgpack_packer_ext_registry_t* pkrg,
-        VALUE ext_module, int* ext_type_result)
+        VALUE lookup_class, int* ext_type_result)
 {
-    VALUE type = rb_hash_lookup(pkrg->hash, ext_module);
+    VALUE type = rb_hash_lookup(pkrg->hash, lookup_class);
     if(type != Qnil) {
         *ext_type_result = FIX2INT(rb_ary_entry(type, 0));
         return rb_ary_entry(type, 1);
     }
 
-    VALUE type_inht = rb_hash_lookup(pkrg->cache, ext_module);
+    VALUE type_inht = rb_hash_lookup(pkrg->cache, lookup_class);
     if(type_inht != Qnil) {
         *ext_type_result = FIX2INT(rb_ary_entry(type_inht, 0));
         return rb_ary_entry(type_inht, 1);
     }
 
     /*
-     * check all keys whether it is an ancestor of ext_module, or not
+     * check all keys whether it is an ancestor of lookup_class, or not
      */
     VALUE args[2];
-    args[0] = ext_module;
+    args[0] = lookup_class;
     args[1] = Qnil;
     rb_hash_foreach(pkrg->hash, msgpack_packer_ext_find_superclass, (VALUE) args);
 
     VALUE superclass = args[1];
     if(superclass != Qnil) {
         VALUE superclass_type = rb_hash_lookup(pkrg->hash, superclass);
-        rb_hash_aset(pkrg->cache, ext_module, superclass_type);
+        rb_hash_aset(pkrg->cache, lookup_class, superclass_type);
         *ext_type_result = FIX2INT(rb_ary_entry(superclass_type, 0));
         return rb_ary_entry(superclass_type, 1);
     }

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -348,7 +348,7 @@ static VALUE Unpacker_register_type(int argc, VALUE* argv, VALUE self)
     int ext_type;
     VALUE proc;
     VALUE arg;
-    VALUE ext_class;
+    VALUE ext_module;
 
     switch (argc) {
     case 1:
@@ -361,13 +361,13 @@ static VALUE Unpacker_register_type(int argc, VALUE* argv, VALUE self)
         proc = rb_block_proc();
 #endif
         arg = proc;
-        ext_class = Qnil;
+        ext_module = Qnil;
         break;
     case 3:
         /* register_type(0x7f, Time, :from_msgpack_ext) */
-        ext_class = argv[1];
+        ext_module = argv[1];
         arg = argv[2];
-        proc = rb_obj_method(ext_class, arg);
+        proc = rb_obj_method(ext_module, arg);
         break;
     default:
         rb_raise(rb_eArgError, "wrong number of arguments (%d for 1 or 3)", argc);
@@ -378,7 +378,7 @@ static VALUE Unpacker_register_type(int argc, VALUE* argv, VALUE self)
         rb_raise(rb_eRangeError, "integer %d too big to convert to `signed char'", ext_type);
     }
 
-    msgpack_unpacker_ext_registry_put(&uk->ext_registry, ext_class, ext_type, proc, arg);
+    msgpack_unpacker_ext_registry_put(&uk->ext_registry, ext_module, ext_type, proc, arg);
 
     return Qnil;
 }

--- a/ext/msgpack/unpacker_ext_registry.c
+++ b/ext/msgpack/unpacker_ext_registry.c
@@ -53,9 +53,9 @@ void msgpack_unpacker_ext_registry_dup(msgpack_unpacker_ext_registry_t* src,
 }
 
 VALUE msgpack_unpacker_ext_registry_put(msgpack_unpacker_ext_registry_t* ukrg,
-        VALUE ext_class, int ext_type, VALUE proc, VALUE arg)
+        VALUE ext_module, int ext_type, VALUE proc, VALUE arg)
 {
-    VALUE e = rb_ary_new3(3, ext_class, proc, arg);
+    VALUE e = rb_ary_new3(3, ext_module, proc, arg);
     VALUE before = ukrg->array[ext_type + 128];
     ukrg->array[ext_type + 128] = e;
     return before;

--- a/ext/msgpack/unpacker_ext_registry.h
+++ b/ext/msgpack/unpacker_ext_registry.h
@@ -44,7 +44,7 @@ void msgpack_unpacker_ext_registry_dup(msgpack_unpacker_ext_registry_t* src,
         msgpack_unpacker_ext_registry_t* dst);
 
 VALUE msgpack_unpacker_ext_registry_put(msgpack_unpacker_ext_registry_t* ukrg,
-        VALUE ext_class, int ext_type, VALUE proc, VALUE arg);
+        VALUE ext_module, int ext_type, VALUE proc, VALUE arg);
 
 static inline VALUE msgpack_unpacker_ext_registry_lookup(msgpack_unpacker_ext_registry_t* ukrg,
         int ext_type)

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -225,10 +225,16 @@ describe MessagePack::Factory do
       let(:factory) { described_class.new }
       before { factory.register_type(0x01, Mod) }
 
-      describe "packing an object having the module as its ancestor" do
+      describe "packing an object whose class included the module" do
         subject { factory.packer.pack(value).to_s }
         before { stub_const('Value', Class.new{ include Mod }) }
         let(:value) { Value.new }
+        it { is_expected.to eq "\xC7\x0F\x01value_msgpacked" }
+      end
+
+      describe "packing an object which has been extended by the module" do
+        subject { factory.packer.pack(object).to_s }
+        let(:object) { Object.new.extend Mod }
         it { is_expected.to eq "\xC7\x0F\x01value_msgpacked" }
       end
 

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -208,6 +208,35 @@ describe MessagePack::Factory do
       my.a.should == 1
       my.b.should == 2
     end
+
+    describe "registering an ext type for a module" do
+      before do
+        mod = Module.new do
+          def self.from_msgpack_ext(data)
+            "unpacked #{data}"
+          end
+
+          def to_msgpack_ext
+            'value_msgpacked'
+          end
+        end
+        stub_const('Mod', mod)
+      end
+      let(:factory) { described_class.new }
+      before { factory.register_type(0x01, Mod) }
+
+      describe "packing an object having the module as its ancestor" do
+        subject { factory.packer.pack(value).to_s }
+        before { stub_const('Value', Class.new{ include Mod }) }
+        let(:value) { Value.new }
+        it { is_expected.to eq "\xC7\x0F\x01value_msgpacked" }
+      end
+
+      describe "unpacking with the module" do
+        subject { factory.unpacker.feed("\xC7\x06\x01module").unpack }
+        it { is_expected.to eq "unpacked module" }
+      end
+    end
   end
 
   describe 'the special treatment of symbols with ext type' do

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -350,6 +350,24 @@ describe MessagePack::Packer do
       end
     end
 
+    context 'when it has no ext type but an included module has' do
+      subject { packer.pack(Value.new).to_s }
+
+      before do
+        mod = Module.new do
+          def to_msgpack_ext
+            'value_msgpacked'
+          end
+        end
+        stub_const('Mod', mod)
+      end
+      before { packer.register_type(0x01, Mod, :to_msgpack_ext) }
+
+      before { stub_const('Value', Class.new{ include Mod }) }
+
+      it { is_expected.to eq "\xC7\x0F\x01value_msgpacked" }
+    end
+
     context 'when registering a type for symbols' do
       before { packer.register_type(0x00, ::Symbol, :to_msgpack_ext) }
 

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -368,6 +368,24 @@ describe MessagePack::Packer do
       it { is_expected.to eq "\xC7\x0F\x01value_msgpacked" }
     end
 
+    context 'when it has no ext type but it was extended by a module which has one' do
+      subject { packer.pack(object).to_s }
+      let(:object) { Object.new.extend Mod }
+
+      before do
+        mod = Module.new do
+          def to_msgpack_ext
+            'value_msgpacked'
+          end
+        end
+        stub_const('Mod', mod)
+      end
+      before { packer.register_type(0x01, Mod, :to_msgpack_ext) }
+
+
+      it { is_expected.to eq "\xC7\x0F\x01value_msgpacked" }
+    end
+
     context 'when registering a type for symbols' do
       before { packer.register_type(0x00, ::Symbol, :to_msgpack_ext) }
 

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -477,6 +477,24 @@ describe MessagePack::Unpacker do
       expect(two[:class]).to be_nil
       expect(two[:unpacker]).to be_instance_of(Proc)
     end
+
+    describe "registering an ext type for a module" do
+      subject { unpacker.feed("\xc7\x06\x00module").unpack }
+
+      let(:unpacker) { MessagePack::Unpacker.new }
+
+      before do
+        mod = Module.new do
+          def self.from_msgpack_ext(data)
+            "unpacked #{data}"
+          end
+        end
+        stub_const('Mod', mod)
+      end
+
+      before { unpacker.register_type(0x00, Mod, :from_msgpack_ext) }
+      it { is_expected.to eq "unpacked module" }
+    end
   end
 
   def flatten(struct, results = [])


### PR DESCRIPTION
re #131 

What I've done is basically checking for class **or** module when registering an ext type for a packer of factory. Most of the noise comes from renaming variables accordingly and using `RubyModule` instead of `RubyClass` in jruby.

Finally, commit 0863031 adds support for serializing objects extended by a module with an ext type like `object.extend Mod`. To do this looking up an ext type in the ancestor chain already begins with the singleton class instead of its regular class.