### PR TITLE
MessagePack timestamp type

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+AllCops:
+  TargetRubyVersion: 2.3
+
 # Offense count: 3
 Lint/AmbiguousOperator:
   Enabled: false

--- a/README.rdoc
+++ b/README.rdoc
@@ -121,6 +121,22 @@ being serialized altogether by throwing an exception:
 
     [1, :symbol, 'string'].to_msgpack  # => RuntimeError: Serialization of symbols prohibited
 
+= Serializing and deserializing Time instances
+
+There are the timestamp extension type in MessagePack,
+but it is not registered by default.
+
+To map Ruby's Time to MessagePack's timestamp for the default factory:
+
+    MessagePack::DefaultFactory.register_type(
+      MessagePack::Timestamp::TYPE, # or just -1
+      Time,
+      packer: MessagePack::Time::Packer,
+      unpacker: MessagePack::Time::Unpacker
+    )
+
+See {API reference}[http://ruby.msgpack.org/] for details.
+
 = Extension Types
 
 Packer and Unpacker support {Extension types of MessagePack}[https://github.com/msgpack/msgpack/blob/master/spec.md#types-extension-type].

--- a/doclib/msgpack/time.rb
+++ b/doclib/msgpack/time.rb
@@ -1,0 +1,22 @@
+module MessagePack
+
+  # MessagePack::Time provides packer and unpacker functions for a timestamp type.
+  # @example Setup for DefaultFactory
+  #   MessagePack::DefaultFactory.register_type(
+  #     MessagePack::Timestamp::TYPE,
+  #     Time,
+  #     packer: MessagePack::Time::Packer,
+  #     unpacker: MessagePack::Time::Unpacker
+  #   )
+  class Time
+    # A packer function that packs a Time instance to a MessagePack timestamp.
+    Packer = lambda { |payload|
+      # ...
+    }
+
+    # An unpacker function that unpacks a MessagePack timestamp to a Time instance.
+    Unpcker = lambda { |time|
+      # ...
+    }
+  end
+end

--- a/doclib/msgpack/timestamp.rb
+++ b/doclib/msgpack/timestamp.rb
@@ -1,0 +1,44 @@
+module MessagePack
+  # A utility class for MessagePack timestamp type
+  class Timestamp
+    #
+    # The timestamp extension type defined in the MessagePack spec.
+    #
+    # See https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type for details.
+    #
+    TYPE = -1
+
+    # @return [Integer] Second part of the timestamp.
+    attr_reader :sec
+
+    # @return [Integer] Nanosecond part of the timestamp.
+    attr_reader :nsec
+
+    # @param [Integer] sec
+    # @param [Integer] nsec
+    def initialize(sec, nsec)
+    end
+
+    # @example An unpacker implementation for the Time class
+    #   lambda do |payload|
+    #     tv = MessagePack::Timestamp.from_msgpack_ext(payload)
+    #     Time.at(tv.sec, tv.nsec, :nanosecond)
+    #   end
+    #
+    # @param [String] data
+    # @return [MessagePack::Timestamp]
+    def self.from_msgpack_ext(data)
+    end
+
+    # @example A packer implementation for the Time class
+    #   unpacker = lambda do |time|
+    #     MessagePack::Timestamp.to_msgpack_ext(time.tv_sec, time.tv_nsec)
+    #   end
+    #
+    # @param [Integer] sec
+    # @param [Integer] nsec
+    # @return [String]
+    def self.to_msgpack_ext(sec, nsec)
+    end
+  end
+end

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -23,8 +23,6 @@ module MessagePack
   DefaultFactory = MessagePack::Factory.new
   DEFAULT_EMPTY_PARAMS = {}.freeze
 
-  DefaultFactory.register_type(Timestamp::TYPE, Time)
-
   def load(src, param = nil)
     unpacker = nil
 

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -17,6 +17,7 @@ require "msgpack/unpacker"
 require "msgpack/factory"
 require "msgpack/symbol"
 require "msgpack/core_ext"
+require "msgpack/timestamp"
 
 module MessagePack
   DefaultFactory = MessagePack::Factory.new

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -23,6 +23,8 @@ module MessagePack
   DefaultFactory = MessagePack::Factory.new
   DEFAULT_EMPTY_PARAMS = {}.freeze
 
+  DefaultFactory.register_type(Timestamp::TYPE, Time)
+
   def load(src, param = nil)
     unpacker = nil
 

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -18,6 +18,7 @@ require "msgpack/factory"
 require "msgpack/symbol"
 require "msgpack/core_ext"
 require "msgpack/timestamp"
+require "msgpack/time"
 
 module MessagePack
   DefaultFactory = MessagePack::Factory.new

--- a/lib/msgpack/core_ext.rb
+++ b/lib/msgpack/core_ext.rb
@@ -126,6 +126,19 @@ else
   end
 end
 
+class Time
+  include MessagePack::CoreExt
+
+  def self.from_msgpack_ext(payload)
+    tv = MessagePack::Timestamp.from_msgpack_ext(payload)
+    at(tv.sec, tv.nsec, :nanosecond)
+  end
+
+  def to_msgpack_ext
+    MessagePack::Timestamp.to_msgpack_ext(tv_sec, tv_nsec)
+  end
+end
+
 module MessagePack
   class ExtensionValue
     include CoreExt

--- a/lib/msgpack/core_ext.rb
+++ b/lib/msgpack/core_ext.rb
@@ -13,7 +13,7 @@ module MessagePack
     end
   end
 
-  # for namespacing
+  # 3-arg Time.at is available Ruby >= 2.5
   TIME_AT_3_AVAILABLE = begin
     Time.at(0, 0, :nanosecond)
     true

--- a/lib/msgpack/core_ext.rb
+++ b/lib/msgpack/core_ext.rb
@@ -12,6 +12,14 @@ module MessagePack
       end
     end
   end
+
+  # for namespacing
+  TIME_AT_3_AVAILABLE = begin
+    Time.at(0, 0, :nanosecond)
+    true
+  rescue ArgumentError
+    false
+  end
 end
 
 class NilClass
@@ -131,7 +139,12 @@ class Time
 
   def self.from_msgpack_ext(payload)
     tv = MessagePack::Timestamp.from_msgpack_ext(payload)
-    at(tv.sec, tv.nsec, :nanosecond)
+
+    if MessagePack::TIME_AT_3_AVAILABLE
+      at(tv.sec, tv.nsec, :nanosecond)
+    else
+      at(tv.sec, tv.nsec / 1000.0)
+    end
   end
 
   def to_msgpack_ext

--- a/lib/msgpack/core_ext.rb
+++ b/lib/msgpack/core_ext.rb
@@ -12,14 +12,6 @@ module MessagePack
       end
     end
   end
-
-  # 3-arg Time.at is available Ruby >= 2.5
-  TIME_AT_3_AVAILABLE = begin
-    Time.at(0, 0, :nanosecond)
-    true
-  rescue ArgumentError
-    false
-  end
 end
 
 class NilClass
@@ -131,24 +123,6 @@ else
       packer.write_int self
       packer
     end
-  end
-end
-
-class Time
-  include MessagePack::CoreExt
-
-  def self.from_msgpack_ext(payload)
-    tv = MessagePack::Timestamp.from_msgpack_ext(payload)
-
-    if MessagePack::TIME_AT_3_AVAILABLE
-      at(tv.sec, tv.nsec, :nanosecond)
-    else
-      at(tv.sec, tv.nsec / 1000.0)
-    end
-  end
-
-  def to_msgpack_ext
-    MessagePack::Timestamp.to_msgpack_ext(tv_sec, tv_nsec)
   end
 end
 

--- a/lib/msgpack/time.rb
+++ b/lib/msgpack/time.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# MessagePack extention packer and unpacker for built-in Time class
+module MessagePack
+  module Time
+    # 3-arg Time.at is available Ruby >= 2.5
+    TIME_AT_3_AVAILABLE = begin
+      !!::Time.at(0, 0, :nanosecond)
+    rescue ArgumentError
+      false
+    end
+
+    Unpacker = if TIME_AT_3_AVAILABLE
+                 lambda do |payload|
+                   tv = MessagePack::Timestamp.from_msgpack_ext(payload)
+                   ::Time.at(tv.sec, tv.nsec, :nanosecond)
+                 end
+               else
+                 lambda do |payload|
+                   tv = MessagePack::Timestamp.from_msgpack_ext(payload)
+                   ::Time.at(tv.sec, tv.nsec / 1000.0)
+                 end
+               end
+
+    Packer = lambda { |time|
+      MessagePack::Timestamp.to_msgpack_ext(time.tv_sec, time.tv_nsec)
+    }
+  end
+end

--- a/lib/msgpack/time.rb
+++ b/lib/msgpack/time.rb
@@ -6,8 +6,8 @@ module MessagePack
     # 3-arg Time.at is available Ruby >= 2.5
     TIME_AT_3_AVAILABLE = begin
       !!::Time.at(0, 0, :nanosecond)
-    rescue ArgumentError
-      false
+                          rescue ArgumentError
+                            false
     end
 
     Unpacker = if TIME_AT_3_AVAILABLE

--- a/lib/msgpack/time.rb
+++ b/lib/msgpack/time.rb
@@ -5,10 +5,10 @@ module MessagePack
   module Time
     # 3-arg Time.at is available Ruby >= 2.5
     TIME_AT_3_AVAILABLE = begin
-      !!::Time.at(0, 0, :nanosecond)
+                            !!::Time.at(0, 0, :nanosecond)
                           rescue ArgumentError
                             false
-    end
+                          end
 
     Unpacker = if TIME_AT_3_AVAILABLE
                  lambda do |payload|

--- a/lib/msgpack/timestamp.rb
+++ b/lib/msgpack/timestamp.rb
@@ -4,7 +4,13 @@ module MessagePack
   Timestamp = Struct.new(:sec, :nsec)
 
   class Timestamp # a.k.a. "TimeSpec"
-    TYPE = -1 # timestamp extension type
+    # Because the byte-order of MessagePack is big-endian in,
+    # pack() and unpack() specifies ">".
+    # See https://docs.ruby-lang.org/en/trunk/Array.html#method-i-pack for details.
+
+    # The timestamp extension type defined in the MessagePack spec.
+    # See https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type for details.
+    TYPE = -1
 
     TIMESTAMP32_MAX_SEC = (1 << 32) - 1
     TIMESTAMP64_MAX_SEC = (1 << 34) - 1

--- a/lib/msgpack/timestamp.rb
+++ b/lib/msgpack/timestamp.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module MessagePack
-  Timestamp = Struct.new(:sec, :nsec)
-
   class Timestamp # a.k.a. "TimeSpec"
     # Because the byte-order of MessagePack is big-endian in,
     # pack() and unpack() specifies ">".
@@ -14,6 +12,19 @@ module MessagePack
 
     TIMESTAMP32_MAX_SEC = (1 << 32) - 1
     TIMESTAMP64_MAX_SEC = (1 << 34) - 1
+
+    # @return [Integer]
+    attr_reader :sec
+
+    # @return [Integer]
+    attr_reader :nsec
+
+    # @param [Integer] sec
+    # @param [Integer] nsec
+    def initialize(sec, nsec)
+      @sec = sec
+      @nsec = nsec
+    end
 
     def self.from_msgpack_ext(data)
       case data.length
@@ -56,6 +67,10 @@ module MessagePack
 
     def to_msgpack_ext
       self.class.to_msgpack_ext(sec, nsec)
+    end
+
+    def ==(other)
+      other.class == self.class && sec == other.sec && nsec == other.nsec
     end
   end
 end

--- a/lib/msgpack/timestamp.rb
+++ b/lib/msgpack/timestamp.rb
@@ -37,9 +37,10 @@ module MessagePack
           [sec].pack('L>')
         else
           # timestamp64 (nsec: uint30be, sec: uint34be)
-          sec_high = sec << 32
-          sec_low = sec & 0xffffffff
-          [(nsec << 2) | (sec_high & 0b11), sec_low].pack('L>2')
+          nsec30 = nsec << 2
+          sec_high2 = sec << 32 # high 2 bits (`x & 0b11` is redandunt)
+          sec_low32 = sec & 0xffffffff # low 32 bits
+          [nsec30 | sec_high2, sec_low32].pack('L>2')
         end
       else
         # timestamp96 (nsec: uint32be, sec: int64be)

--- a/lib/msgpack/timestamp.rb
+++ b/lib/msgpack/timestamp.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module MessagePack
+  Timestamp = Struct.new(:sec, :nsec)
+
+  class Timestamp # a.k.a. "TimeSpec"
+    TYPE = -1 # timestamp extension type
+
+    TIMESTAMP32_MAX_SEC = 0x100000000 # 32-bit unsigned int
+    TIMESTAMP64_MAX_SEC = 0x400000000 # 34-bit unsigned int
+
+    def self.from_payload(data)
+      case data.length
+      when 4
+        # timestamp32 = (uint32be)
+        sec = data.unpack("L>").first
+        new(sec, 0)
+      when 8
+        # timestamp64 = (uint32be, uint32be)
+        n, s = data.unpack("L>2")
+        sec = (n & 0x3) * 0x100000000 + s
+        nsec = n >> 2
+        new(sec, nsec)
+      when 12
+        # timestam96 = (uint32be, int64be)
+        nsec, sec = data.unpack("L>q>")
+        new(sec, nsec)
+      else
+        raise "Invalid timestamp data size: #{data.length}"
+      end
+    end
+
+    def to_msgpack_payload
+      if sec >= 0 && nsec >= 0 && sec < TIMESTAMP64_MAX_SEC
+        if nsec === 0 && sec < TIMESTAMP32_MAX_SEC
+          # timestamp32 = (uint32)
+          [sec].pack("L>")
+        else
+          # timestamp64 (uint32, uint32)
+          sec_high = sec << 32
+          sec_low = sec & 0xffffffff
+          [(nsec << 2) | (sec_high & 0x3), sec_low].pack("L>2")
+        end
+      else
+        # timestamp96 (uint32, int64)
+
+        [nsec, sec].pack("L>q>")
+      end
+    end
+  end
+end

--- a/lib/msgpack/timestamp.rb
+++ b/lib/msgpack/timestamp.rb
@@ -43,7 +43,7 @@ module MessagePack
         nsec, sec = data.unpack('L>q>')
         new(sec, nsec)
       else
-        raise "Invalid timestamp data size: #{data.length}"
+        raise MalformedFormatError, "Invalid timestamp data size: #{data.length}"
       end
     end
 

--- a/lib/msgpack/timestamp.rb
+++ b/lib/msgpack/timestamp.rb
@@ -6,23 +6,23 @@ module MessagePack
   class Timestamp # a.k.a. "TimeSpec"
     TYPE = -1 # timestamp extension type
 
-    TIMESTAMP32_MAX_SEC = 0x100000000 # 32-bit unsigned int
-    TIMESTAMP64_MAX_SEC = 0x400000000 # 34-bit unsigned int
+    TIMESTAMP32_MAX_SEC = (1 << 32) - 1
+    TIMESTAMP64_MAX_SEC = (1 << 34) - 1
 
     def self.from_msgpack_ext(data)
       case data.length
       when 4
-        # timestamp32 = (uint32be)
+        # timestamp32 (sec: uint32be)
         sec = data.unpack1('L>')
         new(sec, 0)
       when 8
-        # timestamp64 = (uint32be, uint32be)
+        # timestamp64 (nsec: uint30be, sec: uint34be)
         n, s = data.unpack('L>2')
-        sec = (n & 0x3) * 0x100000000 + s
+        sec = ((n & 0b11) << 32) | s
         nsec = n >> 2
         new(sec, nsec)
       when 12
-        # timestam96 = (uint32be, int64be)
+        # timestam96 (nsec: uint32be, sec: int64be)
         nsec, sec = data.unpack('L>q>')
         new(sec, nsec)
       else
@@ -31,18 +31,18 @@ module MessagePack
     end
 
     def self.to_msgpack_ext(sec, nsec)
-      if sec >= 0 && nsec >= 0 && sec < TIMESTAMP64_MAX_SEC
-        if nsec === 0 && sec < TIMESTAMP32_MAX_SEC
-          # timestamp32 = (uint32be)
+      if sec >= 0 && nsec >= 0 && sec <= TIMESTAMP64_MAX_SEC
+        if nsec === 0 && sec <= TIMESTAMP32_MAX_SEC
+          # timestamp32 = (sec: uint32be)
           [sec].pack('L>')
         else
-          # timestamp64 (uint32be, uint32be)
+          # timestamp64 (nsec: uint30be, sec: uint34be)
           sec_high = sec << 32
           sec_low = sec & 0xffffffff
-          [(nsec << 2) | (sec_high & 0x3), sec_low].pack('L>2')
+          [(nsec << 2) | (sec_high & 0b11), sec_low].pack('L>2')
         end
       else
-        # timestamp96 (uint32be, int64be)
+        # timestamp96 (nsec: uint32be, sec: int64be)
         [nsec, sec].pack('L>q>')
       end
     end

--- a/lib/msgpack/timestamp.rb
+++ b/lib/msgpack/timestamp.rb
@@ -19,7 +19,7 @@ module MessagePack
       case data.length
       when 4
         # timestamp32 (sec: uint32be)
-        sec = data.unpack1('L>')
+        sec, = data.unpack('L>')
         new(sec, 0)
       when 8
         # timestamp64 (nsec: uint30be, sec: uint34be)

--- a/lib/msgpack/timestamp.rb
+++ b/lib/msgpack/timestamp.rb
@@ -13,7 +13,7 @@ module MessagePack
       case data.length
       when 4
         # timestamp32 = (uint32be)
-        sec = data.unpack('L>').first
+        sec = data.unpack1('L>')
         new(sec, 0)
       when 8
         # timestamp64 = (uint32be, uint32be)

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -4,12 +4,33 @@ require 'spec_helper'
 
 describe MessagePack::Timestamp do
 
-  describe 'DefaultFactory' do
+  describe 'register_type with Time' do
+    let(:factory) do
+      factory = MessagePack::Factory.new
+      factory.register_type(MessagePack::Timestamp::TYPE, Time)
+      factory
+    end
+
     let(:time) { Time.local(2019, 6, 17, 1, 2, 3, 123_456) }
     it 'serializes and deserializes Time' do
-      packed = MessagePack.pack(time)
-      unpacked = MessagePack.unpack(packed)
+      packed = factory.pack(time)
+      unpacked = factory.unpack(packed)
       expect(unpacked).to eq(time)
+    end
+  end
+
+  describe 'register_type with MessagePack::Timestamp' do
+    let(:factory) do
+      factory = MessagePack::Factory.new
+      factory.register_type(MessagePack::Timestamp::TYPE, MessagePack::Timestamp)
+      factory
+    end
+
+    let(:timestamp) { MessagePack::Timestamp.new(Time.now.tv_sec, 123_456_789) }
+    it 'serializes and deserializes MessagePack::Timestamp' do
+      packed = factory.pack(timestamp)
+      unpacked = factory.unpack(packed)
+      expect(unpacked).to eq(timestamp)
     end
   end
 

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -3,11 +3,15 @@
 require 'spec_helper'
 
 describe MessagePack::Timestamp do
-
   describe 'register_type with Time' do
     let(:factory) do
       factory = MessagePack::Factory.new
-      factory.register_type(MessagePack::Timestamp::TYPE, Time)
+      factory.register_type(
+        MessagePack::Timestamp::TYPE,
+        Time,
+        packer: MessagePack::Time::Packer,
+        unpacker: MessagePack::Time::Unpacker
+      )
       factory
     end
 

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -5,11 +5,10 @@ require 'spec_helper'
 describe MessagePack::Timestamp do
 
   describe 'DefaultFactory' do
-    let(:time) { Time.gm(2019, 6, 17, 1, 2, 3, 123_456.789) }
+    let(:time) { Time.local(2019, 6, 17, 1, 2, 3, 123_456) }
     it 'serializes and deserializes Time' do
       packed = MessagePack.pack(time)
       unpacked = MessagePack.unpack(packed)
-
       expect(unpacked).to eq(time)
     end
   end

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -3,12 +3,17 @@
 require 'spec_helper'
 
 describe MessagePack::Timestamp do
-  # describe '#dump and #load' do
-  #   it 'is alias as pack and unpack' do
-  #     packed = subject.pack(time)
-  #     expect(subject.unpack(packed)).to be == time
-  #   end
-  # end
+
+  describe 'DefaultFactory' do
+    let(:time) { Time.now }
+
+    it 'serializes and deserializes Time' do
+      packed = MessagePack.pack(time)
+      unpacked = MessagePack.unpack(packed)
+
+      expect(unpacked).to eq(time)
+    end
+  end
 
   describe 'timestamp32' do
     it 'handles [1, 0]' do
@@ -49,17 +54,6 @@ describe MessagePack::Timestamp do
       unpacked = MessagePack::Timestamp.from_msgpack_ext(payload)
 
       expect(unpacked).to eq(t)
-    end
-  end
-
-  describe 'factory' do
-    let(:time) { Time.now }
-
-    it 'serializes and deserializes Time with DefaultFactory' do
-      packed = MessagePack.pack(time)
-      unpacked = MessagePack.unpack(packed)
-
-      expect(unpacked).to eq(time)
     end
   end
 end

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -5,8 +5,7 @@ require 'spec_helper'
 describe MessagePack::Timestamp do
 
   describe 'DefaultFactory' do
-    let(:time) { Time.now }
-
+    let(:time) { Time.gm(2019, 6, 17, 1, 2, 3, 123_456.789) }
     it 'serializes and deserializes Time' do
       packed = MessagePack.pack(time)
       unpacked = MessagePack.unpack(packed)

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -1,4 +1,5 @@
-# frozen_string_literal
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe MessagePack::Timestamp do
@@ -10,35 +11,55 @@ describe MessagePack::Timestamp do
   # end
 
   describe 'timestamp32' do
-    it "serializes and deserializes MessagePack::Timestamp" do
+    it 'handles [1, 0]' do
       t = MessagePack::Timestamp.new(1, 0)
 
-      payload = t.to_msgpack_payload
-      unpacked = MessagePack::Timestamp.from_payload(payload)
+      payload = t.to_msgpack_ext
+      unpacked = MessagePack::Timestamp.from_msgpack_ext(payload)
 
       expect(unpacked).to eq(t)
     end
   end
 
   describe 'timestamp64' do
-    it "serializes and deserializes MessagePack::Timestamp" do
+    it 'handles [1, 1]' do
       t = MessagePack::Timestamp.new(1, 1)
 
-      payload = t.to_msgpack_payload
-      unpacked = MessagePack::Timestamp.from_payload(payload)
+      payload = t.to_msgpack_ext
+      unpacked = MessagePack::Timestamp.from_msgpack_ext(payload)
 
       expect(unpacked).to eq(t)
     end
   end
 
   describe 'timestamp96' do
-    it "serializes and deserializes MessagePack::Timestamp" do
+    it 'handles [-1, 0]' do
       t = MessagePack::Timestamp.new(-1, 0)
 
-      payload = t.to_msgpack_payload
-      unpacked = MessagePack::Timestamp.from_payload(payload)
+      payload = t.to_msgpack_ext
+      unpacked = MessagePack::Timestamp.from_msgpack_ext(payload)
 
       expect(unpacked).to eq(t)
+    end
+
+    it 'handles [-1, 999_999_999]' do
+      t = MessagePack::Timestamp.new(-1, 999_999_999)
+
+      payload = t.to_msgpack_ext
+      unpacked = MessagePack::Timestamp.from_msgpack_ext(payload)
+
+      expect(unpacked).to eq(t)
+    end
+  end
+
+  describe 'factory' do
+    let(:time) { Time.now }
+
+    it 'serializes and deserializes Time with DefaultFactory' do
+      packed = MessagePack.pack(time)
+      unpacked = MessagePack.unpack(packed)
+
+      expect(unpacked).to eq(time)
     end
   end
 end

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal
+require 'spec_helper'
+
+describe MessagePack::Timestamp do
+  # describe '#dump and #load' do
+  #   it 'is alias as pack and unpack' do
+  #     packed = subject.pack(time)
+  #     expect(subject.unpack(packed)).to be == time
+  #   end
+  # end
+
+  describe 'timestamp32' do
+    it "serializes and deserializes MessagePack::Timestamp" do
+      t = MessagePack::Timestamp.new(1, 0)
+
+      payload = t.to_msgpack_payload
+      unpacked = MessagePack::Timestamp.from_payload(payload)
+
+      expect(unpacked).to eq(t)
+    end
+  end
+
+  describe 'timestamp64' do
+    it "serializes and deserializes MessagePack::Timestamp" do
+      t = MessagePack::Timestamp.new(1, 1)
+
+      payload = t.to_msgpack_payload
+      unpacked = MessagePack::Timestamp.from_payload(payload)
+
+      expect(unpacked).to eq(t)
+    end
+  end
+
+  describe 'timestamp96' do
+    it "serializes and deserializes MessagePack::Timestamp" do
+      t = MessagePack::Timestamp.new(-1, 0)
+
+      payload = t.to_msgpack_payload
+      unpacked = MessagePack::Timestamp.from_payload(payload)
+
+      expect(unpacked).to eq(t)
+    end
+  end
+end

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -3,6 +3,14 @@
 require 'spec_helper'
 
 describe MessagePack::Timestamp do
+  describe 'malformed format' do
+    it do
+      expect do
+        MessagePack::Timestamp.from_msgpack_ext([0xd4, 0x00].pack("C*"))
+      end.to raise_error(MessagePack::MalformedFormatError)
+    end
+  end
+
   describe 'register_type with Time' do
     let(:factory) do
       factory = MessagePack::Factory.new


### PR DESCRIPTION
This PR implements the timestamp type of MessagePack: timestamp32, imestamp64, and timestamp96. It also registers Time as the timestamp type for DefaultFactory.

## MessagePack::Timestamp class

This is the core logic for the timestamp type.

This is independent from the built-in Time class because  I'll  use the timestamp type in a Rails app,  overriding it by `MessagePack::DefaultFactory.register_type(MessagePack::TImestamp::TYPE, ActiveSupport::TimeWithZone)`.

## Default behavior

This PR does not change the default behavior because it is not a trivial thing.

However, `factory.register_type(-1, Time)` is tested.

cf. d31e669

## Specification

https://github.com/msgpack/msgpack/blob/master/spec.md