### PR TITLE
Freeze MessagePack::Factory correctly

### DIFF
--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -75,6 +75,11 @@ public class Factory extends RubyObject {
 
     IRubyObject packerArg;
     IRubyObject unpackerArg;
+
+    if (isFrozen()) {
+        throw runtime.newRuntimeError("can't modify frozen Factory");
+    }
+
     if (args.length == 2) {
       packerArg = runtime.newSymbol("to_msgpack_ext");
       unpackerArg = runtime.newSymbol("from_msgpack_ext");

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -145,6 +145,10 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
     VALUE packer_arg, unpacker_arg;
     VALUE packer_proc, unpacker_proc;
 
+    if (OBJ_FROZEN(self)) {
+        rb_raise(rb_eRuntimeError, "can't modify frozen Factory");
+    }
+
     switch (argc) {
     case 2:
         /* register_type(0x7f, Time) */

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -61,6 +61,15 @@ describe MessagePack::Factory do
     end
   end
 
+  describe '#freeze' do
+    it 'can freeze factory instance to deny new registrations anymore' do
+      subject.register_type(0x00, Symbol)
+      subject.freeze
+      expect(subject.frozen?).to be_truthy
+      expect{ subject.register_type(0x01, Array) }.to raise_error(RuntimeError, "can't modify frozen Factory")
+    end
+  end
+
   class MyType
     def initialize(a, b)
       @a = a


### PR DESCRIPTION
Now we can register new types to frozen `MessagePack::Factory`.
It's clearly a bug, because we may get different results from `Factory#dump` or `Factory#load` after `Factory#freeze`.
We should reject type registration operation for frozen Factory objects.