### PR TITLE
Add option to strictly limit serialization of core types

### DIFF
--- a/doclib/msgpack/error.rb
+++ b/doclib/msgpack/error.rb
@@ -1,5 +1,8 @@
 module MessagePack
 
+  class PackError < StandardError
+  end
+
   class UnpackError < StandardError
   end
 

--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -118,7 +118,7 @@ public class Encoder {
       appendInteger((RubyInteger) object);
     } else if (object instanceof RubyFloat) {
       appendFloat((RubyFloat) object);
-    } else if (object instanceof RubyString) {
+    } else if (object.getType() == runtime.getString()) {
       appendString((RubyString) object);
     } else if (object instanceof RubySymbol) {
       if (hasSymbolExtType) {
@@ -126,9 +126,9 @@ public class Encoder {
       } else {
         appendString(((RubySymbol) object).asString());
       }
-    } else if (object instanceof RubyArray) {
+    } else if (object.getType() == runtime.getArray()) {
       appendArray((RubyArray) object);
-    } else if (object instanceof RubyHash) {
+    } else if (object.getType() == runtime.getHash()) {
       appendHash((RubyHash) object);
     } else if (object instanceof ExtensionValue) {
       appendExtensionValue((ExtensionValue) object);

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -32,6 +32,7 @@ struct msgpack_factory_t {
     msgpack_packer_ext_registry_t pkrg;
     msgpack_unpacker_ext_registry_t ukrg;
     bool has_symbol_ext_type;
+    bool strict_types;
 };
 
 #define FACTORY(from, name) \
@@ -74,13 +75,18 @@ static VALUE Factory_initialize(int argc, VALUE* argv, VALUE self)
 
     fc->has_symbol_ext_type = false;
 
-    switch (argc) {
-    case 0:
-        break;
-    default:
-        // TODO options is not supported yet
-        rb_raise(rb_eArgError, "wrong number of arguments (%d for 0)", argc);
+    VALUE options = Qnil;
+    VALUE strict = Qfalse;
+    rb_scan_args(argc, argv, "0:", &options);
+
+    if (!NIL_P(options)) {
+        static ID keyword_ids[1];
+        if (!keyword_ids[0])
+            keyword_ids[0] = rb_intern("strict");
+        rb_get_kwargs(options, keyword_ids, 0, 1, &strict);
     }
+
+    fc->strict_types = RB_TEST(strict);
 
     return Qnil;
 }
@@ -98,6 +104,7 @@ VALUE MessagePack_Factory_packer(int argc, VALUE* argv, VALUE self)
     msgpack_packer_ext_registry_destroy(&pk->ext_registry);
     msgpack_packer_ext_registry_dup(&fc->pkrg, &pk->ext_registry);
     pk->has_symbol_ext_type = fc->has_symbol_ext_type;
+    pk->strict_types = fc->strict_types;
 
     return packer;
 }
@@ -204,6 +211,12 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
     return Qnil;
 }
 
+static VALUE MessagePack_Factory_strict_types_p(VALUE self)
+{
+    FACTORY(self, fc);
+    return fc->strict_types ? Qtrue : Qfalse;
+}
+
 void MessagePack_Factory_module_init(VALUE mMessagePack)
 {
     cMessagePack_Factory = rb_define_class_under(mMessagePack, "Factory", rb_cObject);
@@ -217,4 +230,6 @@ void MessagePack_Factory_module_init(VALUE mMessagePack)
 
     rb_define_private_method(cMessagePack_Factory, "registered_types_internal", Factory_registered_types_internal, 0);
     rb_define_method(cMessagePack_Factory, "register_type", Factory_register_type, -1);
+
+    rb_define_method(cMessagePack_Factory, "strict_types?", MessagePack_Factory_strict_types_p, 0);
 }

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -131,6 +131,12 @@ void msgpack_packer_write_other_value(msgpack_packer_t* pk, VALUE v)
         VALUE payload = rb_funcall(proc, s_call, 1, v);
         StringValue(payload);
         msgpack_packer_write_ext(pk, ext_type, payload);
+    } else if(pk->strict_types) {
+        VALUE mMessagePack = rb_const_get(rb_cObject, rb_intern("MessagePack"));
+        VALUE ePackError = rb_const_get(mMessagePack, rb_intern("PackError"));
+        VALUE exc = rb_obj_alloc(ePackError);
+        rb_ivar_set(exc, rb_intern("@error_value"), v);
+        rb_exc_raise(exc);
     } else {
         rb_funcall(v, pk->to_msgpack_method, 1, pk->to_msgpack_arg);
     }

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -141,35 +141,36 @@ void msgpack_packer_write_value(msgpack_packer_t* pk, VALUE v)
     switch(rb_type(v)) {
     case T_NIL:
         msgpack_packer_write_nil(pk);
-        break;
+        return;
     case T_TRUE:
         msgpack_packer_write_true(pk);
-        break;
+        return;
     case T_FALSE:
         msgpack_packer_write_false(pk);
-        break;
+        return;
     case T_FIXNUM:
         msgpack_packer_write_fixnum_value(pk, v);
-        break;
+        return;
     case T_SYMBOL:
         msgpack_packer_write_symbol_value(pk, v);
-        break;
-    case T_STRING:
-        msgpack_packer_write_string_value(pk, v);
-        break;
-    case T_ARRAY:
-        msgpack_packer_write_array_value(pk, v);
-        break;
-    case T_HASH:
-        msgpack_packer_write_hash_value(pk, v);
-        break;
+        return;
     case T_BIGNUM:
         msgpack_packer_write_bignum_value(pk, v);
-        break;
+        return;
     case T_FLOAT:
         msgpack_packer_write_float_value(pk, v);
-        break;
-    default:
+        return;
+    }
+
+    VALUE klass = rb_class_of(v);
+
+    if (klass == rb_cString) {
+        msgpack_packer_write_string_value(pk, v);
+    } else if (klass == rb_cArray) {
+        msgpack_packer_write_array_value(pk, v);
+    } else if (klass == rb_cHash) {
+        msgpack_packer_write_hash_value(pk, v);
+    } else {
         msgpack_packer_write_other_value(pk, v);
     }
 }

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -33,6 +33,7 @@ struct msgpack_packer_t {
 
     bool compatibility_mode;
     bool has_symbol_ext_type;
+    bool strict_types;
 
     ID to_msgpack_method;
     VALUE to_msgpack_arg;

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -413,6 +413,12 @@ VALUE Packer_full_pack(VALUE self)
     return retval;
 }
 
+static VALUE Packer_strict_types_p(VALUE self)
+{
+    PACKER(self, pk);
+    return pk->strict_types ? Qtrue : Qfalse;
+}
+
 void MessagePack_Packer_module_init(VALUE mMessagePack)
 {
     s_to_msgpack = rb_intern("to_msgpack");
@@ -467,4 +473,6 @@ void MessagePack_Packer_module_init(VALUE mMessagePack)
     //Data_Get_Struct(s_packer_value, msgpack_packer_t, s_packer);
 
     rb_define_method(cMessagePack_Packer, "full_pack", Packer_full_pack, 0);
+
+    rb_define_method(cMessagePack_Packer, "strict_types?", Packer_strict_types_p, 0);
 }

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -46,4 +46,8 @@ module MessagePack
 
   module_function :pack
   module_function :dump
+
+  class PackError < StandardError
+    attr_accessor :error_value
+  end
 end

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -488,6 +488,19 @@ describe MessagePack::Packer do
       it { is_expected.to eq "\xC7\x0F\x01value_msgpacked" }
     end
 
+    shared_examples_for 'extension subclasses core type' do |klass|
+      it "uses core type extension for #{klass.name}" do
+        stub_const('Value', Class.new(klass))
+        object = Value.new
+
+        packer.register_type(0x01, Value, ->(_) { 'value_msgpacked' })
+        expect(packer.pack(object).to_s).to eq("\xC7\x0F\x01value_msgpacked")
+      end
+    end
+    it_behaves_like 'extension subclasses core type', Hash
+    it_behaves_like 'extension subclasses core type', Array
+    it_behaves_like 'extension subclasses core type', String
+
     context 'when registering a type for symbols' do
       before { packer.register_type(0x00, ::Symbol, :to_msgpack_ext) }
 

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -489,12 +489,17 @@ describe MessagePack::Packer do
     end
 
     shared_examples_for 'extension subclasses core type' do |klass|
-      it "uses core type extension for #{klass.name}" do
-        stub_const('Value', Class.new(klass))
-        object = Value.new
+      before { stub_const('Value', Class.new(klass)) }
+      let(:object) { Value.new }
+      subject { packer.pack(object).to_s }
 
+      it "defaults to #{klass.name} packer if no extension is present" do
+        expect(subject).to eq(MessagePack.dump(klass.new))
+      end
+
+      it "uses core type extension for #{klass.name}" do
         packer.register_type(0x01, Value, ->(_) { 'value_msgpacked' })
-        expect(packer.pack(object).to_s).to eq("\xC7\x0F\x01value_msgpacked")
+        expect(subject).to eq("\xC7\x0F\x01value_msgpacked")
       end
     end
     it_behaves_like 'extension subclasses core type', Hash


### PR DESCRIPTION
_Note: this includes #220, which should be reviewed/merged first._

First, thanks for the great gem! ❤️ 

This is a proposal for a small API + implementation change. Currently, MessagePack will treat any subclass of a "core" type like `Hash` in the same way as the parent type. This can have unexpected results:

```ruby
factory = MessagePack::Factory.new
#=> #<MessagePack::Factory:0x0000560ef82e8580>

hash1 = { a: "b" }.with_indifferent_access

hash2 = factory.load(factory.dump(hash1))

hash1[:a]
#=> "b"

hash2[:a]
#=> nil
```

It's also not possible to override this behaviour by, say, defining an extension type for a core type subclass since such a type will be ignored:

```ruby
factory.register_type(
  0x00,
  ActiveSupport::HashWithIndifferentAccess,
  packer: ->(value) { MessagePack.dump(value) },
  unpacker: ->(value) { MessagePack.load(value).with_indifferent_access }
)
factory.load(factory.dump(hash1)).class
#=> Hash
```

This presents a problem if MessagePack is being used in a context where instances of classes like `ActiveSupport::HashWithIndifferentAccess` may be present.

This PR is a suggestion for how this might be dealt with. I've added a `strict` option to `MessagePack::Factory#initialize` which, when `true`, causes the factory to raise a new exception, `MessagePack::PackError`, if the factory attempts to pack any object which is neither an instance of a core type, nor an instance of an extension type (or subclasses thereof).


Continuing from the above example:

```ruby
factory = MessagePack::Factory.new(strict: true)
#=> #<MessagePack::Factory:0x000055df4342e348>

hash1 = { a: "b" }.with_indifferent_access
factory.dump(hash1)
# raises MessagePack::PackError
```

The change here also (as a byproduct of how it is implemented) makes it possible, with either `strict: true` _or_ `strict: false`, to define an extension type for a subclass of a core type, and have that extension type work.

```ruby
factory = MessagePack::Factory.new(strict: false) # or `strict: true`, doesn't impact the result

factory.register_type(
  0x00,
  ActiveSupport::HashWithIndifferentAccess,
  packer: ->(value) { MessagePack.dump(value) },
  unpacker: ->(value) { MessagePack.load(value).with_indifferent_access }
)
factory.load(factory.dump(hash1)).class
#=> ActiveSupport::HashWithIndifferentAccess
```

I think this is a more natural result.

I have not implemented the jruby code yet since I'd like to discuss first whether this change makes sense, and if so whether the implementation is appropriate. It may also make sense to add a `strict` option to `register_type` (to enforce strictness on extension types as well), but I haven't done that since I wanted to get your thoughts on this first. Happy to update the PR incorporating any feedback, etc.

Thanks!