### PR TITLE
Address Rubocop Issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@
 # versions of RuboCop, may require this file to be generated again.
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 # Offense count: 3
 Lint/AmbiguousOperator:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,17 @@ before_install:
 # http://rubies.travis-ci.org/
 matrix:
   include:
-    - rvm: 2.3.8
-      os: linux
     - rvm: 2.4.5
       os: linux
-    - rvm: 2.5.3
+    - rvm: 2.5.8
       os: linux
-    - rvm: 2.6.1
+    - rvm: 2.6.6
       os: linux
-    - rvm: 2.6.1
+    - rvm: 2.6.6
       os: osx
-    - rvm: ruby-head
+    - rvm: 2.7.1
       os: linux
-    - rvm: jruby-9.1.9.0
+    - rvm: ruby-head
       os: linux
     - rvm: jruby-head
       os: linux

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 ## enable this line to run benchmarks
 # gem "viiite"
 
-gem "rubocop"
+gem "rubocop", "~> 0.82.0"
 gem "simplecov"


### PR DESCRIPTION
Rubocop is a fast-moving tool that incorporates many breaking changes in version releases often. The `.rubocop.yml` file in the `msgpack` gem and the open-ended dependency definition in the `Gemfile` poses problems for developers building with newer versions of Rubocop and `msgpack`.

Applications with `msgpack` as it currently stands, if they don't explicitly exclude `vendor/bundle/**/*` in their `AllCops` exclusions will experience the following error:

```
Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in vendor/bundle/ruby/2.5.0/gems/msgpack-1.3.3/.rubocop.yml). 2.3-compatible analysis was dropped after version 0.82.
Supported versions: 2.4, 2.5, 2.6, 2.7
```

This fix does two things:

* Update the `TargetedRubyVersion` to the minimum supported version, which is 2.4
* Restrict the rubocop version in the Gemfile to the current version, so no unintended upgrades are performed that introduce breaking changes without realizing it. This is the recommendation in [Rubocop's installation guide](https://github.com/rubocop-hq/rubocop/blob/master/README.md). 