### PR TITLE
Set string encoding after reading a heap_mapped_string

### DIFF
--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -446,6 +446,7 @@ static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_
             b->head->mapped_string != NO_MAPPED_STRING &&
             length >= b->read_reference_threshold) {
         VALUE result = _msgpack_buffer_refer_head_mapped_string(b, length);
+        if (utf8) ENCODING_SET(result, msgpack_rb_encindex_utf8);
         _msgpack_buffer_consumed(b, length);
         return result;
     }

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -634,6 +634,14 @@ describe MessagePack::Unpacker do
       array = ['foo'] * 10_000
       MessagePack.unpack(MessagePack.pack(array)).size.should == 10_000
     end
+
+    it 'preserve string encoding (issue #200)' do
+      string = 'a'.force_encoding(Encoding::UTF_8)
+      MessagePack.unpack(MessagePack.pack(string)).encoding.should == string.encoding
+
+      string *= 256
+      MessagePack.unpack(MessagePack.pack(string)).encoding.should == string.encoding
+    end
   end
 
   context 'extensions' do


### PR DESCRIPTION
Fix #200 

I think the bug was introduced in https://github.com/msgpack/msgpack-ruby/pull/196

@tagomoris 