### PR TITLE
Optimize MessagePack.unpack to not copy source string

### DIFF
--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -170,7 +170,7 @@ public class Unpacker extends RubyObject {
     return data == null ? ctx.getRuntime().getFalse() : ctx.getRuntime().getTrue();
   }
 
-  @JRubyMethod(required = 1)
+  @JRubyMethod(required = 1, name = "feed", alias = { "feed_reference" })
   public IRubyObject feed(ThreadContext ctx, IRubyObject data) {
     ByteList byteList = data.asString().getByteList();
     if (decoder == null) {

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -262,6 +262,20 @@ static inline size_t msgpack_buffer_append_string(msgpack_buffer_t* b, VALUE str
     return length;
 }
 
+static inline size_t msgpack_buffer_append_string_reference(msgpack_buffer_t* b, VALUE string)
+{
+    size_t length = RSTRING_LEN(string);
+
+    if(length > MSGPACK_BUFFER_STRING_WRITE_REFERENCE_MINIMUM) {
+        _msgpack_buffer_append_long_string(b, string);
+
+    } else {
+        msgpack_buffer_append(b, RSTRING_PTR(string), length);
+    }
+
+    return length;
+}
+
 
 /*
  * IO functions

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -256,6 +256,17 @@ static VALUE Unpacker_feed(VALUE self, VALUE data)
     return self;
 }
 
+static VALUE Unpacker_feed_reference(VALUE self, VALUE data)
+{
+    UNPACKER(self, uk);
+
+    StringValue(data);
+
+    msgpack_buffer_append_string_reference(UNPACKER_BUFFER_(uk), data);
+
+    return self;
+}
+
 static VALUE Unpacker_each_impl(VALUE self)
 {
     UNPACKER(self, uk);
@@ -312,8 +323,7 @@ static VALUE Unpacker_feed_each(VALUE self, VALUE data)
     }
 #endif
 
-    // TODO optimize
-    Unpacker_feed(self, data);
+    Unpacker_feed_reference(self, data);
     return Unpacker_each(self);
 }
 
@@ -444,6 +454,7 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
     rb_define_method(cMessagePack_Unpacker, "read_map_header", Unpacker_read_map_header, 0);
     //rb_define_method(cMessagePack_Unpacker, "peek_next_type", Unpacker_peek_next_type, 0);  // TODO
     rb_define_method(cMessagePack_Unpacker, "feed", Unpacker_feed, 1);
+    rb_define_method(cMessagePack_Unpacker, "feed_reference", Unpacker_feed_reference, 1);
     rb_define_method(cMessagePack_Unpacker, "each", Unpacker_each, 0);
     rb_define_method(cMessagePack_Unpacker, "feed_each", Unpacker_feed_each, 1);
     rb_define_method(cMessagePack_Unpacker, "reset", Unpacker_reset, 0);

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -396,9 +396,6 @@ static VALUE Unpacker_full_unpack(VALUE self)
 {
     UNPACKER(self, uk);
 
-    /* prefer reference than copying; see MessagePack_Unpacker_module_init */
-    msgpack_buffer_set_write_reference_threshold(UNPACKER_BUFFER_(uk), 0);
-
     int r = msgpack_unpacker_read(uk, 0);
     if(r < 0) {
         raise_unpacker_error(r);

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -27,7 +27,7 @@ module MessagePack
 
     if src.is_a? String
       unpacker = DefaultFactory.unpacker param || DEFAULT_EMPTY_PARAMS
-      unpacker.feed src
+      unpacker.feed_reference src
     else
       unpacker = DefaultFactory.unpacker src, param || DEFAULT_EMPTY_PARAMS
     end


### PR DESCRIPTION
When `MessagePack.unpack(str)` is called, `str` is likely a String that
won't be modified. Therefore, copying the string is unnecessary overhead
in many use cases.

This change omits the copy if the string is long enough for effective
optimization.

Benchmark code:

```ruby
require 'msgpack'
require 'benchmark'

Benchmark.bmbm do |x|
  [0.1, 1, 10, 100, 500, 600].each do |kb|
    msg = ['a' * kb * 1024]
    bin = MessagePack.pack(msg)

    x.report("#{kb}kb") do
      for a in 1..1000000 do
        MessagePack.unpack(bin)
      end
    end
  end
end
```

Without this change:

```
        user     system      total        real
0.1kb   1.204809   0.005060   1.209869 (  1.210884)
1kb     1.309668   0.004896   1.314564 (  1.315971)
10kb    2.674302   0.077470   2.751772 (  2.755213)
100kb  29.982771  22.375113  52.357884 ( 52.386822)
500kb 122.625423  82.284026 204.909449 (205.018250)
600kb   1.006700   0.003676   1.010376 (  1.010782)
```

With feed_reference optimization:

```
            user     system      total        real
0.1kb   1.083846   0.003683   1.087529 (  1.088513)
1kb     1.094858   0.005324   1.100182 (  1.101378)
10kb    1.084737   0.003666   1.088403 (  1.089650)
100kb   1.087578   0.003564   1.091142 (  1.092555)
500kb   1.123068   0.003202   1.126270 (  1.127866)
600kb   1.164886   0.004079   1.168965 (  1.170279)
```

This result shows that this optimization is very effective until 500KB of source string, but it has no effect if source string is 600KB. This is because default value of `write_reference_threshold` is 512KB.

Benchmark environment:

* ruby-2.6.2p47
* msgpack-1.2.9
* Mac OS X 10.14.4
* 2.9GHz Intel Core i9 CPU
* 32GB 2400MHz DDR4 memory