### PR TITLE
[Rubocop] 51 files inspected, 1646 offenses detected

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,18 @@ Lint/UnusedMethodArgument:
 # Offense count: 128
 Lint/Void:
   Enabled: false
+
+Layout/LineLength: # Line is too long
+  Enabled: false
+
+Metrics/BlockLength: # Block has too many lines.
+  Enabled: false
+
+Metrics/MethodLength: # Method has too many lines.
+  Enabled: false
+
+Naming/MethodParameterName: # Method parameter must be at least 3 characters long.
+  Enabled: false
+
+Style/FrozenStringLiteralComment: # Missing frozen string literal comment
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 ## enable this line to run benchmarks
 # gem "viiite"
 
-gem "rubocop", "~> 0.82.0"
-gem "simplecov"
+gem 'rubocop', '~> 0.82.0'
+gem 'simplecov'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
@@ -8,22 +7,22 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 require 'yard'
 
-task :spec => :compile
+task spec: :compile
 
 desc 'Run RSpec code examples and measure coverage'
 task :coverage do |t|
   ENV['SIMPLE_COV'] = '1'
-  Rake::Task["spec"].invoke
+  Rake::Task['spec'].invoke
 end
 
 desc 'Generate YARD document'
 YARD::Rake::YardocTask.new(:doc) do |t|
-  t.files   = ['lib/msgpack/version.rb','doclib/**/*.rb']
+  t.files   = ['lib/msgpack/version.rb', 'doclib/**/*.rb']
   t.options = []
   t.options << '--debug' << '--verbose' if $trace
 end
 
-spec = eval File.read("msgpack.gemspec")
+spec = eval File.read('msgpack.gemspec')
 
 if RUBY_PLATFORM =~ /java/
   require 'rake/javaextensiontask'
@@ -45,25 +44,24 @@ else
     ext.cross_compile = true
     ext.lib_dir = File.join(*['lib', 'msgpack', ENV['FAT_DIR']].compact)
     # cross_platform names are of MRI's platform name
-    ext.cross_platform = ['x86-mingw32', 'x64-mingw32']
+    ext.cross_platform = %w[x86-mingw32 x64-mingw32]
   end
 end
 
-test_pattern = case
-               when RUBY_PLATFORM =~ /java/ then 'spec/{,jruby/}*_spec.rb'
-               when RUBY_ENGINE =~ /rbx/ then 'spec/*_spec.rb'
+test_pattern = if RUBY_PLATFORM =~ /java/ then 'spec/{,jruby/}*_spec.rb'
+               elsif RUBY_ENGINE =~ /rbx/ then 'spec/*_spec.rb'
                else 'spec/{,cruby/}*_spec.rb' # MRI
                end
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = ["-c", "-f progress"]
-  t.rspec_opts << "-Ilib"
+  t.rspec_opts = ['-c', '-f progress']
+  t.rspec_opts << '-Ilib'
   t.pattern = test_pattern
   t.verbose = true
 end
 
 namespace :build do
   desc 'Build gem for JRuby after cleaning'
-  task :java => [:clean, :spec, :build]
+  task java: %i[clean spec build]
 
   desc 'Build gems for Windows per rake-compiler-dock'
   task :windows do
@@ -75,4 +73,4 @@ end
 
 CLEAN.include('lib/msgpack/msgpack.*')
 
-task :default => [:spec, :build, :doc]
+task default: %i[spec build doc]

--- a/bench/pack.rb
+++ b/bench/pack.rb
@@ -1,13 +1,13 @@
 require 'viiite'
 require 'msgpack'
 
-data = { 'hello' => 'world', 'nested' => ['structure', {value: 42}] }
-data_sym = { hello: 'world', nested: ['structure', {value: 42}] }
+data = { 'hello' => 'world', 'nested' => ['structure', { value: 42 }] }
+data_sym = { hello: 'world', nested: ['structure', { value: 42 }] }
 
-data = MessagePack.pack(:hello => 'world', :nested => ['structure', {:value => 42}])
+data = MessagePack.pack(hello: 'world', nested: ['structure', { value: 42 }])
 
 Viiite.bench do |b|
-  b.range_over([10_000, 100_000, 1000_000], :runs) do |runs|
+  b.range_over([10_000, 100_000, 1_000_000], :runs) do |runs|
     b.report(:strings) do
       runs.times do
         MessagePack.pack(data)

--- a/bench/pack_log.rb
+++ b/bench/pack_log.rb
@@ -13,11 +13,11 @@ data_structure = {
   'status' => 200,
   'bytes' => 2326,
   'referer' => 'http://www.example.com/start.html',
-  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
+  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)'
 }
 
 Viiite.bench do |b|
-  b.range_over([10_000, 100_000, 1000_000], :runs) do |runs|
+  b.range_over([10_000, 100_000, 1_000_000], :runs) do |runs|
     b.report(:plain) do
       runs.times do
         MessagePack.pack(data_plain)

--- a/bench/pack_log_long.rb
+++ b/bench/pack_log_long.rb
@@ -15,7 +15,7 @@ data_structure = {
   'status' => 200,
   'bytes' => 2326,
   'referer' => 'http://www.example.com/start.html',
-  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
+  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)'
 }
 
 seconds = 3600 # 1 hour
@@ -29,16 +29,16 @@ Viiite.bench do |b|
         t = Thread.new do
           packs = 0
           while Time.now < end_at
-            10000.times do
+            10_000.times do
               MessagePack.pack(data_plain)
             end
-            packs += 10000
+            packs += 10_000
           end
           packs
         end
         ths.push t
       end
-      sum = ths.reduce(0){|r,t| r + t.value }
+      sum = ths.reduce(0) { |r, t| r + t.value }
       puts "MessagePack.pack, plain, #{threads} threads: #{sum} times, #{sum / seconds} times/second."
     end
 
@@ -49,16 +49,16 @@ Viiite.bench do |b|
         t = Thread.new do
           packs = 0
           while Time.now < end_at
-            10000.times do
+            10_000.times do
               MessagePack.pack(data_structure)
             end
-            packs += 10000
+            packs += 10_000
           end
           packs
         end
         ths.push t
       end
-      sum = ths.reduce(0){|r,t| r + t.value }
+      sum = ths.reduce(0) { |r, t| r + t.value }
       puts "MessagePack.pack, structured, #{threads} threads: #{sum} times, #{sum / seconds} times/second."
     end
   end

--- a/bench/pack_symbols.rb
+++ b/bench/pack_symbols.rb
@@ -6,7 +6,7 @@ data = :symbol
 Viiite.bench do |b|
   b.variation_point :branch, `git rev-parse --abbrev-ref HEAD`
 
-  b.range_over([:symbol, :none], :reg_type) do |reg_type|
+  b.range_over(%i[symbol none], :reg_type) do |reg_type|
     packer = MessagePack::Packer.new
     packer.register_type(0x00, Symbol, :to_msgpack_ext) if reg_type == :symbol
 

--- a/bench/unpack.rb
+++ b/bench/unpack.rb
@@ -1,10 +1,10 @@
 require 'viiite'
 require 'msgpack'
 
-data = MessagePack.pack(:hello => 'world', :nested => ['structure', {:value => 42}])
+data = MessagePack.pack(hello: 'world', nested: ['structure', { value: 42 }])
 
 Viiite.bench do |b|
-  b.range_over([10_000, 100_000, 1000_000], :runs) do |runs|
+  b.range_over([10_000, 100_000, 1_000_000], :runs) do |runs|
     b.report(:strings) do
       runs.times do
         MessagePack.unpack(data)
@@ -12,7 +12,7 @@ Viiite.bench do |b|
     end
 
     b.report(:symbols) do
-      options = {:symbolize_keys => true}
+      options = { symbolize_keys: true }
       runs.times do
         MessagePack.unpack(data, options)
       end

--- a/bench/unpack_log.rb
+++ b/bench/unpack_log.rb
@@ -4,21 +4,21 @@ require 'msgpack'
 data_plain = MessagePack.pack({ 'message' => '127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"' })
 
 data_structure = MessagePack.pack({
-  'remote_host' => '127.0.0.1',
-  'remote_user' => '-',
-  'date' => '10/Oct/2000:13:55:36 -0700',
-  'request' => 'GET /apache_pb.gif HTTP/1.0',
-  'method' => 'GET',
-  'path' => '/apache_pb.gif',
-  'protocol' => 'HTTP/1.0',
-  'status' => 200,
-  'bytes' => 2326,
-  'referer' => 'http://www.example.com/start.html',
-  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
-})
+                                    'remote_host' => '127.0.0.1',
+                                    'remote_user' => '-',
+                                    'date' => '10/Oct/2000:13:55:36 -0700',
+                                    'request' => 'GET /apache_pb.gif HTTP/1.0',
+                                    'method' => 'GET',
+                                    'path' => '/apache_pb.gif',
+                                    'protocol' => 'HTTP/1.0',
+                                    'status' => 200,
+                                    'bytes' => 2326,
+                                    'referer' => 'http://www.example.com/start.html',
+                                    'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)'
+                                  })
 
 Viiite.bench do |b|
-  b.range_over([10_000, 100_000, 1000_000], :runs) do |runs|
+  b.range_over([10_000, 100_000, 1_000_000], :runs) do |runs|
     b.report(:plain) do
       runs.times do
         MessagePack.unpack(data_plain)

--- a/bench/unpack_log_long.rb
+++ b/bench/unpack_log_long.rb
@@ -4,21 +4,21 @@ require 'viiite'
 require 'msgpack'
 
 data_plain = MessagePack.pack({
-    'message' => '127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"'
-})
+                                'message' => '127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"'
+                              })
 data_structure = MessagePack.pack({
-  'remote_host' => '127.0.0.1',
-  'remote_user' => '-',
-  'date' => '10/Oct/2000:13:55:36 -0700',
-  'request' => 'GET /apache_pb.gif HTTP/1.0',
-  'method' => 'GET',
-  'path' => '/apache_pb.gif',
-  'protocol' => 'HTTP/1.0',
-  'status' => 200,
-  'bytes' => 2326,
-  'referer' => 'http://www.example.com/start.html',
-  'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)',
-})
+                                    'remote_host' => '127.0.0.1',
+                                    'remote_user' => '-',
+                                    'date' => '10/Oct/2000:13:55:36 -0700',
+                                    'request' => 'GET /apache_pb.gif HTTP/1.0',
+                                    'method' => 'GET',
+                                    'path' => '/apache_pb.gif',
+                                    'protocol' => 'HTTP/1.0',
+                                    'status' => 200,
+                                    'bytes' => 2326,
+                                    'referer' => 'http://www.example.com/start.html',
+                                    'agent' => 'Mozilla/4.08 [en] (Win98; I ;Nav)'
+                                  })
 
 seconds = 3600 # 1 hour
 
@@ -31,16 +31,16 @@ Viiite.bench do |b|
         t = Thread.new do
           packs = 0
           while Time.now < end_at
-            10000.times do
+            10_000.times do
               MessagePack.unpack(data_plain)
             end
-            packs += 10000
+            packs += 10_000
           end
           packs
         end
         ths.push t
       end
-      sum = ths.reduce(0){|r,t| r + t.value }
+      sum = ths.reduce(0) { |r, t| r + t.value }
       puts "MessagePack.unpack, plain, #{threads} threads: #{sum} times, #{sum / seconds} times/second."
     end
 
@@ -51,16 +51,16 @@ Viiite.bench do |b|
         t = Thread.new do
           packs = 0
           while Time.now < end_at
-            10000.times do
+            10_000.times do
               MessagePack.unpack(data_structure)
             end
-            packs += 10000
+            packs += 10_000
           end
           packs
         end
         ths.push t
       end
-      sum = ths.reduce(0){|r,t| r + t.value }
+      sum = ths.reduce(0) { |r, t| r + t.value }
       puts "MessagePack.unpack, structured, #{threads} threads: #{sum} times, #{sum / seconds} times/second."
     end
   end

--- a/doclib/msgpack.rb
+++ b/doclib/msgpack.rb
@@ -1,4 +1,3 @@
-
 module MessagePack
   #
   # Serializes an object into an IO or String.
@@ -16,8 +15,7 @@ module MessagePack
   #
   # See Packer#initialize for supported options.
   #
-  def self.dump(obj)
-  end
+  def self.dump(obj); end
 
   #
   # Serializes an object into an IO or String. Alias of dump.
@@ -35,8 +33,7 @@ module MessagePack
   #
   # See Packer#initialize for supported options.
   #
-  def self.pack(obj)
-  end
+  def self.pack(obj); end
 
   #
   # Deserializes an object from an IO or String.
@@ -53,8 +50,7 @@ module MessagePack
   #
   # See Unpacker#initialize for supported options.
   #
-  def self.load(src, options={})
-  end
+  def self.load(src, options = {}); end
 
   #
   # Deserializes an object from an IO or String. Alias of load.
@@ -71,8 +67,7 @@ module MessagePack
   #
   # See Unpacker#initialize for supported options.
   #
-  def self.unpack(src, options={})
-  end
+  def self.unpack(src, options = {}); end
 
   #
   # An instance of Factory class. DefaultFactory is also used
@@ -84,4 +79,3 @@ module MessagePack
   #
   DefaultFactory = Factory.new
 end
-

--- a/doclib/msgpack/buffer.rb
+++ b/doclib/msgpack/buffer.rb
@@ -1,5 +1,4 @@
 module MessagePack
-
   class Buffer
     #
     # Creates a MessagePack::Buffer instance.
@@ -22,24 +21,21 @@ module MessagePack
     # * *:read_reference_threshold* the threshold size to enable zero-copy deserialize optimization. Read strings longer than this threshold will refer the original string instead of copying it. (default: 256) (supported in MRI only)
     # * *:write_reference_threshold* the threshold size to enable zero-copy serialize optimization. The buffer refers written strings longer than this threshold instead of copying it. (default: 524288) (supported in MRI only)
     #
-    def initialize(*args)
-    end
+    def initialize(*args); end
 
     #
     # Makes the buffer empty
     #
     # @return nil
     #
-    def clear
-    end
+    def clear; end
 
     #
     # Returns byte size of the buffer.
     #
     # @return nil
     #
-    def size
-    end
+    def size; end
 
     #
     # Returns _true_ if the buffer is empty.
@@ -47,8 +43,7 @@ module MessagePack
     #
     # @return [Boolean]
     #
-    def empty?
-    end
+    def empty?; end
 
     #
     # Appends the given data to the buffer.
@@ -56,8 +51,7 @@ module MessagePack
     # @param data [String]
     # @return [Integer] byte size written
     #
-    def write(data)
-    end
+    def write(data); end
 
     #
     # Appends the given data to the buffer.
@@ -65,8 +59,7 @@ module MessagePack
     # @param data [String]
     # @return [Buffer] self
     #
-    def <<(data)
-    end
+    def <<(data); end
 
     #
     # Consumes _n_ bytes from the head of the buffer and returns consumed data.
@@ -86,8 +79,7 @@ module MessagePack
     #
     # @return [String]
     #
-    def read(n)
-    end
+    def read(n); end
 
     #
     # Consumes _n_ bytes from the head of the buffer and returns consumed data.
@@ -107,8 +99,7 @@ module MessagePack
     #
     # @return [String]
     #
-    def read_all(n, buffer=nil)
-    end
+    def read_all(n, buffer = nil); end
 
     #
     # Consumes _n_ bytes from the head of the buffer.
@@ -119,8 +110,7 @@ module MessagePack
     # @param n [Integer] byte size to skip
     # @return [Integer] byte size actually skipped
     #
-    def skip(n)
-    end
+    def skip(n); end
 
     #
     # Consumes _n_ bytes from the head of the buffer.
@@ -130,8 +120,7 @@ module MessagePack
     # @param n [Integer] byte size to skip
     # @return [Buffer] self
     #
-    def skip_all(n)
-    end
+    def skip_all(n); end
 
     #
     # Returns all data in the buffer as a string.
@@ -139,8 +128,7 @@ module MessagePack
     #
     # @return [String]
     #
-    def to_str
-    end
+    def to_str; end
 
     #
     # Returns content of the buffer as an array of strings.
@@ -150,8 +138,7 @@ module MessagePack
     #
     # @return [Array] array of strings
     #
-    def to_a
-    end
+    def to_a; end
 
     #
     # Internal io
@@ -166,8 +153,7 @@ module MessagePack
     #
     # @return [Buffer] self
     #
-    def flush
-    end
+    def flush; end
 
     #
     # Closes internal IO if its set.
@@ -175,8 +161,7 @@ module MessagePack
     #
     # @return nil
     #
-    def close
-    end
+    def close; end
 
     #
     # Writes all of data in the internal buffer into the given IO.
@@ -186,8 +171,6 @@ module MessagePack
     # @param io [IO]
     # @return [Integer] byte size of written data
     #
-    def write_to(io)
-    end
+    def write_to(io); end
   end
-
 end

--- a/doclib/msgpack/core_ext.rb
+++ b/doclib/msgpack/core_ext.rb
@@ -1,12 +1,10 @@
-
 class NilClass
   #
   # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
 class TrueClass
@@ -15,8 +13,7 @@ class TrueClass
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
 class FalseClass
@@ -25,28 +22,25 @@ class FalseClass
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
-class Fixnum < Integer
+class Fixnum < Integer # rubocop:disable Lint/UnifiedInteger
   #
   # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
-class Bignum < Integer
+class Bignum < Integer # rubocop:disable Lint/UnifiedInteger
   #
   # Same as MessagePack.to_msgpack(self[, packer]).
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
 class Float < Numeric
@@ -55,8 +49,7 @@ class Float < Numeric
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
 class String
@@ -65,8 +58,7 @@ class String
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
 class Array
@@ -75,8 +67,7 @@ class Array
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
 class Hash
@@ -85,8 +76,7 @@ class Hash
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
 
 class Symbol
@@ -95,7 +85,5 @@ class Symbol
   #
   # @return [String] serialized data
   #
-  def to_msgpack(packer=nil)
-  end
+  def to_msgpack(packer = nil); end
 end
-

--- a/doclib/msgpack/error.rb
+++ b/doclib/msgpack/error.rb
@@ -1,5 +1,4 @@
 module MessagePack
-
   class UnpackError < StandardError
   end
 

--- a/doclib/msgpack/extension_value.rb
+++ b/doclib/msgpack/extension_value.rb
@@ -1,5 +1,4 @@
 module MessagePack
-
   #
   # MessagePack::ExtensionValue is a struct to represent unknown ext type object.
   # Its contents are accessed by type and payload (messagepack bytes representation) methods.

--- a/doclib/msgpack/factory.rb
+++ b/doclib/msgpack/factory.rb
@@ -7,8 +7,7 @@ module MessagePack
     #
     # Creates a MessagePack::Factory instance
     #
-    def initialize
-    end
+    def initialize; end
 
     #
     # Creates a MessagePack::Packer instance, which has ext types already registered.
@@ -16,8 +15,7 @@ module MessagePack
     #
     # See also Packer#initialize for options.
     #
-    def packer(*args)
-    end
+    def packer(*args); end
 
     #
     # Serialize the passed value
@@ -31,8 +29,7 @@ module MessagePack
     #
     # See Packer#initialize for supported options.
     #
-    def dump(obj, options={})
-    end
+    def dump(obj, options = {}); end
     alias pack dump
 
     #
@@ -41,8 +38,7 @@ module MessagePack
     #
     # See also Unpacker#initialize for options.
     #
-    def unpacker(*args)
-    end
+    def unpacker(*args); end
 
     #
     # Deserializes an object from the string or io and returns it.
@@ -57,8 +53,7 @@ module MessagePack
     #
     # See Unpacker#initialize for supported options.
     #
-    def load(data, options={})
-    end
+    def load(data, options = {}); end
     alias unpack load
 
     #
@@ -76,8 +71,7 @@ module MessagePack
     # * *:packer* specify symbol or proc object for packer
     # * *:unpacker* specify symbol or proc object for unpacker
     #
-    def register_type(type, klass, options={})
-    end
+    def register_type(type, klass, options = {}); end
 
     #
     # Returns a list of registered types, ordered by type id.
@@ -85,8 +79,7 @@ module MessagePack
     # @param selector [Symbol] specify to list types registered for :packer, :unpacker or :both (default)
     # @return Array
     #
-    def registered_types(selector=:both)
-    end
+    def registered_types(selector = :both); end
 
     #
     # Returns true/false which indicate specified class or type id is registered or not.
@@ -95,7 +88,6 @@ module MessagePack
     # @param selector [Symbol] specify to check for :packer, :unpacker or :both (default)
     # @return true or false
     #
-    def type_registered?(klass_or_type, selector=:both)
-    end
+    def type_registered?(klass_or_type, selector = :both); end
   end
 end

--- a/doclib/msgpack/packer.rb
+++ b/doclib/msgpack/packer.rb
@@ -1,5 +1,4 @@
 module MessagePack
-
   #
   # MessagePack::Packer is a class to serialize objects.
   #
@@ -23,8 +22,7 @@ module MessagePack
     #
     # See also Buffer#initialize for other options.
     #
-    def initialize(*args)
-    end
+    def initialize(*args); end
 
     #
     # Register a new ext type to serialize it. This method should be called with one of
@@ -43,8 +41,7 @@ module MessagePack
     #
     # @return nil
     #
-    def register_type(type, klass, method_name, &block)
-    end
+    def register_type(type, klass, method_name, &block); end
 
     #
     # Returns a list of registered types, ordered by type id.
@@ -52,8 +49,7 @@ module MessagePack
     #
     # @return Array
     #
-    def registered_types
-    end
+    def registered_types; end
 
     #
     # Returns true/false which indicate specified class or type id is registered or not.
@@ -61,8 +57,7 @@ module MessagePack
     # @param klass_or_type [Class or Fixnum] Class or type id (0-127) to be checked
     # @return true or false
     #
-    def type_registered?(klass_or_type)
-    end
+    def type_registered?(klass_or_type); end
 
     #
     # Internal buffer
@@ -80,22 +75,19 @@ module MessagePack
     # @param obj [Object] object to serialize
     # @return [Packer] self
     #
-    def write(obj)
-    end
+    def write(obj); end
 
     alias pack write
 
     #
     # Serializes a nil object. Same as write(nil).
     #
-    def write_nil
-    end
+    def write_nil; end
 
     #
     # Serializes a string object as binary data. Same as write("string".encode(Encoding::BINARY)).
     #
-    def write_bin(obj)
-    end
+    def write_bin(obj); end
 
     #
     # Write a header of an array whose size is _n_.
@@ -103,8 +95,7 @@ module MessagePack
     #
     # @return [Packer] self
     #
-    def write_array_header(n)
-    end
+    def write_array_header(n); end
 
     #
     # Write a header of an map whose size is _n_.
@@ -112,8 +103,7 @@ module MessagePack
     #
     # @return [Packer] self
     #
-    def write_map_header(n)
-    end
+    def write_map_header(n); end
 
     #
     # Write a header of a binary string whose size is _n_. Useful if you want to append large binary data without loading it into memory at once.
@@ -126,8 +116,7 @@ module MessagePack
     #
     # @return [Packer] self
     #
-    def write_bin_header(n)
-    end
+    def write_bin_header(n); end
 
     #
     # Serializes _value_ as 32-bit single precision float into internal buffer.
@@ -138,8 +127,7 @@ module MessagePack
     # @param value [Numeric]
     # @return [Packer] self
     #
-    def write_float32(value)
-    end
+    def write_float32(value); end
 
     #
     # Flushes data in the internal buffer to the internal IO. Same as _buffer.flush.
@@ -147,24 +135,21 @@ module MessagePack
     #
     # @return [Packer] self
     #
-    def flush
-    end
+    def flush; end
 
     #
     # Makes the internal buffer empty. Same as _buffer.clear_.
     #
     # @return nil
     #
-    def clear
-    end
+    def clear; end
 
     #
     # Returns size of the internal buffer. Same as buffer.size.
     #
     # @return [Integer]
     #
-    def size
-    end
+    def size; end
 
     #
     # Returns _true_ if the internal buffer is empty. Same as buffer.empty?.
@@ -172,16 +157,14 @@ module MessagePack
     #
     # @return [Boolean]
     #
-    def empty?
-    end
+    def empty?; end
 
     #
     # Returns all data in the buffer as a string. Same as buffer.to_str.
     #
     # @return [String]
     #
-    def to_str
-    end
+    def to_str; end
 
     alias to_s to_str
 
@@ -191,8 +174,7 @@ module MessagePack
     #
     # @return [Array] array of strings
     #
-    def to_a
-    end
+    def to_a; end
 
     #
     # Writes all of data in the internal buffer into the given IO. Same as buffer.write_to(io).
@@ -202,7 +184,6 @@ module MessagePack
     # @param io [IO]
     # @return [Integer] byte size of written data
     #
-    def write_to(io)
-    end
+    def write_to(io); end
   end
 end

--- a/doclib/msgpack/time.rb
+++ b/doclib/msgpack/time.rb
@@ -1,5 +1,4 @@
 module MessagePack
-
   # MessagePack::Time provides packer and unpacker functions for a timestamp type.
   # @example Setup for DefaultFactory
   #   MessagePack::DefaultFactory.register_type(

--- a/doclib/msgpack/timestamp.rb
+++ b/doclib/msgpack/timestamp.rb
@@ -16,8 +16,7 @@ module MessagePack
 
     # @param [Integer] sec
     # @param [Integer] nsec
-    def initialize(sec, nsec)
-    end
+    def initialize(sec, nsec); end
 
     # @example An unpacker implementation for the Time class
     #   lambda do |payload|
@@ -27,8 +26,7 @@ module MessagePack
     #
     # @param [String] data
     # @return [MessagePack::Timestamp]
-    def self.from_msgpack_ext(data)
-    end
+    def self.from_msgpack_ext(data); end
 
     # @example A packer implementation for the Time class
     #   unpacker = lambda do |time|
@@ -38,7 +36,6 @@ module MessagePack
     # @param [Integer] sec
     # @param [Integer] nsec
     # @return [String]
-    def self.to_msgpack_ext(sec, nsec)
-    end
+    def self.to_msgpack_ext(sec, nsec); end
   end
 end

--- a/doclib/msgpack/unpacker.rb
+++ b/doclib/msgpack/unpacker.rb
@@ -1,5 +1,4 @@
 module MessagePack
-
   #
   # MessagePack::Unpacker is a class to deserialize objects.
   #
@@ -23,8 +22,7 @@ module MessagePack
     #
     # See also Buffer#initialize for other options.
     #
-    def initialize(*args)
-    end
+    def initialize(*args); end
 
     #
     # Register a new ext type to deserialize it. This method should be called with
@@ -41,8 +39,7 @@ module MessagePack
     #
     # @return nil
     #
-    def register_type(type, klass, method_name, &block)
-    end
+    def register_type(type, klass, method_name, &block); end
 
     #
     # Returns a list of registered types, ordered by type id.
@@ -50,8 +47,7 @@ module MessagePack
     #
     # @return Array
     #
-    def registered_types
-    end
+    def registered_types; end
 
     #
     # Returns true/false which indicate specified class or type id is registered or not.
@@ -59,8 +55,7 @@ module MessagePack
     # @param klass_or_type [Class or Fixnum] Class or type id (0-127) to be checked
     # @return true or false
     #
-    def type_registered?(klass_or_type)
-    end
+    def type_registered?(klass_or_type); end
 
     #
     # Internal buffer
@@ -83,8 +78,7 @@ module MessagePack
     #
     # @return [Object] deserialized object
     #
-    def read
-    end
+    def read; end
 
     alias unpack read
 
@@ -95,8 +89,7 @@ module MessagePack
     #
     # @return nil
     #
-    def skip
-    end
+    def skip; end
 
     #
     # Deserializes a nil value if it exists and returns _true_.
@@ -107,8 +100,7 @@ module MessagePack
     #
     # @return [Boolean]
     #
-    def skip_nil
-    end
+    def skip_nil; end
 
     #
     # Read a header of an array and returns its size.
@@ -119,8 +111,7 @@ module MessagePack
     #
     # @return [Integer] size of the array
     #
-    def read_array_header
-    end
+    def read_array_header; end
 
     #
     # Reads a header of an map and returns its size.
@@ -131,8 +122,7 @@ module MessagePack
     #
     # @return [Integer] size of the map
     #
-    def read_map_header
-    end
+    def read_map_header; end
 
     #
     # Appends data into the internal buffer.
@@ -141,8 +131,7 @@ module MessagePack
     # @param data [String]
     # @return [Unpacker] self
     #
-    def feed(data)
-    end
+    def feed(data); end
 
     #
     # Repeats to deserialize objects.
@@ -157,8 +146,7 @@ module MessagePack
     # @yieldparam object [Object] deserialized object
     # @return nil
     #
-    def each(&block)
-    end
+    def each(&block); end
 
     #
     # Appends data into the internal buffer and repeats to deserialize objects.
@@ -168,16 +156,13 @@ module MessagePack
     # @yieldparam object [Object] deserialized object
     # @return nil
     #
-    def feed_each(data, &block)
-    end
+    def feed_each(data, &block); end
 
     #
     # Clears the internal buffer and resets deserialization state of the unpacker.
     #
     # @return nil
     #
-    def reset
-    end
+    def reset; end
   end
-
 end

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -1,28 +1,28 @@
 require 'mkmf'
 
-have_header("ruby/st.h")
-have_header("st.h")
-have_func("rb_str_replace", ["ruby.h"])
-have_func("rb_intern_str", ["ruby.h"])
-have_func("rb_sym2str", ["ruby.h"])
-have_func("rb_str_intern", ["ruby.h"])
-have_func("rb_block_lambda", ["ruby.h"])
-have_func("rb_hash_dup", ["ruby.h"])
-have_func("rb_hash_clear", ["ruby.h"])
+have_header('ruby/st.h')
+have_header('st.h')
+have_func('rb_str_replace', ['ruby.h'])
+have_func('rb_intern_str', ['ruby.h'])
+have_func('rb_sym2str', ['ruby.h'])
+have_func('rb_str_intern', ['ruby.h'])
+have_func('rb_block_lambda', ['ruby.h'])
+have_func('rb_hash_dup', ['ruby.h'])
+have_func('rb_hash_clear', ['ruby.h'])
 
 unless RUBY_PLATFORM.include? 'mswin'
-  $CFLAGS << %[ -I.. -Wall -O3 -g -std=gnu99]
+  $CFLAGS << %( -I.. -Wall -O3 -g -std=gnu99)
 end
-#$CFLAGS << %[ -DDISABLE_RMEM]
-#$CFLAGS << %[ -DDISABLE_RMEM_REUSE_INTERNAL_FRAGMENT]
-#$CFLAGS << %[ -DDISABLE_BUFFER_READ_REFERENCE_OPTIMIZE]
-#$CFLAGS << %[ -DDISABLE_BUFFER_READ_TO_S_OPTIMIZE]
+# $CFLAGS << %[ -DDISABLE_RMEM]
+# $CFLAGS << %[ -DDISABLE_RMEM_REUSE_INTERNAL_FRAGMENT]
+# $CFLAGS << %[ -DDISABLE_BUFFER_READ_REFERENCE_OPTIMIZE]
+# $CFLAGS << %[ -DDISABLE_BUFFER_READ_TO_S_OPTIMIZE]
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   # msgpack-ruby doesn't modify data came from RSTRING_PTR(str)
-  $CFLAGS << %[ -DRSTRING_NOT_MODIFIED]
+  $CFLAGS << %( -DRSTRING_NOT_MODIFIED)
   # Rubinius C extensions don't grab GVL while rmem is not thread safe
-  $CFLAGS << %[ -DDISABLE_RMEM]
+  $CFLAGS << %( -DDISABLE_RMEM)
 end
 
 if warnflags = CONFIG['warnflags']
@@ -30,4 +30,3 @@ if warnflags = CONFIG['warnflags']
 end
 
 create_makefile('msgpack/msgpack')
-

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -10,9 +10,7 @@ have_func('rb_block_lambda', ['ruby.h'])
 have_func('rb_hash_dup', ['ruby.h'])
 have_func('rb_hash_clear', ['ruby.h'])
 
-unless RUBY_PLATFORM.include? 'mswin'
-  $CFLAGS << %( -I.. -Wall -O3 -g -std=gnu99)
-end
+$CFLAGS << %( -I.. -Wall -O3 -g -std=gnu99) unless RUBY_PLATFORM.include? 'mswin'
 # $CFLAGS << %[ -DDISABLE_RMEM]
 # $CFLAGS << %[ -DDISABLE_RMEM_REUSE_INTERNAL_FRAGMENT]
 # $CFLAGS << %[ -DDISABLE_BUFFER_READ_REFERENCE_OPTIMIZE]

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -1,24 +1,24 @@
-require "msgpack/version"
+require 'msgpack/version'
 
-if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby" # This is same with `/java/ =~ RUBY_VERSION`
-  require "java"
-  require "msgpack/msgpack.jar"
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby' # This is same with `/java/ =~ RUBY_VERSION`
+  require 'java'
+  require 'msgpack/msgpack.jar'
   org.msgpack.jruby.MessagePackLibrary.new.load(JRuby.runtime, false)
 else
   begin
     require "msgpack/#{RUBY_VERSION[/\d+.\d+/]}/msgpack"
   rescue LoadError
-    require "msgpack/msgpack"
+    require 'msgpack/msgpack'
   end
 end
 
-require "msgpack/packer"
-require "msgpack/unpacker"
-require "msgpack/factory"
-require "msgpack/symbol"
-require "msgpack/core_ext"
-require "msgpack/timestamp"
-require "msgpack/time"
+require 'msgpack/packer'
+require 'msgpack/unpacker'
+require 'msgpack/factory'
+require 'msgpack/symbol'
+require 'msgpack/core_ext'
+require 'msgpack/timestamp'
+require 'msgpack/time'
 
 module MessagePack
   DefaultFactory = MessagePack::Factory.new
@@ -36,7 +36,7 @@ module MessagePack
 
     unpacker.full_unpack
   end
-  alias :unpack :load
+  alias unpack load
 
   module_function :load
   module_function :unpack
@@ -46,7 +46,7 @@ module MessagePack
     packer.write v
     packer.full_pack
   end
-  alias :dump :pack
+  alias dump pack
 
   module_function :pack
   module_function :dump

--- a/lib/msgpack/core_ext.rb
+++ b/lib/msgpack/core_ext.rb
@@ -103,7 +103,7 @@ class Symbol
 end
 
 if 1.class.name == 'Integer'
-  class Fixnum  # rubocop:disable Lint/UnifiedInteger
+  class Fixnum # rubocop:disable Lint/UnifiedInteger
     include MessagePack::CoreExt
 
     private

--- a/lib/msgpack/core_ext.rb
+++ b/lib/msgpack/core_ext.rb
@@ -18,6 +18,7 @@ class NilClass
   include MessagePack::CoreExt
 
   private
+
   def to_msgpack_with_packer(packer)
     packer.write_nil
     packer
@@ -28,6 +29,7 @@ class TrueClass
   include MessagePack::CoreExt
 
   private
+
   def to_msgpack_with_packer(packer)
     packer.write_true
     packer
@@ -38,6 +40,7 @@ class FalseClass
   include MessagePack::CoreExt
 
   private
+
   def to_msgpack_with_packer(packer)
     packer.write_false
     packer
@@ -48,6 +51,7 @@ class Float
   include MessagePack::CoreExt
 
   private
+
   def to_msgpack_with_packer(packer)
     packer.write_float self
     packer
@@ -58,6 +62,7 @@ class String
   include MessagePack::CoreExt
 
   private
+
   def to_msgpack_with_packer(packer)
     packer.write_string self
     packer
@@ -68,6 +73,7 @@ class Array
   include MessagePack::CoreExt
 
   private
+
   def to_msgpack_with_packer(packer)
     packer.write_array self
     packer
@@ -78,6 +84,7 @@ class Hash
   include MessagePack::CoreExt
 
   private
+
   def to_msgpack_with_packer(packer)
     packer.write_hash self
     packer
@@ -88,37 +95,41 @@ class Symbol
   include MessagePack::CoreExt
 
   private
+
   def to_msgpack_with_packer(packer)
     packer.write_symbol self
     packer
   end
 end
 
-if 1.class.name == "Integer"
-  class Integer
+if 1.class.name == 'Integer'
+  class Fixnum  # rubocop:disable Lint/UnifiedInteger
     include MessagePack::CoreExt
 
     private
+
     def to_msgpack_with_packer(packer)
       packer.write_int self
       packer
     end
   end
 else
-  class Fixnum
+  class Bignum # rubocop:disable Lint/UnifiedInteger
     include MessagePack::CoreExt
 
     private
+
     def to_msgpack_with_packer(packer)
       packer.write_int self
       packer
     end
   end
 
-  class Bignum
+  class Integer
     include MessagePack::CoreExt
 
     private
+
     def to_msgpack_with_packer(packer)
       packer.write_int self
       packer
@@ -131,6 +142,7 @@ module MessagePack
     include CoreExt
 
     private
+
     def to_msgpack_with_packer(packer)
       packer.write_extension self
       packer

--- a/lib/msgpack/factory.rb
+++ b/lib/msgpack/factory.rb
@@ -16,9 +16,7 @@ module MessagePack
           type = ary[0]
           packer_arg = ary[2]
           unpacker_arg = nil
-          if unpacker.has_key?(type) && unpacker[type][0] == klass
-            unpacker_arg = unpacker.delete(type)[2]
-          end
+          unpacker_arg = unpacker.delete(type)[2] if unpacker.has_key?(type) && unpacker[type][0] == klass
           list << { type: type, class: klass, packer: packer_arg, unpacker: unpacker_arg }
         end
 

--- a/lib/msgpack/factory.rb
+++ b/lib/msgpack/factory.rb
@@ -3,7 +3,7 @@ module MessagePack
     # see ext for other methods
 
     # [ {type: id, class: Class(or nil), packer: arg, unpacker: arg}, ... ]
-    def registered_types(selector=:both)
+    def registered_types(selector = :both)
       packer, unpacker = registered_types_internal
       # packer: Class -> [tid, proc, arg]
       # unpacker: tid -> [klass, proc, arg]
@@ -19,41 +19,41 @@ module MessagePack
           if unpacker.has_key?(type) && unpacker[type][0] == klass
             unpacker_arg = unpacker.delete(type)[2]
           end
-          list << {type: type, class: klass, packer: packer_arg, unpacker: unpacker_arg}
+          list << { type: type, class: klass, packer: packer_arg, unpacker: unpacker_arg }
         end
 
         # unpacker definition only
         unpacker.each_pair do |type, ary|
-          list << {type: type, class: ary[0], packer: nil, unpacker: ary[2]}
+          list << { type: type, class: ary[0], packer: nil, unpacker: ary[2] }
         end
 
       when :packer
         packer.each_pair do |klass, ary|
-          list << {type: ary[0], class: klass, packer: ary[2]}
+          list << { type: ary[0], class: klass, packer: ary[2] }
         end
 
       when :unpacker
         unpacker.each_pair do |type, ary|
-          list << {type: type, class: ary[0], unpacker: ary[2]}
+          list << { type: type, class: ary[0], unpacker: ary[2] }
         end
 
       else
         raise ArgumentError, "invalid selector #{selector}"
       end
 
-      list.sort{|a, b| a[:type] <=> b[:type] }
+      list.sort { |a, b| a[:type] <=> b[:type] }
     end
 
-    def type_registered?(klass_or_type, selector=:both)
+    def type_registered?(klass_or_type, selector = :both)
       case klass_or_type
       when Class
         klass = klass_or_type
-        registered_types(selector).any?{|entry| klass <= entry[:class] }
+        registered_types(selector).any? { |entry| klass <= entry[:class] }
       when Integer
         type = klass_or_type
-        registered_types(selector).any?{|entry| type == entry[:type] }
+        registered_types(selector).any? { |entry| type == entry[:type] }
       else
-        raise ArgumentError, "class or type id"
+        raise ArgumentError, 'class or type id'
       end
     end
 
@@ -69,13 +69,13 @@ module MessagePack
 
       unpacker.full_unpack
     end
-    alias :unpack :load
+    alias unpack load
 
     def dump(v, *rest)
       packer = packer(*rest)
       packer.write(v)
       packer.full_pack
     end
-    alias :pack :dump
+    alias pack dump
   end
 end

--- a/lib/msgpack/packer.rb
+++ b/lib/msgpack/packer.rb
@@ -6,22 +6,22 @@ module MessagePack
       list = []
 
       registered_types_internal.each_pair do |klass, ary|
-        list << {type: ary[0], class: klass, packer: ary[2]}
+        list << { type: ary[0], class: klass, packer: ary[2] }
       end
 
-      list.sort{|a, b| a[:type] <=> b[:type] }
+      list.sort { |a, b| a[:type] <=> b[:type] }
     end
 
     def type_registered?(klass_or_type)
       case klass_or_type
       when Class
         klass = klass_or_type
-        registered_types.any?{|entry| klass <= entry[:class] }
+        registered_types.any? { |entry| klass <= entry[:class] }
       when Integer
         type = klass_or_type
-        registered_types.any?{|entry| type == entry[:type] }
+        registered_types.any? { |entry| type == entry[:type] }
       else
-        raise ArgumentError, "class or type id"
+        raise ArgumentError, 'class or type id'
       end
     end
   end

--- a/lib/msgpack/symbol.rb
+++ b/lib/msgpack/symbol.rb
@@ -4,6 +4,6 @@ class Symbol
   end
 
   def self.from_msgpack_ext(data)
-    data.unpack('A*').first.to_sym
+    data.unpack1('A*').to_sym
   end
 end

--- a/lib/msgpack/unpacker.rb
+++ b/lib/msgpack/unpacker.rb
@@ -6,22 +6,22 @@ module MessagePack
       list = []
 
       registered_types_internal.each_pair do |type, ary|
-        list << {type: type, class: ary[0], unpacker: ary[2]}
+        list << { type: type, class: ary[0], unpacker: ary[2] }
       end
 
-      list.sort{|a, b| a[:type] <=> b[:type] }
+      list.sort { |a, b| a[:type] <=> b[:type] }
     end
 
     def type_registered?(klass_or_type)
       case klass_or_type
       when Class
         klass = klass_or_type
-        registered_types.any?{|entry| klass == entry[:class] }
+        registered_types.any? { |entry| klass == entry[:class] }
       when Integer
         type = klass_or_type
-        registered_types.any?{|entry| type == entry[:type] }
+        registered_types.any? { |entry| type == entry[:type] }
       else
-        raise ArgumentError, "class or type id"
+        raise ArgumentError, 'class or type id'
       end
     end
   end

--- a/lib/msgpack/version.rb
+++ b/lib/msgpack/version.rb
@@ -1,5 +1,5 @@
 module MessagePack
-  VERSION = "1.3.3"
+  VERSION = '1.3.3'.freeze
 
   # NOTE for msgpack-ruby maintainer:
   # Check these things to release new binaryes for new Ruby versions (especially for Windows):

--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -1,22 +1,22 @@
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'msgpack/version'
 
 Gem::Specification.new do |s|
-  s.name = "msgpack"
+  s.name = 'msgpack'
   s.version = MessagePack::VERSION
-  s.summary = "MessagePack, a binary-based efficient data interchange format."
-  s.description = %q{MessagePack is a binary-based efficient object serialization library. It enables to exchange structured objects between many languages like JSON. But unlike JSON, it is very fast and small.}
-  s.authors = ["Sadayuki Furuhashi", "Theo Hultberg", "Satoshi Tagomori"]
-  s.email = ["frsyuki@gmail.com", "theo@iconara.net", "tagomoris@gmail.com"]
-  s.license = "Apache 2.0"
-  s.homepage = "http://msgpack.org/"
-  s.require_paths = ["lib"]
+  s.summary = 'MessagePack, a binary-based efficient data interchange format.'
+  s.description = 'MessagePack is a binary-based efficient object serialization library. It enables to exchange structured objects between many languages like JSON. But unlike JSON, it is very fast and small.'
+  s.authors = ['Sadayuki Furuhashi', 'Theo Hultberg', 'Satoshi Tagomori']
+  s.email = ['frsyuki@gmail.com', 'theo@iconara.net', 'tagomoris@gmail.com']
+  s.license = 'Apache 2.0'
+  s.homepage = 'http://msgpack.org/'
+  s.require_paths = ['lib']
   if /java/ =~ RUBY_PLATFORM
     s.files = Dir['lib/**/*.rb', 'lib/**/*.jar']
     s.platform = Gem::Platform.new('java')
   else
     s.files = `git ls-files`.split("\n")
-    s.extensions = ["ext/msgpack/extconf.rb"]
+    s.extensions = ['ext/msgpack/extconf.rb']
   end
   s.test_files = `git ls-files -- {test,spec}/*`.split("\n")
 
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     # NOTE: rake-compiler-dock SHOULD be updated for new Ruby versions
     s.add_development_dependency 'rake-compiler-dock', ['~> 1.0']
   end
+  s.add_development_dependency 'json'
   s.add_development_dependency 'rspec', ['~> 3.3']
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'json'
 end

--- a/spec/cases_spec.rb
+++ b/spec/cases_spec.rb
@@ -9,31 +9,30 @@ describe MessagePack do
 
   it 'compare with json' do
     ms = []
-    MessagePack::Unpacker.new.feed_each(CASES) {|m|
+    MessagePack::Unpacker.new.feed_each(CASES) do |m|
       ms << m
-    }
+    end
 
     js = JSON.load(CASES_JSON)
 
-    ms.zip(js) {|m,j|
+    ms.zip(js) do |m, j|
       m.should == j
-    }
+    end
   end
 
   it 'compare with compat' do
     ms = []
-    MessagePack::Unpacker.new.feed_each(CASES) {|m|
+    MessagePack::Unpacker.new.feed_each(CASES) do |m|
       ms << m
-    }
+    end
 
     cs = []
-    MessagePack::Unpacker.new.feed_each(CASES_COMPACT) {|c|
+    MessagePack::Unpacker.new.feed_each(CASES_COMPACT) do |c|
       cs << c
-    }
+    end
 
-    ms.zip(cs) {|m,c|
+    ms.zip(cs) do |m, c|
       m.should == c
-    }
+    end
   end
 end
-

--- a/spec/cruby/buffer_io_spec.rb
+++ b/spec/cruby/buffer_io_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 require 'random_compat'
 
 require 'stringio'
-if defined?(Encoding)
-  Encoding.default_external = 'ASCII-8BIT'
-end
+Encoding.default_external = 'ASCII-8BIT' if defined?(Encoding)
 
 describe Buffer do
   r = Random.new
@@ -45,18 +43,18 @@ describe Buffer do
     set_source 'aa'
     buffer.read(1).should == 'a'
     buffer.read(1).should == 'a'
-    buffer.read(1).should == nil
+    buffer.read(1).should.nil?
   end
 
   it 'long feed and read all' do
-    set_source ' '*(1024*1024)
+    set_source ' ' * (1024 * 1024)
     s = buffer.read
     s.size.should == source.size
     s.should == source
   end
 
   it 'long feed and read mixed' do
-    set_source ' '*(1024*1024)
+    set_source ' ' * (1024 * 1024)
     buffer.read(10).should == source.slice!(0, 10)
     buffer.read(10).should == source.slice!(0, 10)
     buffer.read(10).should == source.slice!(0, 10)
@@ -90,7 +88,7 @@ describe Buffer do
   end
 
   it 'write long once and flush' do
-    s = ' '*(1024*1024)
+    s = ' ' * (1024 * 1024)
     buffer.write s
     buffer.flush
     io.string.size.should == s.size
@@ -98,10 +96,10 @@ describe Buffer do
   end
 
   it 'write short multi and flush' do
-    s = ' '*(1024*1024)
-    1024.times {
-      buffer.write ' '*1024
-    }
+    s = ' ' * (1024 * 1024)
+    1024.times do
+      buffer.write ' ' * 1024
+    end
     buffer.flush
     io.string.size.should == s.size
     io.string.should == s
@@ -110,11 +108,11 @@ describe Buffer do
   it 'random read' do
     r = Random.new(random_seed)
 
-    50.times {
+    50.times do
       fragments = []
 
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         s = r.bytes(n)
         fragments << s
       end
@@ -122,25 +120,25 @@ describe Buffer do
       io = StringIO.new(fragments.join)
       b = Buffer.new(io)
 
-      fragments.each {|s|
+      fragments.each do |s|
         x = b.read(s.size)
         x.size.should == s.size
         x.should == s
-      }
+      end
       b.empty?.should == true
       b.read.should == ''
-    }
+    end
   end
 
   it 'random read_all' do
     r = Random.new(random_seed)
 
-    50.times {
+    50.times do
       fragments = []
       r.bytes(0)
 
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         s = r.bytes(n)
         fragments << s
       end
@@ -148,26 +146,26 @@ describe Buffer do
       io = StringIO.new(fragments.join)
       b = Buffer.new(io)
 
-      fragments.each {|s|
+      fragments.each do |s|
         x = b.read_all(s.size)
         x.size.should == s.size
         x.should == s
-      }
+      end
       b.empty?.should == true
       lambda {
         b.read_all(1)
       }.should raise_error(EOFError)
-    }
+    end
   end
 
   it 'random skip' do
     r = Random.new(random_seed)
 
-    50.times {
+    50.times do
       fragments = []
 
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         s = r.bytes(n)
         fragments << s
       end
@@ -175,22 +173,22 @@ describe Buffer do
       io = StringIO.new(fragments.join)
       b = Buffer.new(io)
 
-      fragments.each {|s|
+      fragments.each do |s|
         b.skip(s.size).should == s.size
-      }
+      end
       b.empty?.should == true
       b.skip(1).should == 0
-    }
+    end
   end
 
   it 'random skip_all' do
     r = Random.new(random_seed)
 
-    50.times {
+    50.times do
       fragments = []
 
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         s = r.bytes(n)
         fragments << s
       end
@@ -198,28 +196,28 @@ describe Buffer do
       io = StringIO.new(fragments.join)
       b = Buffer.new(io)
 
-      fragments.each {|s|
+      fragments.each do |s|
         lambda {
           b.skip_all(s.size)
         }.should_not raise_error
-      }
+      end
       b.empty?.should == true
       lambda {
         b.skip_all(1)
       }.should raise_error(EOFError)
-    }
+    end
   end
 
   it 'random write and flush' do
     r = Random.new(random_seed)
 
-    50.times {
+    50.times do
       s = r.bytes(0)
       io = StringIO.new
       b = Buffer.new(io)
 
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         x = r.bytes(n)
         s << x
         b.write(x)
@@ -231,18 +229,18 @@ describe Buffer do
 
       io.string.size.should == s.size
       io.string.should == s
-    }
+    end
   end
 
   it 'random write and clear' do
     r = Random.new(random_seed)
     b = Buffer.new
 
-    50.times {
+    50.times do
       s = r.bytes(0)
 
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         x = r.bytes(n)
         s << x
         b.write(x)
@@ -250,6 +248,6 @@ describe Buffer do
 
       b.size.should == s.size
       b.clear
-    }
+    end
   end
 end

--- a/spec/cruby/buffer_packer.rb
+++ b/spec/cruby/buffer_packer.rb
@@ -1,10 +1,9 @@
 # encoding: ascii-8bit
+
 require 'spec_helper'
 
 require 'stringio'
-if defined?(Encoding)
-  Encoding.default_external = 'ASCII-8BIT'
-end
+Encoding.default_external = 'ASCII-8BIT' if defined?(Encoding)
 
 describe Packer do
   let :packer do
@@ -26,4 +25,3 @@ describe Packer do
     packer.buffer.object_id.should == o1
   end
 end
-

--- a/spec/cruby/buffer_spec.rb
+++ b/spec/cruby/buffer_spec.rb
@@ -21,9 +21,7 @@ describe Buffer do
   STATIC_EXAMPLES[:offset02] = 'ort' + 'short' * 127
   STATIC_EXAMPLES[:offset03] = 'ort' + 'short' * (126 + 1024)
 
-  if ''.respond_to?(:force_encoding)
-    STATIC_EXAMPLES.each_value { |v| v.force_encoding('ASCII-8BIT') }
-  end
+  STATIC_EXAMPLES.each_value { |v| v.force_encoding('ASCII-8BIT') } if ''.respond_to?(:force_encoding)
   STATIC_EXAMPLES.each_value { |v| v.freeze }
 
   r = Random.new

--- a/spec/cruby/buffer_spec.rb
+++ b/spec/cruby/buffer_spec.rb
@@ -2,30 +2,29 @@ require 'spec_helper'
 require 'random_compat'
 
 require 'stringio'
-if defined?(Encoding)
-  Encoding.default_external = 'ASCII-8BIT'
-end
+Encoding.default_external = 'ASCII-8BIT' if defined?(Encoding)
 
 describe Buffer do
-  STATIC_EXAMPLES = {}
+  # Adding .freeze will raise: "FrozenError: can't modify frozen Hash: {}"
+  STATIC_EXAMPLES = {} # rubocop:disable Style/MutableConstant
   STATIC_EXAMPLES[:empty01] = ''
   STATIC_EXAMPLES[:empty02] = ''
   STATIC_EXAMPLES[:copy01] = 'short'
-  STATIC_EXAMPLES[:copy02] = 'short'*2
-  STATIC_EXAMPLES[:ref01] = 'short'*128
-  STATIC_EXAMPLES[:ref02] = 'short'*128*2
-  STATIC_EXAMPLES[:ref03] = 'a'*((1024*1024+2)*2)
-  STATIC_EXAMPLES[:refcopy01] = 'short'*128
-  STATIC_EXAMPLES[:expand01] = 'short'*1024
-  STATIC_EXAMPLES[:expand02] = 'short'*(127+1024)
-  STATIC_EXAMPLES[:offset01] = 'ort'+'short'
-  STATIC_EXAMPLES[:offset02] = 'ort'+'short'*127
-  STATIC_EXAMPLES[:offset03] = 'ort'+'short'*(126+1024)
+  STATIC_EXAMPLES[:copy02] = 'short' * 2
+  STATIC_EXAMPLES[:ref01] = 'short' * 128
+  STATIC_EXAMPLES[:ref02] = 'short' * 128 * 2
+  STATIC_EXAMPLES[:ref03] = 'a' * ((1024 * 1024 + 2) * 2)
+  STATIC_EXAMPLES[:refcopy01] = 'short' * 128
+  STATIC_EXAMPLES[:expand01] = 'short' * 1024
+  STATIC_EXAMPLES[:expand02] = 'short' * (127 + 1024)
+  STATIC_EXAMPLES[:offset01] = 'ort' + 'short'
+  STATIC_EXAMPLES[:offset02] = 'ort' + 'short' * 127
+  STATIC_EXAMPLES[:offset03] = 'ort' + 'short' * (126 + 1024)
 
   if ''.respond_to?(:force_encoding)
-    STATIC_EXAMPLES.each_value {|v| v.force_encoding('ASCII-8BIT') }
+    STATIC_EXAMPLES.each_value { |v| v.force_encoding('ASCII-8BIT') }
   end
-  STATIC_EXAMPLES.each_value {|v| v.freeze }
+  STATIC_EXAMPLES.each_value { |v| v.freeze }
 
   r = Random.new
   random_seed = r.seed
@@ -40,17 +39,17 @@ describe Buffer do
       b = Buffer.new
       s = r.bytes(0)
       r.rand(3).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         x = r.bytes(n)
         s << x
         b << x
       end
       r.rand(2).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         b.read(n)
         s.slice!(0, n)
       end
-      key = :"random#{"%02d" % i}"
+      key = :"random#{'%02d' % i}"
       cases[key] = b
       examples[key] = s
     end
@@ -138,7 +137,7 @@ describe Buffer do
   let :ref01 do
     # one reference chunk
     b = Buffer.new
-    b << 'short'*128
+    b << 'short' * 128
     b.to_s
     b
   end
@@ -146,9 +145,9 @@ describe Buffer do
   let :ref02 do
     # two reference chunks
     b = Buffer.new
-    b << 'short'*128
+    b << 'short' * 128
     b.to_s
-    b << 'short'*128
+    b << 'short' * 128
     b.to_a
     b
   end
@@ -156,15 +155,15 @@ describe Buffer do
   let :ref03 do
     # two reference chunks
     b = Buffer.new
-    b << 'a'*(1024*1024+2)
-    b << 'a'*(1024*1024+2)
+    b << 'a' * (1024 * 1024 + 2)
+    b << 'a' * (1024 * 1024 + 2)
     b
   end
 
   let :refcopy01 do
     # one reference chunk + one copy chunk
     b = Buffer.new
-    b << 'short'*127
+    b << 'short' * 127
     b.to_s
     b << 'short'
     b
@@ -182,7 +181,7 @@ describe Buffer do
   let :expand02 do
     # one reference chunk + one copy chunk / expanded
     b = Buffer.new
-    b << 'short'*127
+    b << 'short' * 127
     b.to_s
     1024.times do
       b << 'short'
@@ -202,7 +201,7 @@ describe Buffer do
   let :offset02 do
     # one reference chunk / offset
     b = Buffer.new
-    b << 'short'*127
+    b << 'short' * 127
     b.to_s
     b.skip(2)
     b << 'short'
@@ -212,7 +211,7 @@ describe Buffer do
   let :offset03 do
     # one reference chunk / offset + one copy chunk / expanded
     b = Buffer.new
-    b << 'short'*127
+    b << 'short' * 127
     b.to_s
     1024.times do
       b << 'short'
@@ -227,54 +226,54 @@ describe Buffer do
   end
 
   it 'size' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       cases[k].size.should == examples[k].size
-    }
+    end
   end
 
   it 'short write increments size' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
       10.times do |i|
         cases[k].write 'short'
         sz += 'short'.size
         cases[k].size.should == sz
       end
-    }
+    end
   end
 
   it 'read with limit decrements size' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
       next if sz < 2
 
-      cases[k].read(1).should == examples[k][0,1]
+      cases[k].read(1).should == examples[k][0, 1]
       sz -= 1
       cases[k].size.should == sz
 
-      cases[k].read(1).should == examples[k][1,1]
+      cases[k].read(1).should == examples[k][1, 1]
       sz -= 1
       cases[k].size.should == sz
-    }
+    end
   end
 
   it 'read_all with limit decrements size' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
       next if sz < 2
 
-      cases[k].read_all(1).should == examples[k][0,1]
+      cases[k].read_all(1).should == examples[k][0, 1]
       sz -= 1
       cases[k].size.should == sz
 
-      cases[k].read_all(1).should == examples[k][1,1]
+      cases[k].read_all(1).should == examples[k][1, 1]
       sz -= 1
       cases[k].size.should == sz
-    }
+    end
   end
 
   it 'skip decrements size' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
       next if sz < 2
 
@@ -285,11 +284,11 @@ describe Buffer do
       cases[k].skip(1).should == 1
       sz -= 1
       cases[k].size.should == sz
-    }
+    end
   end
 
   it 'skip_all decrements size' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
       next if sz < 2
 
@@ -300,112 +299,112 @@ describe Buffer do
       cases[k].skip_all(1)
       sz -= 1
       cases[k].size.should == sz
-    }
+    end
   end
 
   it 'read_all against insufficient buffer raises EOFError and consumes nothing' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
       lambda {
-        cases[k].read_all(sz+1)
+        cases[k].read_all(sz + 1)
       }.should raise_error(EOFError)
       cases[k].size.should == sz
-    }
+    end
   end
 
   it 'skip_all against insufficient buffer raises EOFError and consumes nothing' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
       lambda {
-        cases[k].skip_all(sz+1)
+        cases[k].skip_all(sz + 1)
       }.should raise_error(EOFError)
       cases[k].size.should == sz
-    }
+    end
   end
 
   it 'read against insufficient buffer consumes all buffer or return nil' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
-      if sz == 0
-        cases[k].read(sz+1).should == nil
-      else
-        cases[k].read(sz+1).should == examples[k]
-      end
+      cases[k].read(sz + 1).should == if sz == 0
+                                        nil
+                                      else
+                                        examples[k]
+                                      end
       cases[k].size.should == 0
-    }
+    end
   end
 
   it 'skip against insufficient buffer consumes all buffer' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
-      cases[k].skip(sz+1).should == examples[k].size
+      cases[k].skip(sz + 1).should == examples[k].size
       cases[k].size.should == 0
-    }
+    end
   end
 
   it 'read with no arguments consumes all buffer and returns string and do not return nil' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       cases[k].read_all.should == examples[k]
       cases[k].size.should == 0
-    }
+    end
   end
 
   it 'read_all with no arguments consumes all buffer and returns string' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       cases[k].read_all.should == examples[k]
       cases[k].size.should == 0
-    }
+    end
   end
 
   it 'to_s returns a string and consume nothing' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       cases[k].to_s.should == examples[k]
       cases[k].size.should == examples[k].size
-    }
+    end
   end
 
   it 'to_s and modify' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       s = cases[k].to_s
       s << 'x'
       cases[k].to_s.should == examples[k]
-    }
+    end
   end
 
   it 'big write and modify reference' do
-    big2 = "a" * (1024*1024 + 2)
+    big2 = 'a' * (1024 * 1024 + 2)
 
-    case_keys.each {|k|
-      big1 = "a" * (1024*1024 + 2)
+    case_keys.each do |k|
+      big1 = 'a' * (1024 * 1024 + 2)
       cases[k].write(big1)
       big1 << 'x'
       cases[k].read.should == examples[k] + big2
-    }
+    end
   end
 
   it 'big write -> short write' do
-    big1 = "a" * (1024*1024 + 2)
+    big1 = 'a' * (1024 * 1024 + 2)
 
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
 
       cases[k].write big1
       cases[k].size.should == sz + big1.size
 
-      cases[k].write("c")
+      cases[k].write('c')
       cases[k].size.should == sz + big1.size + 1
 
-      cases[k].read_all.should == examples[k] + big1 + "c"
+      cases[k].read_all.should == examples[k] + big1 + 'c'
       cases[k].size.should == 0
       cases[k].empty?.should == true
-    }
+    end
   end
 
-  it 'big write 2'do
-    big1 = "a" * (1024*1024 + 2)
-    big2 = "b" * (1024*1024 + 2)
+  it 'big write 2' do
+    big1 = 'a' * (1024 * 1024 + 2)
+    big2 = 'b' * (1024 * 1024 + 2)
 
-    case_keys.each {|k|
+    case_keys.each do |k|
       sz = examples[k].size
 
       cases[k].write big1
@@ -418,44 +417,44 @@ describe Buffer do
       cases[k].read.should == big2
       cases[k].size.should == 0
       cases[k].empty?.should == true
-    }
+    end
   end
 
   it 'read 0' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       cases[k].read(0).should == ''
       cases[k].read.should == examples[k]
-    }
+    end
   end
 
   it 'skip 0' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       cases[k].skip(0).should == 0
       cases[k].read.should == examples[k]
-    }
+    end
   end
 
   it 'read_all 0' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       cases[k].read_all(0).should == ''
       cases[k].read_all.should == examples[k]
-    }
+    end
   end
 
   it 'skip_all 0' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       cases[k].skip_all(0)
       cases[k].read_all.should == examples[k]
-    }
+    end
   end
 
   it 'write_to' do
-    case_keys.each {|k|
+    case_keys.each do |k|
       sio = StringIO.new
       cases[k].write_to(sio).should == examples[k].size
       cases[k].size.should == 0
       sio.string.should == examples[k]
-    }
+    end
   end
 
   it 'random read/write' do
@@ -463,10 +462,10 @@ describe Buffer do
     s = r.bytes(0)
     b = Buffer.new
 
-    10.times {
+    10.times do
       # write
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         x = r.bytes(n)
         s << x
         b.write(x)
@@ -474,15 +473,15 @@ describe Buffer do
 
       # read
       r.rand(3).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         ex = s.slice!(0, n)
         ex = nil if ex.empty?
         x = b.read(n)
-        x.size == ex.size if x != nil
+        x.size == ex.size unless x.nil?
         x.should == ex
         b.size.should == s.size
       end
-    }
+    end
   end
 
   it 'random read_all/write' do
@@ -490,10 +489,10 @@ describe Buffer do
     s = r.bytes(0)
     b = Buffer.new
 
-    10.times {
+    10.times do
       # write
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         x = r.bytes(n)
         s << x
         b.write(x)
@@ -501,7 +500,7 @@ describe Buffer do
 
       # read_all
       r.rand(3).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         begin
           x = b.read_all(n)
           ex = s.slice!(0, n)
@@ -515,7 +514,7 @@ describe Buffer do
           break
         end
       end
-    }
+    end
   end
 
   it 'random skip write' do
@@ -523,10 +522,10 @@ describe Buffer do
     s = r.bytes(0)
     b = Buffer.new
 
-    10.times {
+    10.times do
       # write
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         x = r.bytes(n)
         s << x
         b.write(x)
@@ -534,12 +533,12 @@ describe Buffer do
 
       # skip
       r.rand(3).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         ex = s.slice!(0, n)
         b.skip(n).should == ex.size
         b.size.should == s.size
       end
-    }
+    end
   end
 
   it 'random skip_all write' do
@@ -547,10 +546,10 @@ describe Buffer do
     s = r.bytes(0)
     b = Buffer.new
 
-    10.times {
+    10.times do
       # write
       r.rand(4).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         x = r.bytes(n)
         s << x
         b.write(x)
@@ -558,18 +557,18 @@ describe Buffer do
 
       # skip_all
       r.rand(3).times do
-        n = r.rand(1024*1400)
+        n = r.rand(1024 * 1400)
         begin
           b.skip_all(n)
           s.slice!(0, n)
           b.size.should == s.size
         ensure EOFError
-          b.size.should == s.size
-          b.read.should == s
-          s.clear
-          break
+               b.size.should == s.size
+               b.read.should == s
+               s.clear
+               break
         end
       end
-    }
+    end
   end
 end

--- a/spec/cruby/buffer_unpacker.rb
+++ b/spec/cruby/buffer_unpacker.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+
 require 'spec_helper'
 
 describe Unpacker do

--- a/spec/cruby/unpacker_spec.rb
+++ b/spec/cruby/unpacker_spec.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+
 require 'spec_helper'
 
 describe Unpacker do
@@ -67,4 +68,3 @@ describe Unpacker do
     }.should raise_error(MessagePack::MalformedFormatError)
   end
 end
-

--- a/spec/ext_value_spec.rb
+++ b/spec/ext_value_spec.rb
@@ -1,9 +1,10 @@
 # encoding: ascii-8bit
+
 require 'spec_helper'
 
 describe MessagePack::ExtensionValue do
   subject do
-    described_class.new(1, "data")
+    described_class.new(1, 'data')
   end
 
   describe '#type/#type=' do
@@ -19,35 +20,35 @@ describe MessagePack::ExtensionValue do
 
   describe '#payload/#payload=' do
     it 'returns value set by #initialize' do
-      subject.payload.should == "data"
+      subject.payload.should == 'data'
     end
 
     it 'assigns a value' do
-      subject.payload = "a"
-      subject.payload.should == "a"
+      subject.payload = 'a'
+      subject.payload.should == 'a'
     end
   end
 
   describe '#==/#eql?/#hash' do
     it 'returns equivalent if the content is same' do
-      ext1 = MessagePack::ExtensionValue.new(1, "data")
-      ext2 = MessagePack::ExtensionValue.new(1, "data")
+      ext1 = MessagePack::ExtensionValue.new(1, 'data')
+      ext2 = MessagePack::ExtensionValue.new(1, 'data')
       (ext1 == ext2).should be true
       ext1.eql?(ext2).should be true
       (ext1.hash == ext2.hash).should be true
     end
 
     it 'returns not equivalent if type is not same' do
-      ext1 = MessagePack::ExtensionValue.new(1, "data")
-      ext2 = MessagePack::ExtensionValue.new(2, "data")
+      ext1 = MessagePack::ExtensionValue.new(1, 'data')
+      ext2 = MessagePack::ExtensionValue.new(2, 'data')
       (ext1 == ext2).should be false
       ext1.eql?(ext2).should be false
       (ext1.hash == ext2.hash).should be false
     end
 
     it 'returns not equivalent if payload is not same' do
-      ext1 = MessagePack::ExtensionValue.new(1, "data")
-      ext2 = MessagePack::ExtensionValue.new(1, "value")
+      ext1 = MessagePack::ExtensionValue.new(1, 'data')
+      ext2 = MessagePack::ExtensionValue.new(1, 'value')
       (ext1 == ext2).should be false
       ext1.eql?(ext2).should be false
       (ext1.hash == ext2.hash).should be false
@@ -56,31 +57,31 @@ describe MessagePack::ExtensionValue do
 
   describe '#to_msgpack' do
     it 'serializes very short payload' do
-      ext = MessagePack::ExtensionValue.new(1, "a"*2).to_msgpack
-      ext.should == "\xd5\x01" + "a"*2
+      ext = MessagePack::ExtensionValue.new(1, 'a' * 2).to_msgpack
+      ext.should == "\xd5\x01" + 'a' * 2
     end
 
     it 'serializes short payload' do
-      ext = MessagePack::ExtensionValue.new(1, "a"*18).to_msgpack
-      ext.should == "\xc7\x12\x01" + "a"*18
+      ext = MessagePack::ExtensionValue.new(1, 'a' * 18).to_msgpack
+      ext.should == "\xc7\x12\x01" + 'a' * 18
     end
 
     it 'serializes long payload' do
-      ext = MessagePack::ExtensionValue.new(1, "a"*65540).to_msgpack
-      ext.should == "\xc9\x00\x01\x00\x04\x01" + "a"*65540
+      ext = MessagePack::ExtensionValue.new(1, 'a' * 65_540).to_msgpack
+      ext.should == "\xc9\x00\x01\x00\x04\x01" + 'a' * 65_540
     end
 
     it 'with a packer serializes to a packer' do
-      ext = MessagePack::ExtensionValue.new(1, "aa")
+      ext = MessagePack::ExtensionValue.new(1, 'aa')
       packer = MessagePack::Packer.new
       ext.to_msgpack(packer)
       packer.buffer.to_s.should == "\xd5\x01aa"
     end
 
-    [-129, -65540, -(2**40), 128, 65540, 2**40].each do |type|
+    [-129, -65_540, -(2**40), 128, 65_540, 2**40].each do |type|
       context "with invalid type (#{type})" do
         it 'raises RangeError' do
-          lambda { MessagePack::ExtensionValue.new(type, "a").to_msgpack }.should raise_error(RangeError)
+          -> { MessagePack::ExtensionValue.new(type, 'a').to_msgpack }.should raise_error(RangeError)
         end
       end
     end
@@ -88,12 +89,12 @@ describe MessagePack::ExtensionValue do
 
   describe '#dup' do
     it 'duplicates' do
-      ext1 = MessagePack::ExtensionValue.new(1, "data")
+      ext1 = MessagePack::ExtensionValue.new(1, 'data')
       ext2 = ext1.dup
       ext2.type = 2
-      ext2.payload = "data2"
+      ext2.payload = 'data2'
       ext1.type.should == 1
-      ext1.payload.should == "data"
+      ext1.payload.should == 'data'
     end
   end
 end

--- a/spec/exttypes.rb
+++ b/spec/exttypes.rb
@@ -10,7 +10,7 @@ class DummyTimeStamp1
   end
 
   def ==(other)
-    self.utime == other.utime && self.usec == other.usec
+    utime == other.utime && usec == other.usec
   end
 
   def self.type_id
@@ -22,7 +22,7 @@ class DummyTimeStamp1
   end
 
   def to_msgpack_ext
-    [@utime,@usec].pack('I*')
+    [@utime, @usec].pack('I*')
   end
 end
 
@@ -38,7 +38,7 @@ class DummyTimeStamp2
   end
 
   def ==(other)
-    self.utime == other.utime && self.usec == other.usec
+    utime == other.utime && usec == other.usec
   end
 
   def self.deserialize(data)
@@ -46,6 +46,6 @@ class DummyTimeStamp2
   end
 
   def serialize
-    [@utime,@usec].map(&:to_s).join(',')
+    [@utime, @usec].map(&:to_s).join(',')
   end
 end

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -1,275 +1,276 @@
 # encoding: ascii-8bit
+
 require 'spec_helper'
 
 describe MessagePack do
-  it "nil" do
+  it 'nil' do
     check 1, nil
   end
 
-  it "true" do
+  it 'true' do
     check 1, true
   end
 
-  it "false" do
+  it 'false' do
     check 1, false
   end
 
-  it "zero" do
+  it 'zero' do
     check 1, 0
   end
 
-  it "positive fixnum" do
+  it 'positive fixnum' do
     check 1, 1
     check 1, (1 << 6)
-    check 1, (1 << 7)-1
+    check 1, (1 << 7) - 1
   end
 
-  it "positive int 8" do
+  it 'positive int 8' do
     check 1, -1
     check 2, (1 << 7)
     check 2, (1 << 8) - 1
   end
 
-  it "positive int 16" do
+  it 'positive int 16' do
     check 3, (1 << 8)
     check 3, (1 << 16) - 1
   end
 
-  it "positive int 32" do
+  it 'positive int 32' do
     check 5, (1 << 16)
     check 5, (1 << 32) - 1
   end
 
-  it "positive int 64" do
+  it 'positive int 64' do
     check 9, (1 << 32)
-    #check 9, (1<<64)-1
+    # check 9, (1<<64)-1
   end
 
-  it "negative fixnum" do
+  it 'negative fixnum' do
     check 1, -1
-    check 1, -((1 << 5)-1)
+    check 1, -((1 << 5) - 1)
     check 1, -(1 << 5)
   end
 
-  it "negative int 8" do
-    check 2, -((1 << 5)+1)
+  it 'negative int 8' do
+    check 2, -((1 << 5) + 1)
     check 2, -(1 << 7)
   end
 
-  it "negative int 16" do
-    check 3, -((1 << 7)+1)
+  it 'negative int 16' do
+    check 3, -((1 << 7) + 1)
     check 3, -(1 << 15)
   end
 
-  it "negative int 32" do
-    check 5, -((1 << 15)+1)
+  it 'negative int 32' do
+    check 5, -((1 << 15) + 1)
     check 5, -(1 << 31)
   end
 
-  it "negative int 64" do
-    check 9, -((1 << 31)+1)
+  it 'negative int 64' do
+    check 9, -((1 << 31) + 1)
     check 9, -(1 << 63)
   end
 
-  it "double" do
+  it 'double' do
     check 9, 1.0
     check 9, 0.1
     check 9, -0.1
     check 9, -1.0
   end
 
-  it "fixraw" do
+  it 'fixraw' do
     check_raw 1, 0
-    check_raw 1, (1 << 5)-1
+    check_raw 1, (1 << 5) - 1
   end
 
-  it "raw 8" do
+  it 'raw 8' do
     check_raw 2, (1 << 5)
-    check_raw 2, (1 << 8)-1
+    check_raw 2, (1 << 8) - 1
   end
 
-  it "raw 16" do
+  it 'raw 16' do
     check_raw 3, (1 << 8)
-    check_raw 3, (1 << 16)-1
+    check_raw 3, (1 << 16) - 1
   end
 
-  it "raw 32" do
+  it 'raw 32' do
     check_raw 5, (1 << 16)
-    #check_raw 5, (1 << 32)-1  # memory error
+    # check_raw 5, (1 << 32)-1  # memory error
   end
 
-  it "str encoding is UTF_8" do
+  it 'str encoding is UTF_8' do
     v = pack_unpack('string'.force_encoding(Encoding::UTF_8))
     v.encoding.should == Encoding::UTF_8
   end
 
-  it "str transcode US-ASCII" do
+  it 'str transcode US-ASCII' do
     v = pack_unpack('string'.force_encoding(Encoding::US_ASCII))
     v.encoding.should == Encoding::UTF_8
   end
 
-  it "str transcode UTF-16" do
+  it 'str transcode UTF-16' do
     v = pack_unpack('string'.encode(Encoding::UTF_16))
     v.encoding.should == Encoding::UTF_8
     v.should == 'string'
   end
 
-  it "str transcode EUC-JP 7bit safe" do
+  it 'str transcode EUC-JP 7bit safe' do
     v = pack_unpack('string'.force_encoding(Encoding::EUC_JP))
     v.encoding.should == Encoding::UTF_8
     v.should == 'string'
   end
 
-  it "str transcode EUC-JP 7bit unsafe" do
+  it 'str transcode EUC-JP 7bit unsafe' do
     v = pack_unpack([0xa4, 0xa2].pack('C*').force_encoding(Encoding::EUC_JP))
     v.encoding.should == Encoding::UTF_8
     v.should == "\xE3\x81\x82".force_encoding('UTF-8')
   end
 
-  it "symbol to str" do
+  it 'symbol to str' do
     v = pack_unpack(:a)
-    v.should == "a".force_encoding('UTF-8')
+    v.should == 'a'.force_encoding('UTF-8')
   end
 
-  it "symbol to str with encoding" do
+  it 'symbol to str with encoding' do
     a = "\xE3\x81\x82".force_encoding('UTF-8')
     v = pack_unpack(a.encode('Shift_JIS').to_sym)
     v.encoding.should == Encoding::UTF_8
     v.should == a
   end
 
-  it "symbol to bin" do
+  it 'symbol to bin' do
     a = "\xE3\x81\x82".force_encoding('ASCII-8BIT')
     v = pack_unpack(a.to_sym)
     v.encoding.should == Encoding::ASCII_8BIT
     v.should == a
   end
 
-  it "bin 8" do
-    check_bin 2, (1<<8)-1
+  it 'bin 8' do
+    check_bin 2, (1 << 8) - 1
   end
 
-  it "bin 16" do
-    check_bin 3, (1<<16)-1
+  it 'bin 16' do
+    check_bin 3, (1 << 16) - 1
   end
 
-  it "bin 32" do
-    check_bin 5, (1<<16)
+  it 'bin 32' do
+    check_bin 5, (1 << 16)
   end
 
-  it "bin encoding is ASCII_8BIT" do
+  it 'bin encoding is ASCII_8BIT' do
     pack_unpack('string'.force_encoding(Encoding::ASCII_8BIT)).encoding.should == Encoding::ASCII_8BIT
   end
 
-  it "fixarray" do
+  it 'fixarray' do
     check_array 1, 0
-    check_array 1, (1 << 4)-1
+    check_array 1, (1 << 4) - 1
   end
 
-  it "array 16" do
+  it 'array 16' do
     check_array 3, (1 << 4)
-    #check_array 3, (1 << 16)-1
+    # check_array 3, (1 << 16)-1
   end
 
-  it "array 32" do
-    #check_array 5, (1 << 16)
-    #check_array 5, (1 << 32)-1  # memory error
+  it 'array 32' do
+    # check_array 5, (1 << 16)
+    # check_array 5, (1 << 32)-1  # memory error
   end
 
-  it "nil" do
+  it 'nil' do
     match nil, "\xc0"
   end
 
-  it "false" do
+  it 'false' do
     match false, "\xc2"
   end
 
-  it "true" do
+  it 'true' do
     match true, "\xc3"
   end
 
-  it "0" do
+  it '0' do
     match 0, "\x00"
   end
 
-  it "127" do
+  it '127' do
     match 127, "\x7f"
   end
 
-  it "128" do
+  it '128' do
     match 128, "\xcc\x80"
   end
 
-  it "256" do
+  it '256' do
     match 256, "\xcd\x01\x00"
   end
 
-  it "-1" do
+  it '-1' do
     match -1, "\xff"
   end
 
-  it "-33" do
+  it '-33' do
     match -33, "\xd0\xdf"
   end
 
-  it "-129" do
+  it '-129' do
     match -129, "\xd1\xff\x7f"
   end
 
-  it "{1=>1}" do
-    obj = {1=>1}
+  it '{1=>1}' do
+    obj = { 1 => 1 }
     match obj, "\x81\x01\x01"
   end
 
-  it "1.0" do
+  it '1.0' do
     match 1.0, "\xcb\x3f\xf0\x00\x00\x00\x00\x00\x00"
   end
 
-  it "[]" do
+  it '[]' do
     match [], "\x90"
   end
 
-  it "[0, 1, ..., 14]" do
+  it '[0, 1, ..., 14]' do
     obj = (0..14).to_a
     match obj, "\x9f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e"
   end
 
-  it "[0, 1, ..., 15]" do
+  it '[0, 1, ..., 15]' do
     obj = (0..15).to_a
     match obj, "\xdc\x00\x10\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
   end
 
-  it "{}" do
+  it '{}' do
     obj = {}
     match obj, "\x80"
   end
 
-## FIXME
-#  it "{0=>0, 1=>1, ..., 14=>14}" do
-#    a = (0..14).to_a;
-#    match Hash[*a.zip(a).flatten], "\x8f\x05\x05\x0b\x0b\x00\x00\x06\x06\x0c\x0c\x01\x01\x07\x07\x0d\x0d\x02\x02\x08\x08\x0e\x0e\x03\x03\x09\x09\x04\x04\x0a\x0a"
-#  end
-#
-#  it "{0=>0, 1=>1, ..., 15=>15}" do
-#    a = (0..15).to_a;
-#    match Hash[*a.zip(a).flatten], "\xde\x00\x10\x05\x05\x0b\x0b\x00\x00\x06\x06\x0c\x0c\x01\x01\x07\x07\x0d\x0d\x02\x02\x08\x08\x0e\x0e\x03\x03\x09\x09\x0f\x0f\x04\x04\x0a\x0a"
-#  end
+  ## FIXME
+  #  it "{0=>0, 1=>1, ..., 14=>14}" do
+  #    a = (0..14).to_a;
+  #    match Hash[*a.zip(a).flatten], "\x8f\x05\x05\x0b\x0b\x00\x00\x06\x06\x0c\x0c\x01\x01\x07\x07\x0d\x0d\x02\x02\x08\x08\x0e\x0e\x03\x03\x09\x09\x04\x04\x0a\x0a"
+  #  end
+  #
+  #  it "{0=>0, 1=>1, ..., 15=>15}" do
+  #    a = (0..15).to_a;
+  #    match Hash[*a.zip(a).flatten], "\xde\x00\x10\x05\x05\x0b\x0b\x00\x00\x06\x06\x0c\x0c\x01\x01\x07\x07\x0d\x0d\x02\x02\x08\x08\x0e\x0e\x03\x03\x09\x09\x0f\x0f\x04\x04\x0a\x0a"
+  #  end
 
-## FIXME
-#  it "fixmap" do
-#    check_map 1, 0
-#    check_map 1, (1<<4)-1
-#  end
-#
-#  it "map 16" do
-#    check_map 3, (1<<4)
-#    check_map 3, (1<<16)-1
-#  end
-#
-#  it "map 32" do
-#    check_map 5, (1<<16)
-#    #check_map 5, (1<<32)-1  # memory error
-#  end
+  ## FIXME
+  #  it "fixmap" do
+  #    check_map 1, 0
+  #    check_map 1, (1<<4)-1
+  #  end
+  #
+  #  it "map 16" do
+  #    check_map 3, (1<<4)
+  #    check_map 3, (1<<16)-1
+  #  end
+  #
+  #  it "map 32" do
+  #    check_map 5, (1<<16)
+  #    #check_map 5, (1<<32)-1  # memory error
+  #  end
 
   def check(len, obj)
     raw = obj.to_msgpack.to_s
@@ -278,15 +279,15 @@ describe MessagePack do
   end
 
   def check_raw(overhead, num)
-    check num+overhead, (" "*num).force_encoding(Encoding::UTF_8)
+    check num + overhead, (' ' * num).force_encoding(Encoding::UTF_8)
   end
 
   def check_bin(overhead, num)
-    check num+overhead, (" "*num).force_encoding(Encoding::ASCII_8BIT)
+    check num + overhead, (' ' * num).force_encoding(Encoding::ASCII_8BIT)
   end
 
   def check_array(overhead, num)
-    check num+overhead, Array.new(num)
+    check num + overhead, Array.new(num)
   end
 
   def match(obj, buf)
@@ -298,4 +299,3 @@ describe MessagePack do
     MessagePack.unpack(obj.to_msgpack)
   end
 end
-

--- a/spec/jruby/benchmarks/shootout_bm.rb
+++ b/spec/jruby/benchmarks/shootout_bm.rb
@@ -1,8 +1,6 @@
-# encoding: utf-8
-
 if RUBY_PLATFORM.include?('java')
   # JRuby should use this library, MRI should use the standard gem
-  $: << File.expand_path('../../../lib', __FILE__)
+  $: << File.expand_path('../../lib', __dir__)
 end
 
 require 'viiite'
@@ -10,26 +8,25 @@ require 'msgpack'
 require 'json'
 require 'bson'
 
-if RUBY_PLATFORM.include?('java')
-  BSON_IMPL = BSON::BSON_JAVA
-else
-  BSON_IMPL = BSON::BSON_C
-end
+BSON_IMPL = if RUBY_PLATFORM.include?('java')
+              BSON::BSON_JAVA
+            else
+              BSON::BSON_C
+            end
 
-OBJECT_STRUCTURE = {'x' => ['y', 34, 2**30 + 3, 2.1223423423356, {'hello' => 'world', '5' => [63, 'asjdl']}]}
-ENCODED_MSGPACK = "\x81\xA1x\x95\xA1y\"\xCE@\x00\x00\x03\xCB@\x00\xFA\x8E\x9F9\xFA\xC1\x82\xA5hello\xA5world\xA15\x92?\xA5asjdl"
-ENCODED_BSON = "d\x00\x00\x00\x04x\x00\\\x00\x00\x00\x020\x00\x02\x00\x00\x00y\x00\x101\x00\"\x00\x00\x00\x102\x00\x03\x00\x00@\x013\x00\xC1\xFA9\x9F\x8E\xFA\x00@\x034\x002\x00\x00\x00\x02hello\x00\x06\x00\x00\x00world\x00\x045\x00\x19\x00\x00\x00\x100\x00?\x00\x00\x00\x021\x00\x06\x00\x00\x00asjdl\x00\x00\x00\x00\x00"
-ENCODED_JSON = '{"x":["y",34,1073741827,2.1223423423356,{"hello":"world","5":[63,"asjdl"]}]}'
-ITERATIONS = 1_00_000
+OBJECT_STRUCTURE = { 'x' => ['y', 34, 2**30 + 3, 2.1223423423356, { 'hello' => 'world', '5' => [63, 'asjdl'] }] }.freeze
+ENCODED_MSGPACK = "\x81\xA1x\x95\xA1y\"\xCE@\x00\x00\x03\xCB@\x00\xFA\x8E\x9F9\xFA\xC1\x82\xA5hello\xA5world\xA15\x92?\xA5asjdl".freeze
+ENCODED_BSON = "d\x00\x00\x00\x04x\x00\\\x00\x00\x00\x020\x00\x02\x00\x00\x00y\x00\x101\x00\"\x00\x00\x00\x102\x00\x03\x00\x00@\x013\x00\xC1\xFA9\x9F\x8E\xFA\x00@\x034\x002\x00\x00\x00\x02hello\x00\x06\x00\x00\x00world\x00\x045\x00\x19\x00\x00\x00\x100\x00?\x00\x00\x00\x021\x00\x06\x00\x00\x00asjdl\x00\x00\x00\x00\x00".freeze
+ENCODED_JSON = '{"x":["y",34,1073741827,2.1223423423356,{"hello":"world","5":[63,"asjdl"]}]}'.freeze
+ITERATIONS = 100_000
 IMPLEMENTATIONS = ENV.fetch('IMPLEMENTATIONS', 'json,bson,msgpack').split(',').map(&:to_sym)
 
 Viiite.bm do |b|
   b.variation_point :ruby, Viiite.which_ruby
-  
+
   IMPLEMENTATIONS.each do |lib|
     b.variation_point :lib, lib
-    
-  
+
     b.report(:pack) do
       ITERATIONS.times do
         case lib
@@ -39,7 +36,7 @@ Viiite.bm do |b|
         end
       end
     end
-  
+
     b.report(:unpack) do
       ITERATIONS.times do
         case lib
@@ -49,7 +46,7 @@ Viiite.bm do |b|
         end
       end
     end
-    
+
     b.report(:pack_unpack) do
       ITERATIONS.times do
         case lib

--- a/spec/jruby/benchmarks/symbolize_keys_bm.rb
+++ b/spec/jruby/benchmarks/symbolize_keys_bm.rb
@@ -1,13 +1,10 @@
-# encoding: utf-8
-
-$: << File.expand_path('../../../lib', __FILE__)
+$: << File.expand_path('../../lib', __dir__)
 
 require 'viiite'
 require 'msgpack'
 
-
 iterations = 10_000
-data = MessagePack.pack(:hello => 'world', :nested => ['structure', {:value => 42}])
+data = MessagePack.pack(hello: 'world', nested: ['structure', { value: 42 }])
 
 Viiite.bm do |b|
   b.report(:strings) do
@@ -17,7 +14,7 @@ Viiite.bm do |b|
   end
 
   b.report(:symbols) do
-    options = {:symbolize_keys => true}
+    options = { symbolize_keys: true }
     iterations.times do
       MessagePack.unpack(data, options)
     end

--- a/spec/jruby/unpacker_spec.rb
+++ b/spec/jruby/unpacker_spec.rb
@@ -15,15 +15,15 @@ describe MessagePack::Unpacker do
   end
 
   let :buffer1 do
-    MessagePack.pack(:foo => 'bar')
+    MessagePack.pack(foo: 'bar')
   end
 
   let :buffer2 do
-    MessagePack.pack(:hello => {:world => [1, 2, 3]})
+    MessagePack.pack(hello: { world: [1, 2, 3] })
   end
 
   let :buffer3 do
-    MessagePack.pack(:x => 'y')
+    MessagePack.pack(x: 'y')
   end
 
   describe '#execute/#execute_limit/#finished?' do
@@ -33,17 +33,17 @@ describe MessagePack::Unpacker do
 
     it 'extracts an object from the buffer' do
       subject.execute(buffer, 0)
-      subject.data.should == {'foo' => 'bar'}
+      subject.data.should == { 'foo' => 'bar' }
     end
 
     it 'extracts an object from the buffer, starting at an offset' do
       subject.execute(buffer, buffer1.length)
-      subject.data.should == {'hello' => {'world' => [1, 2, 3]}}
+      subject.data.should == { 'hello' => { 'world' => [1, 2, 3] } }
     end
 
     it 'extracts an object from the buffer, starting at an offset reading bytes up to a limit' do
       subject.execute_limit(buffer, buffer1.length, buffer2.length)
-      subject.data.should == {'hello' => {'world' => [1, 2, 3]}}
+      subject.data.should == { 'hello' => { 'world' => [1, 2, 3] } }
     end
 
     it 'extracts nothing if the limit cuts an object in half' do
@@ -73,7 +73,7 @@ describe MessagePack::Unpacker do
         subject.each do |obj|
           objects << obj
         end
-        objects.should == [{'foo' => 'bar'}, {'hello' => {'world' => [1, 2, 3]}}, {'x' => 'y'}]
+        objects.should == [{ 'foo' => 'bar' }, { 'hello' => { 'world' => [1, 2, 3] } }, { 'x' => 'y' }]
       end
     end
 
@@ -89,7 +89,7 @@ describe MessagePack::Unpacker do
         subject.each do |obj|
           objects << obj
         end
-        objects.should == [{'foo' => 'bar'}, {'hello' => {'world' => [1, 2, 3]}}, {'x' => 'y'}]
+        objects.should == [{ 'foo' => 'bar' }, { 'hello' => { 'world' => [1, 2, 3] } }, { 'x' => 'y' }]
       end
     end
   end
@@ -126,7 +126,7 @@ describe MessagePack::Unpacker do
     end
 
     let :buffer do
-      MessagePack.pack({'hello' => 'world', 'nested' => ['object', {"sk\xC3\xA5l".force_encoding('utf-8') => true}]})
+      MessagePack.pack({ 'hello' => 'world', 'nested' => ['object', { "sk\xC3\xA5l".force_encoding('utf-8') => true }] })
     end
 
     let :unpacker do
@@ -141,7 +141,7 @@ describe MessagePack::Unpacker do
     it 'produces results with encoding as binary or string(utf8)' do
       unpacker.execute(buffer, 0)
       strings = flatten(unpacker.data).grep(String)
-      strings.map(&:encoding).uniq.sort{|a,b| a.to_s <=> b.to_s}.should == [Encoding::ASCII_8BIT, Encoding::UTF_8]
+      strings.map(&:encoding).uniq.sort { |a, b| a.to_s <=> b.to_s }.should == [Encoding::ASCII_8BIT, Encoding::UTF_8]
     end
 
     it 'recodes to internal encoding' do
@@ -153,26 +153,26 @@ describe MessagePack::Unpacker do
   context 'extensions' do
     context 'symbolized keys' do
       let :buffer do
-        MessagePack.pack({'hello' => 'world', 'nested' => ['object', {'structure' => true}]})
+        MessagePack.pack({ 'hello' => 'world', 'nested' => ['object', { 'structure' => true }] })
       end
 
       let :unpacker do
-        described_class.new(:symbolize_keys => true)
+        described_class.new(symbolize_keys: true)
       end
 
       it 'can symbolize keys when using #execute' do
         unpacker.execute(buffer, 0)
-        unpacker.data.should == {:hello => 'world', :nested => ['object', {:structure => true}]}
+        unpacker.data.should == { hello: 'world', nested: ['object', { structure: true }] }
       end
     end
 
     context 'encoding', :encodings do
       let :buffer do
-        MessagePack.pack({'hello' => 'world', 'nested' => ['object', {'structure' => true}]})
+        MessagePack.pack({ 'hello' => 'world', 'nested' => ['object', { 'structure' => true }] })
       end
 
       let :unpacker do
-        described_class.new()
+        described_class.new
       end
 
       it 'decode binary as ascii-8bit string when using #execute' do

--- a/spec/msgpack_spec.rb
+++ b/spec/msgpack_spec.rb
@@ -25,7 +25,7 @@ describe MessagePack do
       ['-1', -1, "\xFF"],
       ['-33', -33, "\xD0\xDF"],
       ['-129', -129, "\xD1\xFF\x7F"],
-      ['small integers', 42, "*"],
+      ['small integers', 42, '*'],
       ['medium integers', 333, "\xCD\x01M"],
       ['large integers', 2**31 - 1, "\xCE\x7F\xFF\xFF\xFF"],
       ['huge integers', 2**64 - 1, "\xCF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"],
@@ -47,17 +47,17 @@ describe MessagePack do
     ],
     'arrays' => [
       ['empty arrays', [], "\x90"],
-      ['arrays with strings', [utf8enc("hello"), utf8enc("world")], "\x92\xA5hello\xA5world"],
-      ['arrays with mixed values', [utf8enc("hello"), utf8enc("world"), 42], "\x93\xA5hello\xA5world*"],
+      ['arrays with strings', [utf8enc('hello'), utf8enc('world')], "\x92\xA5hello\xA5world"],
+      ['arrays with mixed values', [utf8enc('hello'), utf8enc('world'), 42], "\x93\xA5hello\xA5world*"],
       ['arrays of arrays', [[[[1, 2], 3], 4]], "\x91\x92\x92\x92\x01\x02\x03\x04"],
       ['empty arrays', [], "\x90"]
     ],
     'hashes' => [
       ['empty hashes', {}, "\x80"],
-      ['hashes', {utf8enc('foo') => utf8enc('bar')}, "\x81\xA3foo\xA3bar"],
-      ['hashes with mixed keys and values', {utf8enc('foo') => utf8enc('bar'), 3 => utf8enc('three'), utf8enc('four') => 4, utf8enc('x') => [utf8enc('y')], utf8enc('a') => utf8enc('b')}, "\x85\xA3foo\xA3bar\x03\xA5three\xA4four\x04\xA1x\x91\xA1y\xA1a\xA1b"],
-      ['hashes of hashes', {{utf8enc('x') => {utf8enc('y') => utf8enc('z')}} => utf8enc('s')}, "\x81\x81\xA1x\x81\xA1y\xA1z\xA1s"],
-      ['hashes with nils', {utf8enc('foo') => nil}, "\x81\xA3foo\xC0"]
+      ['hashes', { utf8enc('foo') => utf8enc('bar') }, "\x81\xA3foo\xA3bar"],
+      ['hashes with mixed keys and values', { utf8enc('foo') => utf8enc('bar'), 3 => utf8enc('three'), utf8enc('four') => 4, utf8enc('x') => [utf8enc('y')], utf8enc('a') => utf8enc('b') }, "\x85\xA3foo\xA3bar\x03\xA5three\xA4four\x04\xA1x\x91\xA1y\xA1a\xA1b"],
+      ['hashes of hashes', { { utf8enc('x') => { utf8enc('y') => utf8enc('z') } } => utf8enc('s') }, "\x81\x81\xA1x\x81\xA1y\xA1z\xA1s"],
+      ['hashes with nils', { utf8enc('foo') => nil }, "\x81\xA3foo\xC0"]
     ]
   }
 
@@ -116,32 +116,32 @@ describe MessagePack do
     end
 
     it 'rasies an error on #unpack with garbage' do
-      skip "but nothing was raised. why?"
+      skip 'but nothing was raised. why?'
       expect { MessagePack.unpack('asdka;sd') }.to raise_error(MessagePack::UnpackError)
     end
   end
 
   context 'extensions' do
     it 'can unpack hashes with symbolized keys' do
-      packed = MessagePack.pack({'hello' => 'world', 'nested' => ['object', {'structure' => true}]})
-      unpacked = MessagePack.unpack(packed, :symbolize_keys => true)
-      unpacked.should == {:hello => 'world', :nested => ['object', {:structure => true}]}
+      packed = MessagePack.pack({ 'hello' => 'world', 'nested' => ['object', { 'structure' => true }] })
+      unpacked = MessagePack.unpack(packed, symbolize_keys: true)
+      unpacked.should == { hello: 'world', nested: ['object', { structure: true }] }
     end
 
     it 'does not symbolize keys even if other options are present' do
-      packed = MessagePack.pack({'hello' => 'world', 'nested' => ['object', {'structure' => true}]})
-      unpacked = MessagePack.unpack(packed, :other_option => false)
-      unpacked.should == {'hello' => 'world', 'nested' => ['object', {'structure' => true}]}
+      packed = MessagePack.pack({ 'hello' => 'world', 'nested' => ['object', { 'structure' => true }] })
+      unpacked = MessagePack.unpack(packed, other_option: false)
+      unpacked.should == { 'hello' => 'world', 'nested' => ['object', { 'structure' => true }] }
     end
 
     it 'can unpack strings with a specified encoding', :encodings do
-      packed = MessagePack.pack({utf8enc('hello') => utf8enc('world')})
+      packed = MessagePack.pack({ utf8enc('hello') => utf8enc('world') })
       unpacked = MessagePack.unpack(packed)
       unpacked['hello'].encoding.should == Encoding::UTF_8
     end
 
     it 'can pack strings with a specified encoding', :encodings do
-      packed = MessagePack.pack({'hello' => "w\xE5rld".force_encoding(Encoding::ISO_8859_1)})
+      packed = MessagePack.pack({ 'hello' => "w\xE5rld".force_encoding(Encoding::ISO_8859_1) })
       packed.index("w\xC3\xA5rld").should_not be_nil
     end
   end
@@ -174,7 +174,7 @@ describe MessagePack do
     require 'stringio'
 
     it 'work with IO destination object as 2nd argument of MessagePack.pack' do
-      Tempfile.create("pack-test") do |io|
+      Tempfile.create('pack-test') do |io|
         return_value = MessagePack.pack(utf8enc('hello world'), io)
         return_value.should be_nil
 
@@ -193,7 +193,7 @@ describe MessagePack do
     end
 
     it 'work with IO source object as source of MessagePack.unpack' do
-      Tempfile.create("unpack-test") do |io|
+      Tempfile.create('unpack-test') do |io|
         MessagePack.pack(utf8enc('hello world'), io)
         io.rewind
 

--- a/spec/pack_spec.rb
+++ b/spec/pack_spec.rb
@@ -1,10 +1,9 @@
 # encoding: ascii-8bit
+
 require 'spec_helper'
 
 require 'stringio'
-if defined?(Encoding)
-  Encoding.default_external = 'ASCII-8BIT'
-end
+Encoding.default_external = 'ASCII-8BIT' if defined?(Encoding)
 
 describe MessagePack do
   it 'to_msgpack returns String' do
@@ -13,49 +12,50 @@ describe MessagePack do
     false.to_msgpack.class.should == String
     1.to_msgpack.class.should == String
     1.0.to_msgpack.class.should == String
-    "".to_msgpack.class.should == String
-    Hash.new.to_msgpack.class.should == String
-    Array.new.to_msgpack.class.should == String
+    ''.to_msgpack.class.should == String
+    {}.to_msgpack.class.should == String
+    [].to_msgpack.class.should == String
   end
 
   class CustomPack01
-    def to_msgpack(pk=nil)
+    def to_msgpack(pk = nil)
       return MessagePack.pack(self, pk) unless pk.class == MessagePack::Packer
+
       pk.write_array_header(2)
       pk.write(1)
       pk.write(2)
-      return pk
+      pk
     end
   end
 
   class CustomPack02
-    def to_msgpack(pk=nil)
-      [1,2].to_msgpack(pk)
+    def to_msgpack(pk = nil)
+      [1, 2].to_msgpack(pk)
     end
   end
 
   it 'calls custom to_msgpack method' do
-    MessagePack.pack(CustomPack01.new).should == [1,2].to_msgpack
-    MessagePack.pack(CustomPack02.new).should == [1,2].to_msgpack
-    CustomPack01.new.to_msgpack.should == [1,2].to_msgpack
-    CustomPack02.new.to_msgpack.should == [1,2].to_msgpack
+    MessagePack.pack(CustomPack01.new).should == [1, 2].to_msgpack
+    MessagePack.pack(CustomPack02.new).should == [1, 2].to_msgpack
+    CustomPack01.new.to_msgpack.should == [1, 2].to_msgpack
+    CustomPack02.new.to_msgpack.should == [1, 2].to_msgpack
   end
 
   it 'calls custom to_msgpack method with io' do
     s01 = StringIO.new
     MessagePack.pack(CustomPack01.new, s01)
-    s01.string.should == [1,2].to_msgpack
+    s01.string.should == [1, 2].to_msgpack
 
     s02 = StringIO.new
     MessagePack.pack(CustomPack02.new, s02)
-    s02.string.should == [1,2].to_msgpack
+    s02.string.should == [1, 2].to_msgpack
 
     s03 = StringIO.new
     CustomPack01.new.to_msgpack(s03)
-    s03.string.should == [1,2].to_msgpack
+    s03.string.should == [1, 2].to_msgpack
 
     s04 = StringIO.new
     CustomPack02.new.to_msgpack(s04)
-    s04.string.should == [1,2].to_msgpack
+    s04.string.should == [1, 2].to_msgpack
   end
 end

--- a/spec/random_compat.rb
+++ b/spec/random_compat.rb
@@ -1,7 +1,6 @@
-
 unless defined? Random
   class Random
-    def initialize(seed=Time.now.to_i)
+    def initialize(seed = Time.now.to_i)
       Kernel.srand(seed)
       @seed = seed
     end
@@ -21,4 +20,3 @@ unless defined? Random
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-
 if ENV['SIMPLE_COV']
   require 'simplecov'
   SimpleCov.start do
@@ -9,7 +8,7 @@ if ENV['SIMPLE_COV']
 end
 
 if ENV['GC_STRESS']
-  puts "enable GC.stress"
+  puts 'enable GC.stress'
   GC.stress = true
 end
 
@@ -22,12 +21,12 @@ end
 if java?
   RSpec.configure do |c|
     c.treat_symbols_as_metadata_keys_with_true_values = true
-    c.filter_run_excluding :encodings => !(defined? Encoding)
+    c.filter_run_excluding encodings: !(defined? Encoding)
   end
 else
   RSpec.configure do |config|
     config.expect_with :rspec do |c|
-      c.syntax = [:should, :expect]
+      c.syntax = %i[should expect]
     end
   end
   Packer = MessagePack::Packer

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -6,7 +6,7 @@ describe MessagePack::Timestamp do
   describe 'malformed format' do
     it do
       expect do
-        MessagePack::Timestamp.from_msgpack_ext([0xd4, 0x00].pack("C*"))
+        MessagePack::Timestamp.from_msgpack_ext([0xd4, 0x00].pack('C*'))
       end.to raise_error(MessagePack::MalformedFormatError)
     end
   end
@@ -25,7 +25,7 @@ describe MessagePack::Timestamp do
 
     let(:time) { Time.local(2019, 6, 17, 1, 2, 3, 123_456_789 / 1000.0) }
     it 'serializes and deserializes Time' do
-      prefix_fixext8_with_type_id = [0xd7, -1].pack("c*")
+      prefix_fixext8_with_type_id = [0xd7, -1].pack('c*')
 
       packed = factory.pack(time)
       expect(packed).to start_with(prefix_fixext8_with_type_id)
@@ -38,7 +38,7 @@ describe MessagePack::Timestamp do
 
     let(:time_without_nsec) { Time.local(2019, 6, 17, 1, 2, 3, 0) }
     it 'serializes time without nanosec as fixext4' do
-      prefix_fixext4_with_type_id = [0xd6, -1].pack("c*")
+      prefix_fixext4_with_type_id = [0xd6, -1].pack('c*')
 
       packed = factory.pack(time_without_nsec)
       expect(packed).to start_with(prefix_fixext4_with_type_id)
@@ -49,7 +49,7 @@ describe MessagePack::Timestamp do
 
     let(:time_after_2514) { Time.at(1 << 34) } # the max num of 34bit int means 2514-05-30 01:53:04 UTC
     it 'serializes time after 2038 as ext8' do
-      prefix_ext8_with_12bytes_payload_and_type_id = [0xc7, 12, -1].pack("c*")
+      prefix_ext8_with_12bytes_payload_and_type_id = [0xc7, 12, -1].pack('c*')
 
       expect(time_after_2514.to_i).to be > 0xffffffff
       packed = factory.pack(time_after_2514)

--- a/spec/unpack_spec.rb
+++ b/spec/unpack_spec.rb
@@ -1,57 +1,56 @@
 # encoding: ascii-8bit
+
 require 'spec_helper'
 
 require 'stringio'
-if defined?(Encoding)
-  Encoding.default_external = 'ASCII-8BIT'
-end
+Encoding.default_external = 'ASCII-8BIT' if defined?(Encoding)
 
 describe MessagePack do
   it 'MessagePack.unpack symbolize_keys' do
-    symbolized_hash = {:a => 'b', :c => 'd'}
-    MessagePack.load(MessagePack.pack(symbolized_hash), :symbolize_keys => true).should == symbolized_hash
-    MessagePack.unpack(MessagePack.pack(symbolized_hash), :symbolize_keys => true).should == symbolized_hash
+    symbolized_hash = { a: 'b', c: 'd' }
+    MessagePack.load(MessagePack.pack(symbolized_hash), symbolize_keys: true).should == symbolized_hash
+    MessagePack.unpack(MessagePack.pack(symbolized_hash), symbolize_keys: true).should == symbolized_hash
   end
 
   it 'Unpacker#read symbolize_keys' do
-    unpacker = MessagePack::Unpacker.new(:symbolize_keys => true)
-    symbolized_hash = {:a => 'b', :c => 'd'}
+    unpacker = MessagePack::Unpacker.new(symbolize_keys: true)
+    symbolized_hash = { a: 'b', c: 'd' }
     unpacker.feed(MessagePack.pack(symbolized_hash)).read.should == symbolized_hash
   end
 
-  it "msgpack str 8 type" do
-    MessagePack.unpack([0xd9, 0x00].pack('C*')).should == ""
-    MessagePack.unpack([0xd9, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xd9, 0x02].pack('C*') + 'aa').should == "aa"
+  it 'msgpack str 8 type' do
+    MessagePack.unpack([0xd9, 0x00].pack('C*')).should == ''
+    MessagePack.unpack([0xd9, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xd9, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack str 16 type" do
-    MessagePack.unpack([0xda, 0x00, 0x00].pack('C*')).should == ""
-    MessagePack.unpack([0xda, 0x00, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xda, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
+  it 'msgpack str 16 type' do
+    MessagePack.unpack([0xda, 0x00, 0x00].pack('C*')).should == ''
+    MessagePack.unpack([0xda, 0x00, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xda, 0x00, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack str 32 type" do
-    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ""
-    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
+  it 'msgpack str 32 type' do
+    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ''
+    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack bin 8 type" do
-    MessagePack.unpack([0xc4, 0x00].pack('C*')).should == ""
-    MessagePack.unpack([0xc4, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xc4, 0x02].pack('C*') + 'aa').should == "aa"
+  it 'msgpack bin 8 type' do
+    MessagePack.unpack([0xc4, 0x00].pack('C*')).should == ''
+    MessagePack.unpack([0xc4, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xc4, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack bin 16 type" do
-    MessagePack.unpack([0xc5, 0x00, 0x00].pack('C*')).should == ""
-    MessagePack.unpack([0xc5, 0x00, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xc5, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
+  it 'msgpack bin 16 type' do
+    MessagePack.unpack([0xc5, 0x00, 0x00].pack('C*')).should == ''
+    MessagePack.unpack([0xc5, 0x00, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xc5, 0x00, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack bin 32 type" do
-    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ""
-    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
+  it 'msgpack bin 32 type' do
+    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ''
+    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 end

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -26,10 +26,10 @@ describe MessagePack::Unpacker do
   end
 
   it 'gets IO or object which has #read to read data from it' do
-    sample_data = {"message" => "morning!", "num" => 1}
+    sample_data = { 'message' => 'morning!', 'num' => 1 }
     sample_packed = MessagePack.pack(sample_data).force_encoding('ASCII-8BIT')
 
-    Tempfile.open("for_io") do |file|
+    Tempfile.open('for_io') do |file|
       file.sync = true
       file.write sample_packed
       file.rewind
@@ -48,7 +48,7 @@ describe MessagePack::Unpacker do
     end
 
     dio = StringIO.new
-    Zlib::GzipWriter.wrap(dio){|gz| gz.write sample_packed }
+    Zlib::GzipWriter.wrap(dio) { |gz| gz.write sample_packed }
     reader = Zlib::GzipReader.new(StringIO.new(dio.string))
     u3 = MessagePack::Unpacker.new(reader)
     u3.each do |obj|
@@ -57,13 +57,15 @@ describe MessagePack::Unpacker do
 
     class DummyIO
       def initialize
-        @buf = "".force_encoding('ASCII-8BIT')
+        @buf = ''.force_encoding('ASCII-8BIT')
         @pos = 0
       end
+
       def write(val)
         @buf << val.to_s
       end
-      def read(length=nil,outbuf="")
+
+      def read(length = nil, outbuf = '')
         if @pos == @buf.size
           nil
         elsif length.nil?
@@ -79,6 +81,7 @@ describe MessagePack::Unpacker do
           outbuf
         end
       end
+
       def flush
         # nop
       end
@@ -109,12 +112,12 @@ describe MessagePack::Unpacker do
 
   it 'read_map_header converts an map to key-value sequence' do
     packer.write_array_header(2)
-    packer.write("e")
+    packer.write('e')
     packer.write(1)
     unpacker = MessagePack::Unpacker.new
     unpacker.feed(packer.to_s)
     unpacker.read_array_header.should == 2
-    unpacker.read.should == "e"
+    unpacker.read.should == 'e'
     unpacker.read.should == 1
   end
 
@@ -125,13 +128,13 @@ describe MessagePack::Unpacker do
 
   it 'read_map_header converts an map to key-value sequence' do
     packer.write_map_header(1)
-    packer.write("k")
-    packer.write("v")
+    packer.write('k')
+    packer.write('v')
     unpacker = MessagePack::Unpacker.new
     unpacker.feed(packer.to_s)
     unpacker.read_map_header.should == 1
-    unpacker.read.should == "k"
-    unpacker.read.should == "v"
+    unpacker.read.should == 'k'
+    unpacker.read.should == 'v'
   end
 
   it 'read_map_header fails' do
@@ -151,7 +154,7 @@ describe MessagePack::Unpacker do
   end
 
   let :sample_object do
-    [1024, {["a","b"]=>["c","d"]}, ["e","f"], "d", 70000, 4.12, 1.5, 1.5, 1.5]
+    [1024, { %w[a b] => %w[c d] }, %w[e f], 'd', 70_000, 4.12, 1.5, 1.5, 1.5]
   end
 
   it 'feed and each continue internal state' do
@@ -160,9 +163,9 @@ describe MessagePack::Unpacker do
 
     raw.split(//).each do |b|
       unpacker.feed(b)
-      unpacker.each {|c|
+      unpacker.each do |c|
         objects << c
-      }
+      end
     end
 
     objects.should == [sample_object] * 4
@@ -173,9 +176,9 @@ describe MessagePack::Unpacker do
     objects = []
 
     raw.split(//).each do |b|
-      unpacker.feed_each(b) {|c|
+      unpacker.feed_each(b) do |c|
         objects << c
-      }
+      end
     end
 
     objects.should == [sample_object] * 4
@@ -195,31 +198,31 @@ describe MessagePack::Unpacker do
     unpacker.reset
     unpacker.feed("\x01")
 
-    unpacker.each.map {|x| x }.should == [1]
+    unpacker.each.map { |x| x }.should == [1]
   end
 
   it 'reset clears internal state' do
     # 1-element array
     unpacker.feed("\x91")
-    unpacker.each.map {|x| x }.should == []
+    unpacker.each.map { |x| x }.should == []
 
     unpacker.reset
 
     unpacker.feed("\x01")
-    unpacker.each.map {|x| x }.should == [1]
+    unpacker.each.map { |x| x }.should == [1]
   end
 
   it 'frozen short strings' do
     raw = sample_object.to_msgpack.to_s.force_encoding('UTF-8')
     lambda {
-      unpacker.feed_each(raw.freeze) { }
+      unpacker.feed_each(raw.freeze) {}
     }.should_not raise_error
   end
 
   it 'frozen long strings' do
-    raw = (sample_object.to_msgpack.to_s * 10240).force_encoding('UTF-8')
+    raw = (sample_object.to_msgpack.to_s * 10_240).force_encoding('UTF-8')
     lambda {
-      unpacker.feed_each(raw.freeze) { }
+      unpacker.feed_each(raw.freeze) {}
     }.should_not raise_error
   end
 
@@ -230,25 +233,25 @@ describe MessagePack::Unpacker do
     }.should raise_error(MessagePack::MalformedFormatError)
   end
 
-  it "gc mark" do
+  it 'gc mark' do
     raw = sample_object.to_msgpack.to_s * 4
 
     n = 0
     raw.split(//).each do |b|
       GC.start
-      unpacker.feed_each(b) {|o|
+      unpacker.feed_each(b) do |o|
         GC.start
         o.should == sample_object
         n += 1
-      }
+      end
       GC.start
     end
 
     n.should == 4
   end
 
-  it "buffer" do
-    orig = "a"*32*1024*4
+  it 'buffer' do
+    orig = 'a' * 32 * 1024 * 4
     raw = orig.to_msgpack.to_s
 
     n = 655
@@ -264,94 +267,94 @@ describe MessagePack::Unpacker do
       seg = raw[off, n]
       off += seg.length
 
-      unpacker.feed_each(seg) {|obj|
+      unpacker.feed_each(seg) do |obj|
         parsed.should == false
         obj.should == orig
         parsed = true
-      }
+      end
     end
 
     parsed.should == true
   end
 
   it 'MessagePack.unpack symbolize_keys' do
-    symbolized_hash = {:a => 'b', :c => 'd'}
-    MessagePack.load(MessagePack.pack(symbolized_hash), :symbolize_keys => true).should == symbolized_hash
-    MessagePack.unpack(MessagePack.pack(symbolized_hash), :symbolize_keys => true).should == symbolized_hash
+    symbolized_hash = { a: 'b', c: 'd' }
+    MessagePack.load(MessagePack.pack(symbolized_hash), symbolize_keys: true).should == symbolized_hash
+    MessagePack.unpack(MessagePack.pack(symbolized_hash), symbolize_keys: true).should == symbolized_hash
   end
 
   it 'Unpacker#unpack symbolize_keys' do
-    unpacker = MessagePack::Unpacker.new(:symbolize_keys => true)
-    symbolized_hash = {:a => 'b', :c => 'd'}
+    unpacker = MessagePack::Unpacker.new(symbolize_keys: true)
+    symbolized_hash = { a: 'b', c: 'd' }
     unpacker.feed(MessagePack.pack(symbolized_hash)).read.should == symbolized_hash
   end
 
-  it "msgpack str 8 type" do
-    MessagePack.unpack([0xd9, 0x00].pack('C*')).should == ""
+  it 'msgpack str 8 type' do
+    MessagePack.unpack([0xd9, 0x00].pack('C*')).should == ''
     MessagePack.unpack([0xd9, 0x00].pack('C*')).encoding.should == Encoding::UTF_8
-    MessagePack.unpack([0xd9, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xd9, 0x02].pack('C*') + 'aa').should == "aa"
+    MessagePack.unpack([0xd9, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xd9, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack str 16 type" do
-    MessagePack.unpack([0xda, 0x00, 0x00].pack('C*')).should == ""
+  it 'msgpack str 16 type' do
+    MessagePack.unpack([0xda, 0x00, 0x00].pack('C*')).should == ''
     MessagePack.unpack([0xda, 0x00, 0x00].pack('C*')).encoding.should == Encoding::UTF_8
-    MessagePack.unpack([0xda, 0x00, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xda, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
+    MessagePack.unpack([0xda, 0x00, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xda, 0x00, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack str 32 type" do
-    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ""
+  it 'msgpack str 32 type' do
+    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ''
     MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x00].pack('C*')).encoding.should == Encoding::UTF_8
-    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
+    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xdb, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack bin 8 type" do
-    MessagePack.unpack([0xc4, 0x00].pack('C*')).should == ""
+  it 'msgpack bin 8 type' do
+    MessagePack.unpack([0xc4, 0x00].pack('C*')).should == ''
     MessagePack.unpack([0xc4, 0x00].pack('C*')).encoding.should == Encoding::ASCII_8BIT
-    MessagePack.unpack([0xc4, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xc4, 0x02].pack('C*') + 'aa').should == "aa"
+    MessagePack.unpack([0xc4, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xc4, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack bin 16 type" do
-    MessagePack.unpack([0xc5, 0x00, 0x00].pack('C*')).should == ""
+  it 'msgpack bin 16 type' do
+    MessagePack.unpack([0xc5, 0x00, 0x00].pack('C*')).should == ''
     MessagePack.unpack([0xc5, 0x00, 0x00].pack('C*')).encoding.should == Encoding::ASCII_8BIT
-    MessagePack.unpack([0xc5, 0x00, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xc5, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
+    MessagePack.unpack([0xc5, 0x00, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xc5, 0x00, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  it "msgpack bin 32 type" do
-    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ""
+  it 'msgpack bin 32 type' do
+    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x00].pack('C*')).should == ''
     MessagePack.unpack([0xc6, 0x0, 0x00, 0x00, 0x000].pack('C*')).encoding.should == Encoding::ASCII_8BIT
-    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == "a"
-    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == "aa"
+    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x01].pack('C*') + 'a').should == 'a'
+    MessagePack.unpack([0xc6, 0x00, 0x00, 0x00, 0x02].pack('C*') + 'aa').should == 'aa'
   end
 
-  describe "ext formats" do
+  describe 'ext formats' do
     let(:unpacker) { MessagePack::Unpacker.new(allow_unknown_ext: true) }
 
-    [1, 2, 4, 8, 16].zip([0xd4, 0xd5, 0xd6, 0xd7, 0xd8]).each do |n,b|
+    [1, 2, 4, 8, 16].zip([0xd4, 0xd5, 0xd6, 0xd7, 0xd8]).each do |n, b|
       it "msgpack fixext #{n} format" do
-        unpacker.feed([b, 1].pack('CC') + "a"*n).unpack.should == MessagePack::ExtensionValue.new(1, "a"*n)
-        unpacker.feed([b, -1].pack('CC') + "a"*n).unpack.should == MessagePack::ExtensionValue.new(-1, "a"*n)
+        unpacker.feed([b, 1].pack('CC') + 'a' * n).unpack.should == MessagePack::ExtensionValue.new(1, 'a' * n)
+        unpacker.feed([b, -1].pack('CC') + 'a' * n).unpack.should == MessagePack::ExtensionValue.new(-1, 'a' * n)
       end
     end
 
-    it "msgpack ext 8 format" do
-      unpacker.feed([0xc7, 0, 1].pack('CCC')).unpack.should == MessagePack::ExtensionValue.new(1, "")
-      unpacker.feed([0xc7, 255, -1].pack('CCC') + "a"*255).unpack.should == MessagePack::ExtensionValue.new(-1, "a"*255)
+    it 'msgpack ext 8 format' do
+      unpacker.feed([0xc7, 0, 1].pack('CCC')).unpack.should == MessagePack::ExtensionValue.new(1, '')
+      unpacker.feed([0xc7, 255, -1].pack('CCC') + 'a' * 255).unpack.should == MessagePack::ExtensionValue.new(-1, 'a' * 255)
     end
 
-    it "msgpack ext 16 format" do
-      unpacker.feed([0xc8, 0, 1].pack('CnC')).unpack.should == MessagePack::ExtensionValue.new(1, "")
-      unpacker.feed([0xc8, 256, -1].pack('CnC') + "a"*256).unpack.should == MessagePack::ExtensionValue.new(-1, "a"*256)
+    it 'msgpack ext 16 format' do
+      unpacker.feed([0xc8, 0, 1].pack('CnC')).unpack.should == MessagePack::ExtensionValue.new(1, '')
+      unpacker.feed([0xc8, 256, -1].pack('CnC') + 'a' * 256).unpack.should == MessagePack::ExtensionValue.new(-1, 'a' * 256)
     end
 
-    it "msgpack ext 32 format" do
-      unpacker.feed([0xc9, 0, 1].pack('CNC')).unpack.should == MessagePack::ExtensionValue.new(1, "")
-      unpacker.feed([0xc9, 256, -1].pack('CNC') + "a"*256).unpack.should == MessagePack::ExtensionValue.new(-1, "a"*256)
-      unpacker.feed([0xc9, 65536, -1].pack('CNC') + "a"*65536).unpack.should == MessagePack::ExtensionValue.new(-1, "a"*65536)
+    it 'msgpack ext 32 format' do
+      unpacker.feed([0xc9, 0, 1].pack('CNC')).unpack.should == MessagePack::ExtensionValue.new(1, '')
+      unpacker.feed([0xc9, 256, -1].pack('CNC') + 'a' * 256).unpack.should == MessagePack::ExtensionValue.new(-1, 'a' * 256)
+      unpacker.feed([0xc9, 65_536, -1].pack('CNC') + 'a' * 65_536).unpack.should == MessagePack::ExtensionValue.new(-1, 'a' * 65_536)
     end
   end
 
@@ -360,17 +363,19 @@ describe MessagePack::Unpacker do
     def initialize(num)
       @num = num
     end
+
     def ==(obj)
-      self.num == obj.num
+      num == obj.num
     end
-    def num
-      @num
-    end
+
+    attr_reader :num
+
     def to_msgpack_ext
       @num.to_msgpack
     end
+
     def self.from_msgpack_ext(data)
-      self.new(MessagePack.unpack(data))
+      new(MessagePack.unpack(data))
     end
   end
 
@@ -379,17 +384,21 @@ describe MessagePack::Unpacker do
     def initialize(num)
       @num_s = num.to_s
     end
+
     def ==(obj)
-      self.num_s == obj.num_s
+      num_s == obj.num_s
     end
+
     def num
       @num_s.to_i
     end
+
     def to_msgpack_ext
       @num_s.to_msgpack
     end
+
     def self.from_msgpack_ext(data)
-      self.new(MessagePack.unpack(data))
+      new(MessagePack.unpack(data))
     end
   end
 
@@ -414,7 +423,7 @@ describe MessagePack::Unpacker do
     end
 
     it 'cannot detect unpack rule with block, not method' do
-      subject.register_type(0x40){|data| ValueOne.from_msgpack_ext(data) }
+      subject.register_type(0x40) { |data| ValueOne.from_msgpack_ext(data) }
 
       expect(subject.type_registered?(0x40)).to be_truthy
       expect(subject.type_registered?(ValueOne)).to be_falsy
@@ -424,8 +433,8 @@ describe MessagePack::Unpacker do
   context 'with ext definitions' do
     it 'get type and class mapping for packing' do
       unpacker = MessagePack::Unpacker.new
-      unpacker.register_type(0x01){|data| ValueOne.from_msgpack_ext }
-      unpacker.register_type(0x02){|data| ValueTwo.from_msgpack_ext(data) }
+      unpacker.register_type(0x01) { |data| ValueOne.from_msgpack_ext }
+      unpacker.register_type(0x02) { |data| ValueTwo.from_msgpack_ext(data) }
 
       unpacker = MessagePack::Unpacker.new
       unpacker.register_type(0x01, ValueOne, :from_msgpack_ext)
@@ -443,13 +452,13 @@ describe MessagePack::Unpacker do
       expect(list.size).to eq(2)
 
       one = list[0]
-      expect(one.keys.sort).to eq([:type, :class, :unpacker].sort)
+      expect(one.keys.sort).to eq(%i[type class unpacker].sort)
       expect(one[:type]).to eq(0x01)
       expect(one[:class]).to eq(ValueOne)
       expect(one[:unpacker]).to eq(:from_msgpack_ext)
 
       two = list[1]
-      expect(two.keys.sort).to eq([:type, :class, :unpacker].sort)
+      expect(two.keys.sort).to eq(%i[type class unpacker].sort)
       expect(two[:type]).to eq(0x02)
       expect(two[:class]).to eq(ValueTwo)
       expect(two[:unpacker]).to eq(:from_msgpack_ext)
@@ -457,7 +466,7 @@ describe MessagePack::Unpacker do
 
     it 'returns a Array of Hash, which contains nil for class if block unpacker specified' do
       unpacker = MessagePack::Unpacker.new
-      unpacker.register_type(0x01){|data| ValueOne.from_msgpack_ext }
+      unpacker.register_type(0x01) { |data| ValueOne.from_msgpack_ext }
       unpacker.register_type(0x02, &ValueTwo.method(:from_msgpack_ext))
 
       list = unpacker.registered_types
@@ -466,19 +475,19 @@ describe MessagePack::Unpacker do
       expect(list.size).to eq(2)
 
       one = list[0]
-      expect(one.keys.sort).to eq([:type, :class, :unpacker].sort)
+      expect(one.keys.sort).to eq(%i[type class unpacker].sort)
       expect(one[:type]).to eq(0x01)
       expect(one[:class]).to be_nil
       expect(one[:unpacker]).to be_instance_of(Proc)
 
       two = list[1]
-      expect(two.keys.sort).to eq([:type, :class, :unpacker].sort)
+      expect(two.keys.sort).to eq(%i[type class unpacker].sort)
       expect(two[:type]).to eq(0x02)
       expect(two[:class]).to be_nil
       expect(two[:unpacker]).to be_instance_of(Proc)
     end
 
-    describe "registering an ext type for a module" do
+    describe 'registering an ext type for a module' do
       subject { unpacker.feed("\xc7\x06\x00module").unpack }
 
       let(:unpacker) { MessagePack::Unpacker.new }
@@ -493,7 +502,7 @@ describe MessagePack::Unpacker do
       end
 
       before { unpacker.register_type(0x00, Mod, :from_msgpack_ext) }
-      it { is_expected.to eq "unpacked module" }
+      it { is_expected.to eq 'unpacked module' }
     end
   end
 
@@ -514,15 +523,15 @@ describe MessagePack::Unpacker do
   end
 
   let :buffer1 do
-    MessagePack.pack(:foo => 'bar')
+    MessagePack.pack(foo: 'bar')
   end
 
   let :buffer2 do
-    MessagePack.pack(:hello => {:world => [1, 2, 3]})
+    MessagePack.pack(hello: { world: [1, 2, 3] })
   end
 
   let :buffer3 do
-    MessagePack.pack(:x => 'y')
+    MessagePack.pack(x: 'y')
   end
 
   describe '#read' do
@@ -535,7 +544,7 @@ describe MessagePack::Unpacker do
         objects << subject.read
         objects << subject.read
         objects << subject.read
-        objects.should == [{'foo' => 'bar'}, {'hello' => {'world' => [1, 2, 3]}}, {'x' => 'y'}]
+        objects.should == [{ 'foo' => 'bar' }, { 'hello' => { 'world' => [1, 2, 3] } }, { 'x' => 'y' }]
       end
 
       it 'reads map header' do
@@ -560,7 +569,7 @@ describe MessagePack::Unpacker do
         subject.each do |obj|
           objects << obj
         end
-        objects.should == [{'foo' => 'bar'}, {'hello' => {'world' => [1, 2, 3]}}, {'x' => 'y'}]
+        objects.should == [{ 'foo' => 'bar' }, { 'hello' => { 'world' => [1, 2, 3] } }, { 'x' => 'y' }]
       end
 
       it 'returns an enumerator when no block is given' do
@@ -579,7 +588,7 @@ describe MessagePack::Unpacker do
         unpacker.each do |obj|
           objects << obj
         end
-        objects.should == [{'foo' => 'bar'}, {'hello' => {'world' => [1, 2, 3]}}, {'x' => 'y'}]
+        objects.should == [{ 'foo' => 'bar' }, { 'hello' => { 'world' => [1, 2, 3] } }, { 'x' => 'y' }]
       end
     end
 
@@ -590,7 +599,7 @@ describe MessagePack::Unpacker do
         unpacker.each do |obj|
           objects << obj
         end
-        objects.should == [{:foo => 'bar'}, {:hello => {:world => [1, 2, 3]}}, {:x => 'y'}]
+        objects.should == [{ foo: 'bar' }, { hello: { world: [1, 2, 3] } }, { x: 'y' }]
       end
     end
   end
@@ -601,7 +610,7 @@ describe MessagePack::Unpacker do
       subject.feed_each(buffer1 + buffer2 + buffer3) do |obj|
         objects << obj
       end
-      objects.should == [{'foo' => 'bar'}, {'hello' => {'world' => [1, 2, 3]}}, {'x' => 'y'}]
+      objects.should == [{ 'foo' => 'bar' }, { 'hello' => { 'world' => [1, 2, 3] } }, { 'x' => 'y' }]
     end
 
     it 'handles chunked data' do
@@ -612,7 +621,7 @@ describe MessagePack::Unpacker do
           objects << obj
         end
       end
-      objects.should == [{'foo' => 'bar'}, {'hello' => {'world' => [1, 2, 3]}}, {'x' => 'y'}]
+      objects.should == [{ 'foo' => 'bar' }, { 'hello' => { 'world' => [1, 2, 3] } }, { 'x' => 'y' }]
     end
   end
 
@@ -626,11 +635,11 @@ describe MessagePack::Unpacker do
   context 'extensions' do
     context 'symbolized keys' do
       let :buffer do
-        MessagePack.pack({'hello' => 'world', 'nested' => ['object', {'structure' => true}]})
+        MessagePack.pack({ 'hello' => 'world', 'nested' => ['object', { 'structure' => true }] })
       end
 
       let :unpacker do
-        described_class.new(:symbolize_keys => true)
+        described_class.new(symbolize_keys: true)
       end
 
       it 'can symbolize keys when using #each' do
@@ -639,7 +648,7 @@ describe MessagePack::Unpacker do
         unpacker.each do |obj|
           objs << obj
         end
-        objs.should == [{:hello => 'world', :nested => ['object', {:structure => true}]}]
+        objs.should == [{ hello: 'world', nested: ['object', { structure: true }] }]
       end
 
       it 'can symbolize keys when using #feed_each' do
@@ -647,17 +656,17 @@ describe MessagePack::Unpacker do
         unpacker.feed_each(buffer) do |obj|
           objs << obj
         end
-        objs.should == [{:hello => 'world', :nested => ['object', {:structure => true}]}]
+        objs.should == [{ hello: 'world', nested: ['object', { structure: true }] }]
       end
     end
 
     context 'binary encoding', :encodings do
       let :buffer do
-        MessagePack.pack({'hello' => 'world', 'nested' => ['object', {'structure' => true}]})
+        MessagePack.pack({ 'hello' => 'world', 'nested' => ['object', { 'structure' => true }] })
       end
 
       let :unpacker do
-        described_class.new()
+        described_class.new
       end
 
       it 'decodes binary as ascii-8bit when using #feed' do
@@ -684,11 +693,11 @@ describe MessagePack::Unpacker do
 
     context 'string encoding', :encodings do
       let :buffer do
-        MessagePack.pack({'hello'.force_encoding(Encoding::UTF_8) => 'world'.force_encoding(Encoding::UTF_8), 'nested'.force_encoding(Encoding::UTF_8) => ['object'.force_encoding(Encoding::UTF_8), {'structure'.force_encoding(Encoding::UTF_8) => true}]})
+        MessagePack.pack({ 'hello'.force_encoding(Encoding::UTF_8) => 'world'.force_encoding(Encoding::UTF_8), 'nested'.force_encoding(Encoding::UTF_8) => ['object'.force_encoding(Encoding::UTF_8), { 'structure'.force_encoding(Encoding::UTF_8) => true }] })
       end
 
       let :unpacker do
-        described_class.new()
+        described_class.new
       end
 
       it 'decodes string as utf-8 when using #feed' do


### PR DESCRIPTION
### Changes

1. Disabled `Style/MutableConstant` on `buffer_spec.rb` because it would raise:
```
FrozenError: can't modify frozen Hash: {}
```
2. Disabled `Lint/UnifiedInteger` on `core_ext.rb` because it would raise:
```
ArgumentError: superclass #<yardoc class Integer> cannot be the same as the declared class #<yardoc class Integer>
```
3. Used Rubocop safe auto-correct:
```ruby
rubocop --safe-auto-correct
Inspecting 51 files
CCCCCCCCCCCWCCCCCCCCCWCCCCCCCCCCCCCCCCWCCCCCCCCCCCC

Offenses:

...

51 files inspected, 1645 offenses detected, 1278 offenses corrected
```
4. Disabled commonly disabled cops with several incidents:
```
Layout/LineLength: # Line is too long
  Enabled: false

Metrics/BlockLength: # Block has too many lines.
  Enabled: false

Metrics/MethodLength: # Method has too many lines.
  Enabled: false

Naming/MethodParameterName: # Method parameter must be at least 3 characters long.
  Enabled: false

Style/FrozenStringLiteralComment: # Missing frozen string literal comment
  Enabled: false
```
