### PR TITLE
use a new loading mechanism on jruby

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        ruby: ['jruby']
+        ruby: ['jruby-9.2.19.0', 'jruby-head']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -1,9 +1,8 @@
 require "msgpack/version"
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby" # This is same with `/java/ =~ RUBY_VERSION`
-  require "java"
   require "msgpack/msgpack.jar"
-  org.msgpack.jruby.MessagePackLibrary.new.load(JRuby.runtime, false)
+  JRuby::Util.load_ext("org.msgpack.jruby.MessagePackLibrary")
 else
   require "msgpack/msgpack"
 end


### PR DESCRIPTION
this PR fixes https://github.com/msgpack/msgpack-ruby/issues/226 compatibility for JRuby 9.3.x
and drops support for JRuby 9.1.x. Since the [minimum supported Ruby version](https://github.com/msgpack/msgpack-ruby/blob/master/msgpack.gemspec#L23) is 2.4 and JRuby 9.1.x targets 2.3 I guess it's ok.

see also https://github.com/jruby/jruby/issues/6868