### PR TITLE
Fix unnecessary T_HASH check

### DIFF
--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -77,9 +77,6 @@ VALUE MessagePack_Unpacker_initialize(int argc, VALUE* argv, VALUE self)
         VALUE v = argv[0];
         if(rb_type(v) == T_HASH) {
             options = v;
-            if(rb_type(options) != T_HASH) {
-                rb_raise(rb_eArgError, "expected Hash but found %s.", rb_obj_classname(options));
-            }
         } else {
             io = v;
         }


### PR DESCRIPTION
### Goal

Resolves https://github.com/msgpack/msgpack-ruby/issues/173

I could be mistaken but there seems to be an unnecessary double-check for `T_HASH` here:

https://github.com/msgpack/msgpack-ruby/blob/b48f9580bfd33be6a86652f10a41bd691a7d0c91/ext/msgpack/unpacker_class.c#L78-L80

Why is the second check required when we've already tested the type of `v` against `T_HASH`, then only rebound it to `options` ? 

### Approach

Simply remove the (seemingly) unnecessary second-check: https://github.com/msgpack/msgpack-ruby/commit/0b1bf902375283985fb0963143e5f9528b2767df

### Attn

Feel free to merge if I'm correct, otherwise: I'm just interested to learn why this check was required :p 
