### PR TITLE
Fix misspelled word: Unpcker -> Unpacker

### DIFF
--- a/doclib/msgpack/time.rb
+++ b/doclib/msgpack/time.rb
@@ -15,7 +15,7 @@ module MessagePack
     }
 
     # An unpacker function that unpacks a MessagePack timestamp to a Time instance.
-    Unpcker = lambda { |time|
+    Unpacker = lambda { |time|
       # ...
     }
   end


### PR DESCRIPTION
I noticed that `Unpacker` was not spelled consistently while going through the diff of the last release.