### PR TITLE
Drop unused directives from gemspec

### DIFF
--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
     s.files = `git ls-files`.split("\n")
     s.extensions = ["ext/msgpack/extconf.rb"]
   end
-  s.test_files = `git ls-files -- {test,spec}/*`.split("\n")
 
   s.required_ruby_version = ">= 2.4"
 


### PR DESCRIPTION
`test_files` is not used by RubyGems.org.