### PR TITLE
spec description: Grammar fix preserve->preserves

### DIFF
--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -635,7 +635,7 @@ describe MessagePack::Unpacker do
       MessagePack.unpack(MessagePack.pack(array)).size.should == 10_000
     end
 
-    it 'preserve string encoding (issue #200)' do
+    it 'preserves string encoding (issue #200)' do
       string = 'a'.force_encoding(Encoding::UTF_8)
       MessagePack.unpack(MessagePack.pack(string)).encoding.should == string.encoding
 


### PR DESCRIPTION
This PR changes the wording in a description of a test, so that the wording harmonizes with the other tests in place.