### PR TITLE
Failing test for behavior of to_msgpack without extension type

### DIFF
--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -364,4 +364,18 @@ describe MessagePack::Factory do
       expect(MessagePack.unpack(MessagePack.pack(dm2))).to eq(dm2)
     end
   end
+
+  describe '#to_msgpack' do
+    it 'does not raise on classes that define public to_msgpack method' do
+      stub_const('Foo', Class.new do
+        def to_msgpack(*)
+          "to_msgpacked"
+        end
+      end)
+      object = Foo.new
+      factory = described_class.new
+
+      expect(factory.dump(object)).to eq('to_msgpacked')
+    end
+  end
 end


### PR DESCRIPTION
I'm creating this PR to demonstrate what seems like inconsistent, or at least unclear, behaviour of `to_msgpack` when called from `MessagePack::Factory#dump`.

```ruby
describe '#to_msgpack' do
  it 'does not raise on classes that define public to_msgpack method' do
    stub_const('Foo', Class.new do
      def to_msgpack(*)
        "to_msgpacked"
      end
    end)
    object = Foo.new
    factory = described_class.new

    expect(factory.dump(object)).to eq('to_msgpacked')
  end
end
```

I would expect this test to pass, but it fails. `MessagePack::Factory#dump` here does not raise anything, it simply returns a blank string. Is this the correct behaviour?