### PR TITLE
Remove COMPAT_HAVE_ENCODING ifdef

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -23,11 +23,9 @@
 static ID s_replace;
 #endif
 
-#ifdef COMPAT_HAVE_ENCODING  /* see compat.h*/
 int msgpack_rb_encindex_utf8;
 int msgpack_rb_encindex_usascii;
 int msgpack_rb_encindex_ascii8bit;
-#endif
 
 #ifndef DISABLE_RMEM
 static msgpack_rmem_t s_rmem;
@@ -35,11 +33,9 @@ static msgpack_rmem_t s_rmem;
 
 void msgpack_buffer_static_init()
 {
-#ifdef COMPAT_HAVE_ENCODING
     msgpack_rb_encindex_utf8 = rb_utf8_encindex();
     msgpack_rb_encindex_usascii = rb_usascii_encindex();
     msgpack_rb_encindex_ascii8bit = rb_ascii8bit_encindex();
-#endif
 
 #ifndef DISABLE_RMEM
     msgpack_rmem_init(&s_rmem);
@@ -308,9 +304,7 @@ static inline void _msgpack_buffer_add_new_chunk(msgpack_buffer_t* b)
 static inline void _msgpack_buffer_append_reference(msgpack_buffer_t* b, VALUE string)
 {
     VALUE mapped_string = rb_str_dup(string);
-#ifdef COMPAT_HAVE_ENCODING
     ENCODING_SET(mapped_string, msgpack_rb_encindex_ascii8bit);
-#endif
 
     _msgpack_buffer_add_new_chunk(b);
 
@@ -337,7 +331,6 @@ void _msgpack_buffer_append_long_string(msgpack_buffer_t* b, VALUE string)
 
     if(b->io != Qnil) {
         msgpack_buffer_flush(b);
-#ifdef COMPAT_HAVE_ENCODING
         if (ENCODING_GET(string) == msgpack_rb_encindex_ascii8bit) {
             rb_funcall(b->io, b->io_write_all_method, 1, string);
         } else if(!STR_DUP_LIKELY_DOES_COPY(string)) {
@@ -347,10 +340,6 @@ void _msgpack_buffer_append_long_string(msgpack_buffer_t* b, VALUE string)
         } else {
             msgpack_buffer_append(b, RSTRING_PTR(string), length);
         }
-#else
-        rb_funcall(b->io, b->io_write_all_method, 1, string);
-#endif
-
     } else if(!STR_DUP_LIKELY_DOES_COPY(string)) {
         _msgpack_buffer_append_reference(b, string);
 

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -49,11 +49,9 @@
 
 #define NO_MAPPED_STRING ((VALUE)0)
 
-#ifdef COMPAT_HAVE_ENCODING  /* see compat.h*/
 extern int msgpack_rb_encindex_utf8;
 extern int msgpack_rb_encindex_usascii;
 extern int msgpack_rb_encindex_ascii8bit;
-#endif
 
 struct msgpack_buffer_chunk_t;
 typedef struct msgpack_buffer_chunk_t msgpack_buffer_chunk_t;

--- a/ext/msgpack/compat.h
+++ b/ext/msgpack/compat.h
@@ -20,6 +20,7 @@
 
 #include <stdbool.h>
 #include "ruby.h"
+#include "ruby/encoding.h"
 
 #if defined(HAVE_RUBY_ST_H)
 #  include "ruby/st.h"  /* ruby hash on Ruby 1.9 */
@@ -36,18 +37,6 @@
 #endif
 #ifndef ZALLOC_N
 #  define ZALLOC_N(type,n) RB_ZALLOC_N(type,n)
-#endif
-
-/*
- * COMPAT_HAVE_ENCODING
- */
-#ifdef HAVE_RUBY_ENCODING_H
-#  include "ruby/encoding.h"
-#  define COMPAT_HAVE_ENCODING
-#endif
-
-#if defined(__MACRUBY__)  /* MacRuby */
-#  undef COMPAT_HAVE_ENCODING
 #endif
 
 

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -396,7 +396,6 @@ static inline void msgpack_packer_write_ext(msgpack_packer_t* pk, int ext_type, 
     msgpack_buffer_append_string(PACKER_BUFFER_(pk), payload);
 }
 
-#ifdef COMPAT_HAVE_ENCODING
 static inline bool msgpack_packer_is_binary(VALUE v, int encindex)
 {
     return encindex == msgpack_rb_encindex_ascii8bit;
@@ -414,7 +413,6 @@ static inline bool msgpack_packer_is_utf8_compat_string(VALUE v, int encindex)
 #endif
         ;
 }
-#endif
 
 static inline void msgpack_packer_write_string_value(msgpack_packer_t* pk, VALUE v)
 {
@@ -425,7 +423,6 @@ static inline void msgpack_packer_write_string_value(msgpack_packer_t* pk, VALUE
         rb_raise(rb_eArgError, "size of string is too long to pack: %lu bytes should be <= %lu", len, 0xffffffffUL);
     }
 
-#ifdef COMPAT_HAVE_ENCODING
     int encindex = ENCODING_GET(v);
     if(msgpack_packer_is_binary(v, encindex) && !pk->compatibility_mode) {
         /* write ASCII-8BIT string using Binary type */
@@ -443,10 +440,6 @@ static inline void msgpack_packer_write_string_value(msgpack_packer_t* pk, VALUE
         msgpack_packer_write_raw_header(pk, (unsigned int)len);
         msgpack_buffer_append_string(PACKER_BUFFER_(pk), v);
     }
-#else
-    msgpack_packer_write_raw_header(pk, (unsigned int)len);
-    msgpack_buffer_append_string(PACKER_BUFFER_(pk), v);
-#endif
 }
 
 static inline void msgpack_packer_write_symbol_string_value(msgpack_packer_t* pk, VALUE v)

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -154,9 +154,7 @@ static inline int object_complete(msgpack_unpacker_t* uk, VALUE object)
 
 static inline int object_complete_string(msgpack_unpacker_t* uk, VALUE str)
 {
-#ifdef COMPAT_HAVE_ENCODING
     ENCODING_SET(str, msgpack_rb_encindex_utf8);
-#endif
 
 #if STR_UMINUS_DEDUPE
     if(uk->freeze) {
@@ -177,9 +175,7 @@ static inline int object_complete_string(msgpack_unpacker_t* uk, VALUE str)
 
 static inline int object_complete_binary(msgpack_unpacker_t* uk, VALUE str)
 {
-#ifdef COMPAT_HAVE_ENCODING
     ENCODING_SET(str, msgpack_rb_encindex_ascii8bit);
-#endif
 
 #if STR_UMINUS_DEDUPE
     if(uk->freeze) {
@@ -195,9 +191,7 @@ static inline int object_complete_binary(msgpack_unpacker_t* uk, VALUE str)
 
 static inline int object_complete_ext(msgpack_unpacker_t* uk, int ext_type, VALUE str)
 {
-#ifdef COMPAT_HAVE_ENCODING
     ENCODING_SET(str, msgpack_rb_encindex_ascii8bit);
-#endif
 
 #if STR_UMINUS_DEDUPE
     if(uk->freeze) {


### PR DESCRIPTION
Ref: https://github.com/msgpack/msgpack-ruby/issues/197

As discussed in https://github.com/msgpack/msgpack-ruby/pull/196#discussion_r532515695. That flag is for Ruby 1.8 (and MacRuby) support. Both are so old that we can now assume encoding support.