### PR TITLE
dedup hash keys

### DIFF
--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -140,9 +140,15 @@ public class Decoder implements Iterator<IRubyObject> {
     RubyHash hash = RubyHash.newHash(runtime);
     for (int i = 0; i < size; i++) {
       IRubyObject key = next();
-      if (this.symbolizeKeys && key instanceof RubyString) {
+      if (key instanceof RubyString) {
+        if (this.symbolizeKeys) {
           key = ((RubyString) key).intern();
+        } else {
+          key.setFrozen(true);
+          key = runtime.freezeAndDedupString((RubyString) key);
+        }
       }
+
       hash.fastASet(key, next());
     }
     return hash;

--- a/ext/java/org/msgpack/jruby/Decoder.java
+++ b/ext/java/org/msgpack/jruby/Decoder.java
@@ -122,7 +122,6 @@ public class Decoder implements Iterator<IRubyObject> {
     ByteList byteList = new ByteList(bytes, encoding);
     RubyString string = runtime.newString(byteList);
     if (this.freeze) {
-      string.setFrozen(true);
       string = runtime.freezeAndDedupString(string);
     }
     return string;
@@ -144,7 +143,6 @@ public class Decoder implements Iterator<IRubyObject> {
         if (this.symbolizeKeys) {
           key = ((RubyString) key).intern();
         } else {
-          key.setFrozen(true);
           key = runtime.freezeAndDedupString((RubyString) key);
         }
       }

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -36,6 +36,15 @@ describe MessagePack::Unpacker do
       unpacker.each { |obj| hashes = obj }
       expect(hashes[0].keys.first).to equal(hashes[1].keys.first)
     end
+
+    it 'ensure strings are not deduplicated' do
+      sample_data = ["foo"]
+      sample_packed = MessagePack.pack(sample_data).force_encoding('ASCII-8BIT')
+      unpacker.feed(sample_packed)
+      ary = nil
+      unpacker.each { |obj| ary = obj }
+      expect(ary.first.frozen?).to eq(false)
+    end
   end
 
   it 'gets IO or object which has #read to read data from it' do


### PR DESCRIPTION
JRuby 9.3 does dedup hash keys since https://github.com/jruby/jruby/commit/454ef8b3cec17a842c08a394d4453ef1dd82f0fa

fixes a test failure
```
  1) MessagePack::Unpacker ensure string hash keys are deduplicated
     Failure/Error: expect(hashes[0].keys.first).to equal(hashes[1].keys.first)

       expected #<String:4020> => "foo"
            got #<String:4024> => "foo"

       Compared using equal?, which compares object identity,
       but expected and actual are not the same object. Use
       `expect(actual).to eq(expected)` if you don't care about
       object identity in this example.
     # ./spec/unpacker_spec.rb:37:in `block in <main>'
```