### PR TITLE
Do not pre-freeze string keys if Ruby will dedup them

### DIFF
--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -25,6 +25,18 @@ if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   $CFLAGS << %[ -DDISABLE_RMEM]
 end
 
+# checking if Hash#[]= (rb_hash_aset) dedupes string keys
+h = {}
+x = {}
+r = rand.to_s
+h[%W(#{r}).join('')] = :foo
+x[%W(#{r}).join('')] = :foo
+if x.keys[0].equal?(h.keys[0])
+  $CFLAGS << ' -DHASH_ASET_DEDUPE=1 '
+else
+  $CFLAGS << ' -DHASH_ASET_DEDUPE=0 '
+end
+
 if warnflags = CONFIG['warnflags']
   warnflags.slice!(/ -Wdeclaration-after-statement/)
 end

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -300,9 +300,12 @@ static inline int read_raw_body_begin(msgpack_unpacker_t* uk, int raw_type)
         } else {
             ret = object_complete_ext(uk, raw_type, string);
         }
+
+# if !HASH_ASET_DEDUPE
         if(will_freeze) {
             rb_obj_freeze(string);
         }
+# endif
         uk->reading_raw_remaining = 0;
         return ret;
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,17 @@ def java?
   /java/ =~ RUBY_PLATFORM
 end
 
+# checking if Hash#[]= (rb_hash_aset) dedupes string keys
+def automatic_string_keys_deduplication?
+  h = {}
+  x = {}
+  r = rand.to_s
+  h[%W(#{r}).join('')] = :foo
+  x[%W(#{r}).join('')] = :foo
+
+  x.keys[0].equal?(h.keys[0])
+end
+
 if java?
   RSpec.configure do |c|
     c.treat_symbols_as_metadata_keys_with_true_values = true

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -25,6 +25,17 @@ describe MessagePack::Unpacker do
     u2.allow_unknown_ext?.should == true
   end
 
+  if automatic_string_keys_deduplication?
+    it 'ensure string hash keys are deduplicated' do
+      sample_data = [{"foo" => 1}, {"foo" => 2}]
+      sample_packed = MessagePack.pack(sample_data).force_encoding('ASCII-8BIT')
+      unpacker.feed(sample_packed)
+      hashes = nil
+      unpacker.each { |obj| hashes = obj }
+      expect(hashes[0].keys.first).to equal(hashes[1].keys.first)
+    end
+  end
+
   it 'gets IO or object which has #read to read data from it' do
     sample_data = {"message" => "morning!", "num" => 1}
     sample_packed = MessagePack.pack(sample_data).force_encoding('ASCII-8BIT')


### PR DESCRIPTION
Extracted out of https://github.com/msgpack/msgpack-ruby/pull/190

As discussed there, since 2.6 `Hash#[]=` / `rb_hash_aset` automatically deduplicate string keys, unless (and I think it's a bug) they are already frozen. [Source](https://github.com/ruby/ruby/blob/17a27060a75f2b2f773e2ebef56cf943bf1b4e4e/hash.c#L2876-L2894).

So I this case I don't think pre-freezing the keys is as much of an optimization as it was pre 2.6. 