### PR TITLE
Implement a freeze: unpacker option

### DIFF
--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -37,6 +37,32 @@ else
   $CFLAGS << ' -DHASH_ASET_DEDUPE=0 '
 end
 
+
+# checking if String#-@ (str_uminus) dedupes... '
+begin
+  a = -(%w(t e s t).join)
+  b = -(%w(t e s t).join)
+  if a.equal?(b)
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE=1 '
+  else
+    $CFLAGS += ' -DSTR_UMINUS_DEDUPE=0 '
+  end
+rescue NoMethodError
+  $CFLAGS << ' -DSTR_UMINUS_DEDUPE=0 '
+end
+
+# checking if String#-@ (str_uminus) directly interns frozen strings... '
+begin
+  s = rand.to_s.freeze
+  if (-s).equal?(s) && (-s.dup).equal?(s)
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE_FROZEN=1 '
+  else
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE_FROZEN=0 '
+  end
+rescue NoMethodError
+  $CFLAGS << ' -DSTR_UMINUS_DEDUPE_FROZEN=0 '
+end
+
 if warnflags = CONFIG['warnflags']
   warnflags.slice!(/ -Wdeclaration-after-statement/)
 end

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -64,6 +64,7 @@ struct msgpack_unpacker_t {
 
     /* options */
     bool symbolize_keys;
+    bool freeze;
     bool allow_unknown_ext;
 };
 
@@ -94,6 +95,11 @@ void _msgpack_unpacker_reset(msgpack_unpacker_t* uk);
 static inline void msgpack_unpacker_set_symbolized_keys(msgpack_unpacker_t* uk, bool enable)
 {
     uk->symbolize_keys = enable;
+}
+
+static inline void msgpack_unpacker_set_freeze(msgpack_unpacker_t* uk, bool enable)
+{
+    uk->freeze = enable;
 }
 
 static inline void msgpack_unpacker_set_allow_unknown_ext(msgpack_unpacker_t* uk, bool enable)

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -105,6 +105,9 @@ VALUE MessagePack_Unpacker_initialize(int argc, VALUE* argv, VALUE self)
         v = rb_hash_aref(options, ID2SYM(rb_intern("symbolize_keys")));
         msgpack_unpacker_set_symbolized_keys(uk, RTEST(v));
 
+        v = rb_hash_aref(options, ID2SYM(rb_intern("freeze")));
+        msgpack_unpacker_set_freeze(uk, RTEST(v));
+
         v = rb_hash_aref(options, ID2SYM(rb_intern("allow_unknown_ext")));
         msgpack_unpacker_set_allow_unknown_ext(uk, RTEST(v));
     }
@@ -116,6 +119,12 @@ static VALUE Unpacker_symbolized_keys_p(VALUE self)
 {
     UNPACKER(self, uk);
     return uk->symbolize_keys ? Qtrue : Qfalse;
+}
+
+static VALUE Unpacker_freeze_p(VALUE self)
+{
+    UNPACKER(self, uk);
+    return uk->freeze ? Qtrue : Qfalse;
 }
 
 static VALUE Unpacker_allow_unknown_ext_p(VALUE self)
@@ -438,6 +447,7 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
 
     rb_define_method(cMessagePack_Unpacker, "initialize", MessagePack_Unpacker_initialize, -1);
     rb_define_method(cMessagePack_Unpacker, "symbolize_keys?", Unpacker_symbolized_keys_p, 0);
+    rb_define_method(cMessagePack_Unpacker, "freeze?", Unpacker_freeze_p, 0);
     rb_define_method(cMessagePack_Unpacker, "allow_unknown_ext?", Unpacker_allow_unknown_ext_p, 0);
     rb_define_method(cMessagePack_Unpacker, "buffer", Unpacker_buffer, 0);
     rb_define_method(cMessagePack_Unpacker, "read", Unpacker_read, 0);

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,12 @@ def automatic_string_keys_deduplication?
   x.keys[0].equal?(h.keys[0])
 end
 
+def string_deduplication?
+  r1 = rand.to_s
+  r2 = r1.dup
+  (-r1).equal?(-r2)
+end
+
 if java?
   RSpec.configure do |c|
     c.treat_symbols_as_metadata_keys_with_true_values = true

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -18,10 +18,12 @@ describe MessagePack::Unpacker do
   it 'gets options to specify how to unpack values' do
     u1 = MessagePack::Unpacker.new
     u1.symbolize_keys?.should == false
+    u1.freeze?.should == false
     u1.allow_unknown_ext?.should == false
 
-    u2 = MessagePack::Unpacker.new(symbolize_keys: true, allow_unknown_ext: true)
+    u2 = MessagePack::Unpacker.new(symbolize_keys: true, freeze: true, allow_unknown_ext: true)
     u2.symbolize_keys?.should == true
+    u2.freeze?.should == true
     u2.allow_unknown_ext?.should == true
   end
 
@@ -659,6 +661,88 @@ describe MessagePack::Unpacker do
           objs << obj
         end
         objs.should == [{:hello => 'world', :nested => ['object', {:structure => true}]}]
+      end
+    end
+
+    context 'freeze' do
+      let :struct do
+        {'hello' => 'world', 'nested' => ['object', {'structure' => true}]}
+      end
+
+      let :buffer do
+        MessagePack.pack(struct)
+      end
+
+      let :unpacker do
+        described_class.new(:freeze => true)
+      end
+
+      it 'can freeze objects when using .unpack' do
+        parsed_struct = MessagePack.unpack(buffer, freeze: true)
+        parsed_struct.should == struct
+
+        parsed_struct.should be_frozen
+        parsed_struct['hello'].should be_frozen
+        parsed_struct['nested'].should be_frozen
+        parsed_struct['nested'][0].should be_frozen
+        parsed_struct['nested'][1].should be_frozen
+
+        if string_deduplication?
+          parsed_struct.keys[0].should be_equal('hello'.freeze)
+          parsed_struct.keys[1].should be_equal('nested'.freeze)
+          parsed_struct.values[0].should be_equal('world'.freeze)
+          parsed_struct.values[1][0].should be_equal('object'.freeze)
+          parsed_struct.values[1][1].keys[0].should be_equal('structure'.freeze)
+        end
+      end
+
+      it 'can freeze objects when using #each' do
+        objs = []
+        unpacker.feed(buffer)
+        unpacker.each do |obj|
+          objs << obj
+        end
+
+        parsed_struct = objs.first
+        parsed_struct.should == struct
+
+        parsed_struct.should be_frozen
+        parsed_struct['hello'].should be_frozen
+        parsed_struct['nested'].should be_frozen
+        parsed_struct['nested'][0].should be_frozen
+        parsed_struct['nested'][1].should be_frozen
+
+        if string_deduplication?
+          parsed_struct.keys[0].should be_equal('hello'.freeze)
+          parsed_struct.keys[1].should be_equal('nested'.freeze)
+          parsed_struct.values[0].should be_equal('world'.freeze)
+          parsed_struct.values[1][0].should be_equal('object'.freeze)
+          parsed_struct.values[1][1].keys[0].should be_equal('structure'.freeze)
+        end
+      end
+
+      it 'can freeze objects when using #feed_each' do
+        objs = []
+        unpacker.feed_each(buffer) do |obj|
+          objs << obj
+        end
+
+        parsed_struct = objs.first
+        parsed_struct.should == struct
+
+        parsed_struct.should be_frozen
+        parsed_struct['hello'].should be_frozen
+        parsed_struct['nested'].should be_frozen
+        parsed_struct['nested'][0].should be_frozen
+        parsed_struct['nested'][1].should be_frozen
+
+        if string_deduplication?
+          parsed_struct.keys[0].should be_equal('hello'.freeze)
+          parsed_struct.keys[1].should be_equal('nested'.freeze)
+          parsed_struct.values[0].should be_equal('world'.freeze)
+          parsed_struct.values[1][0].should be_equal('object'.freeze)
+          parsed_struct.values[1][1].keys[0].should be_equal('structure'.freeze)
+        end
       end
     end
 


### PR DESCRIPTION
As discussed in https://github.com/msgpack/msgpack-ruby/pull/190

If set to true all parsed objects will be immediately frozen, and strings will be deduplicated if the Ruby implementation allows it.

This feature is meant to be similar to Pysch's `freeze:` option: https://github.com/ruby/psych/pull/414

For now this option is only useful if you plan to keep the parsed objects around, and want to reduce their memory footprint.

But hopefully Ruby 3.0 should soon expose `rb_fstring_new(const char *ptr, long len)` (likely under another name) which should allow to reduce allocations by directly looking up existing strings without allocating a new one.

cc @tagomoris 

NB: I presume that a java implementation is needed, I'm not too well versed into Java by I can try my hand at it. However I'd rather have your feedback on the MRI implementation first.