### PR TITLE
Optimized symbol parsing

### DIFF
--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -494,4 +494,9 @@ static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_
 #endif // HAVE_RB_ENC_INTERNED_STR
 }
 
+static inline VALUE msgpack_buffer_read_top_as_symbol(msgpack_buffer_t* b, size_t length)
+{
+    return rb_str_intern(msgpack_buffer_read_top_as_string(b, length, true, false));
+}
+
 #endif

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -66,6 +66,8 @@ struct msgpack_unpacker_t {
     bool symbolize_keys;
     bool freeze;
     bool allow_unknown_ext;
+    bool optimized_symbol_ext_type;
+    int symbol_ext_type;
 };
 
 #define UNPACKER_BUFFER_(uk) (&(uk)->buffer)

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -280,6 +280,22 @@ describe MessagePack::Factory do
       unpacker.feed(packed_symbol).unpack
     end
 
+    context 'using the optimized symbol unpacker' do
+      before do
+        subject.register_type(
+          0x00,
+          ::Symbol,
+          packer: :to_msgpack_ext,
+          unpacker: :from_msgpack_ext,
+          optimized_symbols_parsing: true,
+        )
+      end
+
+      it 'lets symbols survive a roundtrip' do
+        expect(symbol_after_roundtrip).to be :symbol
+      end
+    end
+
     context 'if no ext type is registered for symbols' do
       it 'converts symbols to string' do
         expect(symbol_after_roundtrip).to eq 'symbol'


### PR DESCRIPTION
In our app we parse a lot of msgpack payloads containing symbols, and as a result `String#to_sym` called by MessagePack is one of our biggest hotspots, so we would like to optimize it.

However it shows that if we add special handling for symbol parsing we can do it twice faster.

```ruby
require "benchmark/ips"
require "msgpack"

optimized_factory = MessagePack::Factory.new
optimized_factory.register_type(0x00, Symbol, packer: :to_msgpack_ext, unpacker: MessagePack::OPTIMIZED_SYMBOL_UNPACKER)
MessagePack::DefaultFactory.register_type(0x00, Symbol)

raise "BUG" unless MessagePack.load(MessagePack.dump(:foo)) == :foo
raise "BUG" unless optimized_factory.load(MessagePack.dump(:foo)) == :foo

PAYLOAD = MessagePack.dump(20.times.map { |i| :"foo#{i}" })
regular_unpacker = MessagePack::DefaultFactory.unpacker
optimized_unpacker = optimized_factory.unpacker

Benchmark.ips do |x|
  x.report('regular') do
    regular_unpacker.feed(PAYLOAD).full_unpack
  end
  x.report('optimized') do
    optimized_unpacker.feed(PAYLOAD).full_unpack
  end
  x.compare!
end
```

```bash
Warming up --------------------------------------
             regular     4.342k i/100ms
           optimized     9.156k i/100ms
Calculating -------------------------------------
             regular     43.592k (± 1.2%) i/s -    221.442k in   5.080628s
           optimized     92.098k (± 1.0%) i/s -    466.956k in   5.070682s

Comparison:
           optimized:    92098.2 i/s
             regular:    43592.3 i/s - 2.11x  (± 0.00) slower
```

cc @shioyama 

@tagomoris what do you think?