### PR TITLE
[WIP] Add option to enforce strictness on core types

### DIFF
--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -138,38 +138,28 @@ void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
 
 void msgpack_packer_write_value(msgpack_packer_t* pk, VALUE v)
 {
-    switch(rb_type(v)) {
-    case T_NIL:
+    VALUE klass = rb_class_of(v);
+    if (v == Qnil) {
         msgpack_packer_write_nil(pk);
-        break;
-    case T_TRUE:
+    } else if (v == Qtrue) {
         msgpack_packer_write_true(pk);
-        break;
-    case T_FALSE:
+    } else if (v == Qfalse) {
         msgpack_packer_write_false(pk);
-        break;
-    case T_FIXNUM:
+    } else if (FIXNUM_P(v)) {
         msgpack_packer_write_fixnum_value(pk, v);
-        break;
-    case T_SYMBOL:
+    } else if (SYMBOL_P(v)) {
         msgpack_packer_write_symbol_value(pk, v);
-        break;
-    case T_STRING:
+    } else if (klass == rb_cString) {
         msgpack_packer_write_string_value(pk, v);
-        break;
-    case T_ARRAY:
+    } else if (klass == rb_cArray) {
         msgpack_packer_write_array_value(pk, v);
-        break;
-    case T_HASH:
+    } else if (klass == rb_cHash) {
         msgpack_packer_write_hash_value(pk, v);
-        break;
-    case T_BIGNUM:
+    } else if (RB_TYPE_P(v, T_BIGNUM)) {
         msgpack_packer_write_bignum_value(pk, v);
-        break;
-    case T_FLOAT:
+    } else if (klass == rb_cFloat) {
         msgpack_packer_write_float_value(pk, v);
-        break;
-    default:
+    } else {
         msgpack_packer_write_other_value(pk, v);
     }
 }

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -33,6 +33,7 @@ struct msgpack_packer_t {
 
     bool compatibility_mode;
     bool has_symbol_ext_type;
+    bool strict_types;
 
     ID to_msgpack_method;
     VALUE to_msgpack_arg;

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -413,6 +413,13 @@ VALUE Packer_full_pack(VALUE self)
     return retval;
 }
 
+static VALUE Packer_strict_types(VALUE self)
+{
+    PACKER(self, pk);
+    return pk->strict_types ? Qtrue : Qfalse;
+}
+
+
 void MessagePack_Packer_module_init(VALUE mMessagePack)
 {
     s_to_msgpack = rb_intern("to_msgpack");
@@ -467,4 +474,6 @@ void MessagePack_Packer_module_init(VALUE mMessagePack)
     //Data_Get_Struct(s_packer_value, msgpack_packer_t, s_packer);
 
     rb_define_method(cMessagePack_Packer, "full_pack", Packer_full_pack, 0);
+
+    rb_define_method(cMessagePack_Packer, "strict_types", Packer_strict_types, 0);
 }

--- a/lib/msgpack/core_ext.rb
+++ b/lib/msgpack/core_ext.rb
@@ -3,6 +3,9 @@ module MessagePack
     def to_msgpack(packer_or_io = nil)
       if packer_or_io
         if packer_or_io.is_a?(MessagePack::Packer)
+          if packer_or_io.strict_types
+            raise NoMethodError.new("undefined method `to_msgpack' for #{inspect}:#{self.class.inspect}", :to_msgpack)
+          end
           to_msgpack_with_packer packer_or_io
         else
           MessagePack.pack(self, packer_or_io)

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -368,12 +368,20 @@ describe MessagePack::Factory do
   describe 'with strict types' do
     shared_examples_for 'strict core type' do |klass|
       it "enforces exact class match on #{klass} with strict: true" do
-        stub_const('FooClass', Class.new(klass))
+        stub_const('Foo', Class.new(klass))
         factory = described_class.new(strict: true)
-        expect { factory.dump(FooClass.new) }.to raise_error do |e|
+        foo = Foo.new
+        expect { factory.dump(foo) }.to raise_error do |e|
           expect(e.class).to eq(NoMethodError)
           expect(e.name).to eq(:to_msgpack)
         end
+      end
+
+      it "does not enforce exact class match on #{klass} with strict: false (default)" do
+        stub_const('Foo', Class.new(klass))
+        factory = described_class.new
+        foo = Foo.new
+        expect { factory.dump(foo) }.not_to raise_error
       end
     end
 

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -364,4 +364,21 @@ describe MessagePack::Factory do
       expect(MessagePack.unpack(MessagePack.pack(dm2))).to eq(dm2)
     end
   end
+
+  describe 'with strict types' do
+    shared_examples_for 'strict core type' do |klass|
+      it "enforces exact class match on #{klass} with strict: true" do
+        stub_const('FooClass', Class.new(klass))
+        factory = described_class.new(strict: true)
+        expect { factory.dump(FooClass.new) }.to raise_error do |e|
+          expect(e.class).to eq(NoMethodError)
+          expect(e.name).to eq(:to_msgpack)
+        end
+      end
+    end
+
+    it_behaves_like 'strict core type', Hash
+    it_behaves_like 'strict core type', Array
+    it_behaves_like 'strict core type', String
+  end
 end


### PR DESCRIPTION
We'd like an option which would allow a factory to enforce the condition that all core types (`String`, `Hash`, `Array`, etc.) are only accepted if the object is an instance of the class and not any subclass of it. This happens to be particularly important with `ActiveSupport::HashWithIndifferentAccess` which by default will be treated like a `Hash`, potentially with unexpected results.

Creating PR on Shopify/msgpack-ruby for now for discussion.