### PR TITLE
Raise exception when optimized symbols unpacker not supported

### DIFF
--- a/doclib/msgpack/factory.rb
+++ b/doclib/msgpack/factory.rb
@@ -75,6 +75,7 @@ module MessagePack
     #
     # * *:packer* specify symbol or proc object for packer
     # * *:unpacker* specify symbol or proc object for unpacker
+    # * *:optimized_symbols_parsing* specify true to use the optimized symbols parsing (not supported on JRuby now)
     #
     def register_type(type, klass, options={})
     end

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -89,6 +89,10 @@ public class Factory extends RubyObject {
         RubyHash options = (RubyHash) args[args.length - 1];
         packerArg = options.fastARef(runtime.newSymbol("packer"));
         unpackerArg = options.fastARef(runtime.newSymbol("unpacker"));
+        IRubyObject optimizedSymbolsParsingArg = options.fastARef(runtime.newSymbol("optimized_symbols_parsing"));
+        if (optimizedSymbolsParsingArg != null && optimizedSymbolsParsingArg.isTrue()) {
+          throw runtime.newArgumentError("JRuby implementation does not support the optimized_symbols_parsing option");
+        }
       } else {
         throw runtime.newArgumentError(String.format("expected Hash but found %s.", args[args.length - 1].getType().getName()));
       }

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -282,6 +282,7 @@ describe MessagePack::Factory do
 
     context 'using the optimized symbol unpacker' do
       before do
+        skip if IS_JRUBY # JRuby implementation doesn't support the optimized symbols unpacker for now
         subject.register_type(
           0x00,
           ::Symbol,


### PR DESCRIPTION
The follow-up of #225 
https://github.com/msgpack/msgpack-ruby/pull/225#issuecomment-941876605