### PR TITLE
Setup GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  mri:
+    strategy:
+      matrix:
+        os: [ubuntu, macos, windows]
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', 'ruby-head']
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake
+
+  jruby-truffle:
+    strategy:
+      matrix:
+        os: [ubuntu]
+        ruby: ['jruby', 'truffleruby']
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake


### PR DESCRIPTION
Travis is very slow these days because they are about to shutdown the free service. Most projects are migrating to GitHub actions.

This PR is just a quick demo, the config file can be adapted to include the rubies and OS you want.

@tagomoris If you are interested, let me know the support list and I can update the matrix.