### PR TITLE
Update ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ gemfile:
 before_install:
   # This is only for Ruby 2.5.0, Bundler 1.16.1 and rubygems 2.7.3
   # See https://github.com/travis-ci/travis-ci/issues/8969
-  - [ "x2.7.3" = "x"$(gem --version) ] && gem update --system --no-document
+  - "[ \"x2.7.3\" = \"x\"$(gem --version) ] && gem update --system --no-document"
 
 # http://rubies.travis-ci.org/
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ gemfile:
 before_install:
   # This is only for Ruby 2.5.0, Bundler 1.16.1 and rubygems 2.7.3
   # See https://github.com/travis-ci/travis-ci/issues/8969
-  - "[ \"x2.7.3\" = \"x\"$(gem --version) ] && gem update --system --no-document"
+  - "[ \"x2.7.3\" = \"x\"$(gem --version) ] && gem update --system --no-document || echo \"no need to update rubygem\""
 
 # http://rubies.travis-ci.org/
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ matrix:
   include:
     - rvm: 2.1.10
       os: linux
-    - rvm: 2.2.8
+    - rvm: 2.2.9
       os: linux
-    - rvm: 2.3.5
+    - rvm: 2.3.6
       os: linux
-    - rvm: 2.3.5
-      os: osx
-    - rvm: 2.4.2
+    - rvm: 2.4.3
       os: linux
-    - rvm: 2.4.2
+    - rvm: 2.5.0
+      os: linux
+    - rvm: 2.5.0
       os: osx
     - rvm: ruby-head
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ branches:
 gemfile:
   - Gemfile
 
+before_install:
+  # This is only for Ruby 2.5.0, Bundler 1.16.1 and rubygems 2.7.3
+  # See https://github.com/travis-ci/travis-ci/issues/8969
+  - [ "x2.7.3" = "x"$(gem --version) ] && gem update --system --no-document
+
 # http://rubies.travis-ci.org/
 matrix:
   include:

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ namespace :build do
   desc 'Build gems for Windows per rake-compiler-dock'
   task :windows do
     require 'rake_compiler_dock'
-    RakeCompilerDock.sh 'bundle && gem i json && rake cross native gem RUBY_CC_VERSION=1.9.3:2.0.0:2.1.6:2.2.2:2.3.0:2.4.0'
+    RakeCompilerDock.sh 'bundle && gem i json && rake cross native gem RUBY_CC_VERSION=1.9.3:2.0.0:2.1.10:2.2.9:2.3.6:2.4.3:2.5.0'
   end
 end
 

--- a/lib/msgpack/version.rb
+++ b/lib/msgpack/version.rb
@@ -1,3 +1,3 @@
 module MessagePack
-  VERSION = "1.2.2"
+  VERSION = "1.2.3.dev1"
 end


### PR DESCRIPTION
After release of Ruby 2.5.0, I've forgotten about adding it to versions which are included in binary gem for Windows environment.
And this change also adds 2.5.0 to version for CI environment.