### PR TITLE
Fix undefined method `runtime' for JRuby:Module on JRuby 9.3.0.0

### DIFF
--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -1,7 +1,7 @@
 require "msgpack/version"
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby" # This is same with `/java/ =~ RUBY_VERSION`
-  require "java"
+  require "jruby"
   require "msgpack/msgpack.jar"
   org.msgpack.jruby.MessagePackLibrary.new.load(JRuby.runtime, false)
 else


### PR DESCRIPTION
This PR fix #226. I want to confirm the CI result.