### PR TITLE
Fix SEGV on hash in ext-registry

### DIFF
--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -54,7 +54,7 @@ static void Buffer_free(void* data)
 
 static VALUE Buffer_alloc(VALUE klass)
 {
-    msgpack_buffer_t* b = ALLOC_N(msgpack_buffer_t, 1);
+    msgpack_buffer_t* b = ZALLOC_N(msgpack_buffer_t, 1);
     msgpack_buffer_init(b);
 
     return Data_Wrap_Struct(klass, msgpack_buffer_mark, Buffer_free, b);

--- a/ext/msgpack/compat.h
+++ b/ext/msgpack/compat.h
@@ -29,6 +29,16 @@
 
 
 /*
+ * ZALLOC_N (ruby 2.2 or later)
+ */
+#ifndef RB_ZALLOC_N
+#  define RB_ZALLOC_N(type,n) ((type*)ruby_xcalloc((size_t)(n),sizeof(type)))
+#endif
+#ifndef ZALLOC_N
+#  define ZALLOC_N(type,n) RB_ZALLOC_N(type,n)
+#endif
+
+/*
  * COMPAT_HAVE_ENCODING
  */
 #ifdef HAVE_RUBY_ENCODING_H

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -59,10 +59,7 @@ void Factory_mark(msgpack_factory_t* fc)
 
 static VALUE Factory_alloc(VALUE klass)
 {
-    msgpack_factory_t* fc = ALLOC_N(msgpack_factory_t, 1);
-
-    msgpack_packer_ext_registry_init(&fc->pkrg);
-    msgpack_unpacker_ext_registry_init(&fc->ukrg);
+    msgpack_factory_t* fc = ZALLOC_N(msgpack_factory_t, 1);
 
     VALUE self = Data_Wrap_Struct(klass, Factory_mark, Factory_free, fc);
     return self;
@@ -71,6 +68,9 @@ static VALUE Factory_alloc(VALUE klass)
 static VALUE Factory_initialize(int argc, VALUE* argv, VALUE self)
 {
     FACTORY(self, fc);
+
+    msgpack_packer_ext_registry_init(&fc->pkrg);
+    msgpack_unpacker_ext_registry_init(&fc->ukrg);
 
     fc->has_symbol_ext_type = false;
 

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -56,14 +56,12 @@ static void Packer_mark(msgpack_packer_t* pk)
 
 VALUE MessagePack_Packer_alloc(VALUE klass)
 {
-    msgpack_packer_t* pk = ALLOC_N(msgpack_packer_t, 1);
+    msgpack_packer_t* pk = ZALLOC_N(msgpack_packer_t, 1);
     msgpack_packer_init(pk);
 
     VALUE self = Data_Wrap_Struct(klass, Packer_mark, Packer_free, pk);
 
     msgpack_packer_set_to_msgpack_method(pk, s_to_msgpack, self);
-    msgpack_packer_ext_registry_init(&pk->ext_registry);
-    pk->buffer_ref = MessagePack_Buffer_wrap(PACKER_BUFFER_(pk), self);
 
     return self;
 }
@@ -96,6 +94,9 @@ VALUE MessagePack_Packer_initialize(int argc, VALUE* argv, VALUE self)
     }
 
     PACKER(self, pk);
+
+    msgpack_packer_ext_registry_init(&pk->ext_registry);
+    pk->buffer_ref = MessagePack_Buffer_wrap(PACKER_BUFFER_(pk), self);
 
     MessagePack_Buffer_set_options(PACKER_BUFFER_(pk), io, options);
 

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -58,14 +58,10 @@ static void Unpacker_mark(msgpack_unpacker_t* uk)
 
 VALUE MessagePack_Unpacker_alloc(VALUE klass)
 {
-    msgpack_unpacker_t* uk = ALLOC_N(msgpack_unpacker_t, 1);
+    msgpack_unpacker_t* uk = ZALLOC_N(msgpack_unpacker_t, 1);
     _msgpack_unpacker_init(uk);
 
     VALUE self = Data_Wrap_Struct(klass, Unpacker_mark, Unpacker_free, uk);
-
-    msgpack_unpacker_ext_registry_init(&uk->ext_registry);
-    uk->buffer_ref = MessagePack_Buffer_wrap(UNPACKER_BUFFER_(uk), self);
-
     return self;
 }
 
@@ -100,6 +96,9 @@ VALUE MessagePack_Unpacker_initialize(int argc, VALUE* argv, VALUE self)
     }
 
     UNPACKER(self, uk);
+
+    msgpack_unpacker_ext_registry_init(&uk->ext_registry);
+    uk->buffer_ref = MessagePack_Buffer_wrap(UNPACKER_BUFFER_(uk), self);
 
     MessagePack_Buffer_set_options(UNPACKER_BUFFER_(uk), io, options);
 

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -331,6 +331,19 @@ describe MessagePack::Factory do
     end
   end
 
+  describe 'under stressful GC' do
+    it 'works well' do
+      begin
+        GC.stress = true
+
+        f = MessagePack::Factory.new
+        f.register_type(0x0a, Symbol)
+      ensure
+        GC.stress = false
+      end
+    end
+  end
+
   describe 'DefaultFactory' do
     it 'is a factory' do
       MessagePack::DefaultFactory.should be_kind_of(MessagePack::Factory)


### PR DESCRIPTION
The current code allocates structs in `_alloc` methods and creates Hash VALUEs at the same method.
But these VALUEs are not marked until `#initialize` runs, and if GC runs before `#initialize`, these VALUEs will be collected. Generally, VALUEs should be created/assigned at `#initialize`.

On the other hand, other SEGV occurs if we simply move code to create VALUEs to `#initialize`. This is caused by GC, which refers the allocated/uninitialized memory area of structs (allocated by `ALLOC_N`).
@ko1 [said](https://twitter.com/_ko1/status/950973448284549120) that "ALLOC_N brings death to you." We need to use `ZALLOC_N` everywhere.

This change is to fix these problems found (and possibly danger code), and to add a test to make SEGV without these patches.
  