### PR TITLE
Call GC.verify_compaction_references as part of the test suite if available

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,16 @@ end
 
 require 'msgpack'
 
+if GC.respond_to?(:verify_compaction_references)
+  # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+  # move objects around, helping to find object movement bugs.
+  GC.verify_compaction_references(double_heap: true, toward: :empty)
+end
+
+if GC.respond_to?(:auto_compact=)
+  GC.auto_compact = true
+end
+
 def java?
   /java/ =~ RUBY_PLATFORM
 end


### PR DESCRIPTION
This method was added as a simple way to make sure native extensions properly declare their global variable containing `VALUE` to the GC.

More info: https://www.rubydoc.info/stdlib/core/GC.verify_compaction_references