### PR TITLE
Bail out after a certain depth when packing.

### DIFF
--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -33,6 +33,7 @@ struct msgpack_packer_t {
 
     bool compatibility_mode;
     bool has_symbol_ext_type;
+    int depth;
 
     ID to_msgpack_method;
     VALUE to_msgpack_arg;
@@ -42,6 +43,7 @@ struct msgpack_packer_t {
     /* options */
     bool comaptibility_mode;
     msgpack_packer_ext_registry_t ext_registry;
+    int max_depth;
 };
 
 #define PACKER_BUFFER_(pk) (&(pk)->buffer)
@@ -68,6 +70,11 @@ void msgpack_packer_reset(msgpack_packer_t* pk);
 static inline void msgpack_packer_set_compat(msgpack_packer_t* pk, bool enable)
 {
     pk->compatibility_mode = enable;
+}
+
+static inline void msgpack_packer_set_max_depth(msgpack_packer_t* pk, int max_depth)
+{
+    pk->max_depth = max_depth;
 }
 
 static inline void msgpack_packer_write_nil(msgpack_packer_t* pk)

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -104,6 +104,11 @@ VALUE MessagePack_Packer_initialize(int argc, VALUE* argv, VALUE self)
 
         v = rb_hash_aref(options, ID2SYM(rb_intern("compatibility_mode")));
         msgpack_packer_set_compat(pk, RTEST(v));
+
+        v = rb_hash_aref(options, ID2SYM(rb_intern("max_depth")));
+        if(RTEST(v)) {
+            msgpack_packer_set_max_depth(pk, NUM2INT(v));
+        }
     }
 
     return self;

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -474,4 +474,16 @@ describe MessagePack::Packer do
         [0xc9, 65538, -1].pack('CNC') + "a"*65538
     end
   end
+
+  it "gracefully fails on a cyclic hash" do
+    cyclic = {}
+    cyclic[:cyclic] = cyclic
+    expect { cyclic.to_msgpack(max_depth: 32) }.to raise_error(ArgumentError)
+  end
+
+  it "gracefully fails on a cyclic array" do
+    cyclic = []
+    cyclic[0] = cyclic
+    expect { cyclic.to_msgpack(max_depth: 32) }.to raise_error(ArgumentError)
+  end
 end


### PR DESCRIPTION
This PR tackles the problem of failing fast on cyclical data when packing. On the current version of msgpack, packing in implemented with recursive C functions. This means that a value such as

```
cyclical = []
cyclical << cyclical
```

will trigger a stack overflow. If msgpack-ruby could detect this kind of data, it could bail out much faster. As far as know, I might also be safer since it won't rely on a memory protection error on a guard page while executing unmanaged code that we don't know whether it is safe to interrupt?

I went with the approach of having a `max_depth` option, which set the maximum depth of recursion. The alternative would be to keep a stack of visited `object_id` and raise if we see the same object twice.

Something else that could be done is to turn the recursive functions into iterative functions with a fixed-size stack on the size like it is done for decoding.