### PR TITLE
Fix class lookup in packer registry

### DIFF
--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -384,7 +384,7 @@ public class Encoder {
         lookupClass = object.getSingletonClass();
       }
 
-      IRubyObject[] pair = registry.lookupPackerByModule(lookupClass);
+      IRubyObject[] pair = registry.lookupPackerForObject(object);
       if (pair != null) {
         RubyString bytes = pair[0].callMethod(runtime.getCurrentContext(), "call", object).asString();
         int type = (int) ((RubyFixnum) pair[1]).getLongValue();

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -125,25 +125,7 @@ void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
 {
     int ext_type;
 
-    VALUE lookup_class;
-
-    /*
-     * Objects of type Integer (Fixnum, Bignum), Float, Symbol and frozen
-     * String have no singleton class and raise a TypeError when trying to get
-     * it. See implementation of #singleton_class in ruby's source code:
-     * VALUE rb_singleton_class(VALUE obj);
-     *
-     * Since all but symbols are already filtered out when reaching this code
-     * only symbols are checked here.
-     */
-    if (SYMBOL_P(v)) {
-      lookup_class = rb_obj_class(v);
-    } else {
-      lookup_class = rb_singleton_class(v);
-    }
-
-    VALUE proc = msgpack_packer_ext_registry_lookup(&pk->ext_registry, lookup_class,
-      &ext_type);
+    VALUE proc = msgpack_packer_ext_registry_lookup(&pk->ext_registry, v, &ext_type);
 
     if(proc != Qnil) {
         VALUE payload = rb_funcall(proc, s_call, 1, v);

--- a/ext/msgpack/packer_ext_registry.h
+++ b/ext/msgpack/packer_ext_registry.h
@@ -59,15 +59,17 @@ static int msgpack_packer_ext_find_superclass(VALUE key, VALUE value, VALUE arg)
     return ST_CONTINUE;
 }
 
-static inline VALUE msgpack_packer_ext_registry_lookup_(msgpack_packer_ext_registry_t* pkrg,
+static inline VALUE msgpack_packer_ext_registry_fetch(msgpack_packer_ext_registry_t* pkrg,
         VALUE lookup_class, int* ext_type_result)
 {
+    // fetch lookup_class from hash, which is a hash to register classes
     VALUE type = rb_hash_lookup(pkrg->hash, lookup_class);
     if(type != Qnil) {
         *ext_type_result = FIX2INT(rb_ary_entry(type, 0));
         return rb_ary_entry(type, 1);
     }
 
+    // fetch lookup_class from cache, which stores results of searching ancestors from pkrg->hash
     VALUE type_inht = rb_hash_lookup(pkrg->cache, lookup_class);
     if(type_inht != Qnil) {
         *ext_type_result = FIX2INT(rb_ary_entry(type_inht, 0));
@@ -84,6 +86,8 @@ static inline VALUE msgpack_packer_ext_registry_lookup(msgpack_packer_ext_regist
     VALUE type;
 
     /*
+     * 1. check whether singleton_class of this instance is registered (or resolved in past) or not.
+     *
      * Objects of type Integer (Fixnum, Bignum), Float, Symbol and frozen
      * String have no singleton class and raise a TypeError when trying to get
      * it. See implementation of #singleton_class in ruby's source code:
@@ -95,21 +99,24 @@ static inline VALUE msgpack_packer_ext_registry_lookup(msgpack_packer_ext_regist
     if (!SYMBOL_P(instance)) {
       lookup_class = rb_singleton_class(instance);
 
-      type = msgpack_packer_ext_registry_lookup_(pkrg, lookup_class, ext_type_result);
+      type = msgpack_packer_ext_registry_fetch(pkrg, lookup_class, ext_type_result);
 
       if(type != Qnil) {
           return type;
       }
     }
 
-    type = msgpack_packer_ext_registry_lookup_(pkrg, rb_obj_class(instance), ext_type_result);
+    /*
+     * 2. check the class of instance is registered (or resolved in past) or not.
+     */
+    type = msgpack_packer_ext_registry_fetch(pkrg, rb_obj_class(instance), ext_type_result);
 
     if(type != Qnil) {
         return type;
     }
 
     /*
-     * check all keys whether it is an ancestor of lookup_class, or not
+     * 3. check all keys whether it is an ancestor of lookup_class, or not
      */
     VALUE args[2];
     args[0] = lookup_class;

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -372,6 +372,34 @@ describe MessagePack::Packer do
       end
     end
 
+    context 'when it and its super class has an ext type' do
+      before { stub_const('Value', Class.new) }
+      before do
+        Value.class_eval do
+          def to_msgpack_ext
+            'value_msgpacked'
+          end
+        end
+      end
+      before { packer.register_type(0x01, Value, :to_msgpack_ext) }
+
+      context "when it is a child class" do
+        before { stub_const('InheritedValue', Class.new(Value)) }
+        before do
+          InheritedValue.class_eval do
+            def to_msgpack_ext
+              'inherited_value_msgpacked'
+            end
+          end
+        end
+
+        before { packer.register_type(0x02, InheritedValue, :to_msgpack_ext) }
+        subject { packer.pack(InheritedValue.new).to_s }
+
+        it { is_expected.to eq "\xC7\x19\x02inherited_value_msgpacked" }
+      end
+    end
+
     context 'when it has no ext type but an included module has' do
       subject { packer.pack(Value.new).to_s }
 

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -398,6 +398,22 @@ describe MessagePack::Packer do
 
         it { is_expected.to eq "\xC7\x19\x02inherited_value_msgpacked" }
       end
+
+      context "even when it is a child class" do
+        before { stub_const('InheritedValue', Class.new(Value)) }
+        before do
+          InheritedValue.class_eval do
+            def to_msgpack_ext
+              'inherited_value_msgpacked'
+            end
+          end
+        end
+
+        before { packer.register_type(0x02, InheritedValue, :to_msgpack_ext) }
+        subject { packer.pack(Value.new).to_s }
+
+        it { is_expected.to eq "\xC7\x0F\x01value_msgpacked" }
+      end
     end
 
     context 'when it has no ext type but an included module has' do


### PR DESCRIPTION
Fixes #136, follows #137.

#137 has difficulties to be merged, but it shows that packer registry lookup rule has a bug for super-and-sub classes.
This change includes the fix of #137, and add/fix some tests, comments and change of function names.