### PR TITLE
Implement Factory#load and #dump for a more convenient API

### DIFF
--- a/lib/msgpack/factory.rb
+++ b/lib/msgpack/factory.rb
@@ -56,5 +56,26 @@ module MessagePack
         raise ArgumentError, "class or type id"
       end
     end
+
+    def load(src, param = nil)
+      unpacker = nil
+
+      if src.is_a? String
+        unpacker = unpacker(param)
+        unpacker.feed(src)
+      else
+        unpacker = unpacker(src, param)
+      end
+
+      unpacker.full_unpack
+    end
+    alias :unpack :load
+
+    def pack(v, *rest)
+      packer = packer(*rest)
+      packer.write(v)
+      packer.full_pack
+    end
+    alias :dump :pack
   end
 end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -44,6 +44,23 @@ describe MessagePack::Factory do
     end
   end
 
+  describe '#dump and #load' do
+    it 'can be used like a standard coder' do
+      subject.register_type(0x00, Symbol)
+      expect(subject.load(subject.dump(:symbol))).to be == :symbol
+    end
+
+    it 'is alias as pack and unpack' do
+      subject.register_type(0x00, Symbol)
+      expect(subject.unpack(subject.pack(:symbol))).to be == :symbol
+    end
+
+    it 'accept options' do
+      hash = subject.unpack(MessagePack.pack('k' => 'v'), symbolize_keys: true)
+      expect(hash).to be == { k: 'v' }
+    end
+  end
+
   class MyType
     def initialize(a, b)
       @a = a


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/issues/141

I had the same issue than @mwpastore. IMO this simpler API should be enough for the vast majority of use cases:

```ruby
MY_CUSTOMER_PACKER = MessagePack::Factory.new
MY_CUSTOMER_PACKER.register_type(0x00, Symbol)

MY_CUSTOMER_PACKER.load(MY_CUSTOMER_PACKER.dump(:some_symbol))
```

