### PR TITLE
CI: use bundler-cache: true

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: bundle install
+          bundler-cache: true # 'bundle install' and cache
       - run: bundle exec rake
 
   jruby:
@@ -37,7 +37,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: bundle install
+          bundler-cache: true # 'bundle install' and cache
       - run: bundle exec rake
 
   head-versions:
@@ -52,5 +52,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: bundle install
+          bundler-cache: true # 'bundle install' and cache
       - run: bundle exec rake || echo "failed, but ignore it"


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.