### PR TITLE
Ensure that string hash keys are deduplicated

### DIFF
--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -25,6 +25,43 @@ if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   $CFLAGS << %[ -DDISABLE_RMEM]
 end
 
+# checking if String#-@ (str_uminus) dedupes
+begin
+  a = -(%w(t e s t).join)
+  b = -(%w(t e s t).join)
+  if a.equal?(b)
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE=1 '
+  else
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE=0 '
+  end
+rescue NoMethodError
+  $CFLAGS << ' -DSTR_UMINUS_DEDUPE=0 '
+end
+
+# checking if Hash#[]= (rb_hash_aset) dedupes string keys
+h = {}
+x = {}
+r = rand.to_s
+h[%W(#{r}).join('')] = :foo
+x[%W(#{r}).join('')] = :foo
+if x.keys[0].equal?(h.keys[0])
+  $CFLAGS << ' -DHASH_ASET_DEDUPE=1 '
+else
+  $CFLAGS << ' -DHASH_ASET_DEDUPE=0 '
+end
+
+# checking if Hash#[]= (rb_hash_aset) dedupes frozen string keys
+h = {}
+x = {}
+r = rand.to_s
+h[%W(#{r}).join('').freeze] = :foo
+x[%W(#{r}).join('').freeze] = :foo
+if x.keys[0].equal?(h.keys[0])
+  $CFLAGS << ' -DHASH_ASET_DEDUPE_FROZEN=1 '
+else
+  $CFLAGS << ' -DHASH_ASET_DEDUPE_FROZEN=0 '
+end
+
 if warnflags = CONFIG['warnflags']
   warnflags.slice!(/ -Wdeclaration-after-statement/)
 end

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -25,6 +25,15 @@ describe MessagePack::Unpacker do
     u2.allow_unknown_ext?.should == true
   end
 
+  it 'ensure string hash keys are deduplicated' do
+    sample_data = [{"foo" => 1}, {"foo" => 2}]
+    sample_packed = MessagePack.pack(sample_data).force_encoding('ASCII-8BIT')
+    unpacker.feed(sample_packed)
+    hashes = nil
+    unpacker.each { |obj| hashes = obj }
+    expect(hashes[0].keys.first).to equal(hashes[1].keys.first)
+  end
+
   it 'gets IO or object which has #read to read data from it' do
     sample_data = {"message" => "morning!", "num" => 1}
     sample_packed = MessagePack.pack(sample_data).force_encoding('ASCII-8BIT')


### PR DESCRIPTION
@tagomoris, I just saw your Ruby ticket: https://bugs.ruby-lang.org/issues/17147?next_issue_id=16150&prev_issue_id=16651

I wanted to improve msgpack allocations for a while, but I was waiting for the `fstring_*` functions to be expose to C-exts: https://bugs.ruby-lang.org/issues/13381. This is supposed to happen for MRI 3.0, but isn't quite done yet as there is debate on the naming.

In the meantime I think there are a few things that could be done. First modern rubies deduplicate hash keys automatically, but there are a few corner cases. For instance on 2.7 `hash["foo"] = 1` is deduplicated, but not `hash["foo".freeze] = 1`. I suspect it's an oversight.

So I think it would make sense to always deduplicate hash keys.

As a followup I'd like to propose a new `freeze: true` option to deduplicate all strings like Psych: https://github.com/ruby/psych/pull/414