### PR TITLE
Stop supporting fat gems

### DIFF
--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -5,11 +5,7 @@ if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby" # This is same with `/java/ =
   require "msgpack/msgpack.jar"
   org.msgpack.jruby.MessagePackLibrary.new.load(JRuby.runtime, false)
 else
-  begin
-    require "msgpack/#{RUBY_VERSION[/\d+.\d+/]}/msgpack"
-  rescue LoadError
-    require "msgpack/msgpack"
-  end
+  require "msgpack/msgpack"
 end
 
 require "msgpack/packer"

--- a/lib/msgpack/version.rb
+++ b/lib/msgpack/version.rb
@@ -1,5 +1,5 @@
 module MessagePack
-  VERSION = "1.3.3"
+  VERSION = "1.4.0.pre1"
 
   # NOTE for msgpack-ruby maintainer:
   # Check these things to release new binaryes for new Ruby versions (especially for Windows):


### PR DESCRIPTION
This change is to stop loading pre-built binaries (mainly for mswin32 arch).

Such binaries make release steps more complex and introduce barriers from using newer Ruby versions because of un-released msgpack-ruby versions for newer Ruby versions.

Fix #192 