### PR TITLE
Add write_bin_header

### DIFF
--- a/doclib/msgpack/packer.rb
+++ b/doclib/msgpack/packer.rb
@@ -92,6 +92,12 @@ module MessagePack
     end
 
     #
+    # Serializes a string object as binary data. Same as write("string".encode(Encoding::BINARY)).
+    #
+    def write_bin(obj)
+    end
+
+    #
     # Write a header of an array whose size is _n_.
     # For example, write_array_header(1).write(true) is same as write([ true ]).
     #
@@ -116,7 +122,7 @@ module MessagePack
     # io.write('chunk1')
     # io.write('chunk2')
     # is the same as
-    # write('chunk1chunk2'.force_encoding(Encoding::BINARY)).
+    # write('chunk1chunk2'.encode(Encoding::BINARY)).
     #
     # @return [Packer] self
     #

--- a/doclib/msgpack/packer.rb
+++ b/doclib/msgpack/packer.rb
@@ -110,6 +110,20 @@ module MessagePack
     end
 
     #
+    # Write a header of a binary string whose size is _n_. Useful if you want to append large binary data without loading it into memory at once.
+    # For example,
+    # MessagePack::Packer.new(io).write_bin_header(12).flush
+    # io.write('chunk1')
+    # io.write('chunk2')
+    # is the same as
+    # write('chunk1chunk2'.force_encoding(Encoding::BINARY)).
+    #
+    # @return [Packer] self
+    #
+    def write_bin_header(n)
+    end
+
+    #
     # Serializes _value_ as 32-bit single precision float into internal buffer.
     # _value_ will be approximated with the nearest possible single precision float, thus
     # being potentially lossy. However, the serialized string will only take up 5 bytes

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -209,6 +209,13 @@ public class Packer extends RubyObject {
     return this;
   }
 
+  @JRubyMethod(name = "write_bin_header")
+  public IRubyObject writeBinHeader(ThreadContext ctx, IRubyObject size) {
+    int s = (int) size.convertToInteger().getLongValue();
+    buffer.write(ctx, encoder.encodeBinHeader(s));
+    return this;
+  }
+
   @JRubyMethod(name = "full_pack")
   public IRubyObject fullPack(ThreadContext ctx) {
     return toS(ctx);

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -21,6 +21,8 @@ import org.jruby.util.ByteList;
 import org.jruby.util.TypeConverter;
 import org.msgpack.jruby.ExtensionValue;
 
+import org.jcodings.Encoding;
+
 import static org.jruby.runtime.Visibility.PRIVATE;
 
 @JRubyClass(name="MessagePack::Packer")
@@ -29,6 +31,7 @@ public class Packer extends RubyObject {
   private Buffer buffer;
   private Encoder encoder;
   private boolean hasSymbolExtType;
+  private Encoding binaryEncoding;
 
   public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry, boolean hasSymbolExtType) {
     super(runtime, type);
@@ -58,6 +61,7 @@ public class Packer extends RubyObject {
     this.encoder = new Encoder(ctx.getRuntime(), compatibilityMode, registry, hasSymbolExtType);
     this.buffer = new Buffer(ctx.getRuntime(), ctx.getRuntime().getModule("MessagePack").getClass("Buffer"));
     this.buffer.initialize(ctx, args);
+    this.binaryEncoding = ctx.getRuntime().getEncodingService().getAscii8bitEncoding();
     return this;
   }
 
@@ -138,6 +142,13 @@ public class Packer extends RubyObject {
   @JRubyMethod(name = "write_string")
   public IRubyObject writeString(ThreadContext ctx, IRubyObject obj) {
     checkType(ctx, obj, org.jruby.RubyString.class);
+    return write(ctx, obj);
+  }
+
+  @JRubyMethod(name = "write_bin")
+  public IRubyObject writeBin(ThreadContext ctx, IRubyObject obj) {
+    checkType(ctx, obj, org.jruby.RubyString.class);
+    obj = ((org.jruby.RubyString) obj).encode(ctx, ctx.runtime.getEncodingService().getEncoding(binaryEncoding));
     return write(ctx, obj);
   }
 

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -232,6 +232,13 @@ static VALUE Packer_write_map_header(VALUE self, VALUE n)
     return self;
 }
 
+static VALUE Packer_write_bin_header(VALUE self, VALUE n)
+{
+    PACKER(self, pk);
+    msgpack_packer_write_bin_header(pk, NUM2UINT(n));
+    return self;
+}
+
 static VALUE Packer_write_float32(VALUE self, VALUE numeric)
 {
     if(!rb_obj_is_kind_of(numeric, rb_cNumeric)) {
@@ -423,6 +430,7 @@ void MessagePack_Packer_module_init(VALUE mMessagePack)
     rb_define_method(cMessagePack_Packer, "write_extension", Packer_write_extension, 1);
     rb_define_method(cMessagePack_Packer, "write_array_header", Packer_write_array_header, 1);
     rb_define_method(cMessagePack_Packer, "write_map_header", Packer_write_map_header, 1);
+    rb_define_method(cMessagePack_Packer, "write_bin_header", Packer_write_bin_header, 1);
     rb_define_method(cMessagePack_Packer, "write_ext", Packer_write_ext, 2);
     rb_define_method(cMessagePack_Packer, "write_float32", Packer_write_float32, 1);
     rb_define_method(cMessagePack_Packer, "flush", Packer_flush, 0);

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -165,6 +165,18 @@ static VALUE Packer_write_string(VALUE self, VALUE obj)
     return self;
 }
 
+static VALUE Packer_write_bin(VALUE self, VALUE obj)
+{
+    PACKER(self, pk);
+    Check_Type(obj, T_STRING);
+
+    VALUE enc = rb_enc_from_encoding(rb_ascii8bit_encoding());
+    obj = rb_str_encode(obj, enc, 0, Qnil);
+
+    msgpack_packer_write_string_value(pk, obj);
+    return self;
+}
+
 static VALUE Packer_write_array(VALUE self, VALUE obj)
 {
     PACKER(self, pk);
@@ -423,6 +435,7 @@ void MessagePack_Packer_module_init(VALUE mMessagePack)
     rb_define_method(cMessagePack_Packer, "write_false", Packer_write_false, 0);
     rb_define_method(cMessagePack_Packer, "write_float", Packer_write_float, 1);
     rb_define_method(cMessagePack_Packer, "write_string", Packer_write_string, 1);
+    rb_define_method(cMessagePack_Packer, "write_bin", Packer_write_bin, 1);
     rb_define_method(cMessagePack_Packer, "write_array", Packer_write_array, 1);
     rb_define_method(cMessagePack_Packer, "write_hash", Packer_write_hash, 1);
     rb_define_method(cMessagePack_Packer, "write_symbol", Packer_write_symbol, 1);

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -164,6 +164,11 @@ describe MessagePack::Packer do
     packer.to_s.should == "\xC6\x00\x0F\x42\x3F"
   end
 
+  it 'write_bin' do
+    packer.write_bin("hello")
+    packer.to_s.should == "\xC4\x05hello"
+  end
+
   describe '#write_float32' do
     tests = [
       ['small floats', 3.14, "\xCA\x40\x48\xF5\xC3"],
@@ -223,6 +228,7 @@ describe MessagePack::Packer do
     packer = MessagePack::Packer.new
     expect { packer.write_float "hello" }.to raise_error(TypeError)
     expect { packer.write_string 1 }.to raise_error(TypeError)
+    expect { packer.write_bin 1 }.to raise_error(TypeError)
     expect { packer.write_array "hello" }.to raise_error(TypeError)
     expect { packer.write_hash "hello" }.to raise_error(TypeError)
     expect { packer.write_symbol "hello" }.to raise_error(TypeError)

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -134,6 +134,36 @@ describe MessagePack::Packer do
     packer.to_s.should == "\x81"
   end
 
+  it 'write_bin_header 0' do
+    packer.write_bin_header(0)
+    packer.to_s.should == "\xC4\x00"
+  end
+
+  it 'write_bin_header 255' do
+    packer.write_bin_header(255)
+    packer.to_s.should == "\xC4\xFF"
+  end
+
+  it 'write_bin_header 256' do
+    packer.write_bin_header(256)
+    packer.to_s.should == "\xC5\x01\x00"
+  end
+
+  it 'write_bin_header 65535' do
+    packer.write_bin_header(65535)
+    packer.to_s.should == "\xC5\xFF\xFF"
+  end
+
+  it 'write_bin_header 65536' do
+    packer.write_bin_header(65536)
+    packer.to_s.should == "\xC6\x00\x01\x00\x00"
+  end
+
+  it 'write_bin_header 999999' do
+    packer.write_bin_header(999999)
+    packer.to_s.should == "\xC6\x00\x0F\x42\x3F"
+  end
+
   describe '#write_float32' do
     tests = [
       ['small floats', 3.14, "\xCA\x40\x48\xF5\xC3"],


### PR DESCRIPTION
Hi,

I was trying to append a large binary file to a msgpack string in streaming style without loading the binary file into memory and passing it to `Packer#write` but I couldn't find a way. I'm missing a `write_bin_header` method, similar to `write_array_header` and `write_map_header`.

Luckily there's already a `msgpack_packer_write_bin_header(length)` method. This made adding the ruby wrapper methods a piece of cake :)