### PR TITLE
Add missing require and set Encoding.default_external

### DIFF
--- a/spec/cruby/buffer_spec.rb
+++ b/spec/cruby/buffer_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 require 'random_compat'
 
+require 'stringio'
+if defined?(Encoding)
+  Encoding.default_external = 'ASCII-8BIT'
+end
+
 describe Buffer do
   STATIC_EXAMPLES = {}
   STATIC_EXAMPLES[:empty01] = ''


### PR DESCRIPTION
* Otherwise, `bundle exec rspec spec/cruby/buffer_spec.rb` fails.