### PR TITLE
Lint/Eval has the wrong namespace - should be Security

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Lint/AssignmentInCondition:
   Enabled: false
 
 # Offense count: 1
-Lint/Eval:
+Security/Eval:
   Enabled: false
 
 # Offense count: 3


### PR DESCRIPTION
### Description

The v1.3.3 tag is raising a warning on Rubocop with the message: "Lint/Eval has the wrong namespace - should be Security". This PR fixes it.

```
gemfiles/vendor/bundle/ruby/2.5.0/gems/msgpack-1.3.3/.rubocop.yml: Lint/Eval has the wrong namespace - should be Security
Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in gemfiles/vendor/bundle/ruby/2.5.0/gems/msgpack-1.3.3/.rubocop.yml). 2.3-compatible analysis was dropped after version 0.81.
Supported versions: 2.4, 2.5, 2.6, 2.7, 2.8
```

### References