### PR TITLE
Support serializing bigint as extension types

### DIFF
--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -27,12 +27,14 @@ public class Factory extends RubyObject {
   private final Ruby runtime;
   private final ExtensionRegistry extensionRegistry;
   private boolean hasSymbolExtType;
+  private boolean hasBigIntExtType;
 
   public Factory(Ruby runtime, RubyClass type) {
     super(runtime, type);
     this.runtime = runtime;
     this.extensionRegistry = new ExtensionRegistry();
     this.hasSymbolExtType = false;
+    this.hasBigIntExtType = false;
   }
 
   static class FactoryAllocator implements ObjectAllocator {
@@ -52,7 +54,7 @@ public class Factory extends RubyObject {
 
   @JRubyMethod(name = "packer", optional = 1)
   public Packer packer(ThreadContext ctx, IRubyObject[] args) {
-    return Packer.newPacker(ctx, extensionRegistry(), hasSymbolExtType, args);
+    return Packer.newPacker(ctx, extensionRegistry(), hasSymbolExtType, hasBigIntExtType, args);
   }
 
   @JRubyMethod(name = "unpacker", optional = 2)
@@ -77,6 +79,8 @@ public class Factory extends RubyObject {
     IRubyObject packerArg;
     IRubyObject unpackerArg;
 
+    RubyHash options = null;
+
     if (isFrozen()) {
         throw runtime.newRuntimeError("can't modify frozen Factory");
     }
@@ -86,7 +90,7 @@ public class Factory extends RubyObject {
       unpackerArg = runtime.newSymbol("from_msgpack_ext");
     } else if (args.length == 3) {
       if (args[args.length - 1] instanceof RubyHash) {
-        RubyHash options = (RubyHash) args[args.length - 1];
+        options = (RubyHash) args[args.length - 1];
         packerArg = options.fastARef(runtime.newSymbol("packer"));
         unpackerArg = options.fastARef(runtime.newSymbol("unpacker"));
         IRubyObject optimizedSymbolsParsingArg = options.fastARef(runtime.newSymbol("optimized_symbols_parsing"));
@@ -127,6 +131,17 @@ public class Factory extends RubyObject {
 
     if (extModule == runtime.getSymbol()) {
       hasSymbolExtType = true;
+    }
+
+    if (options != null) {
+      IRubyObject oversizedIntegerExtensionArg = options.fastARef(runtime.newSymbol("oversized_integer_extension"));
+      if (oversizedIntegerExtensionArg != null && oversizedIntegerExtensionArg.isTrue()) {
+        if (extModule == runtime.getModule("Integer")) {
+          hasBigIntExtType = true;
+        } else {
+          throw runtime.newArgumentError("oversized_integer_extension: true is only for Integer class");
+        }
+      }
     }
 
     return runtime.getNil();

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -32,17 +32,19 @@ public class Packer extends RubyObject {
   private Buffer buffer;
   private Encoder encoder;
   private boolean hasSymbolExtType;
+  private boolean hasBigintExtType;
   private Encoding binaryEncoding;
 
-  public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry, boolean hasSymbolExtType) {
+  public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry, boolean hasSymbolExtType, boolean hasBigintExtType) {
     super(runtime, type);
     this.registry = registry;
     this.hasSymbolExtType = hasSymbolExtType;
+    this.hasBigintExtType = hasBigintExtType;
   }
 
   static class PackerAllocator implements ObjectAllocator {
     public IRubyObject allocate(Ruby runtime, RubyClass type) {
-      return new Packer(runtime, type, null, false);
+      return new Packer(runtime, type, null, false, false);
     }
   }
 
@@ -60,15 +62,15 @@ public class Packer extends RubyObject {
         // registry is already initialized (and somthing might be registered) when newPacker from Factory
         this.registry = new ExtensionRegistry();
     }
-    this.encoder = new Encoder(runtime, compatibilityMode, registry, hasSymbolExtType);
+    this.encoder = new Encoder(runtime, compatibilityMode, registry, hasSymbolExtType, hasBigintExtType);
     this.buffer = new Buffer(runtime, runtime.getModule("MessagePack").getClass("Buffer"));
     this.buffer.initialize(ctx, args);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
     return this;
   }
 
-  public static Packer newPacker(ThreadContext ctx, ExtensionRegistry extRegistry, boolean hasSymbolExtType, IRubyObject[] args) {
-    Packer packer = new Packer(ctx.runtime, ctx.runtime.getModule("MessagePack").getClass("Packer"), extRegistry, hasSymbolExtType);
+  public static Packer newPacker(ThreadContext ctx, ExtensionRegistry extRegistry, boolean hasSymbolExtType, boolean hasBigintExtType, IRubyObject[] args) {
+    Packer packer = new Packer(ctx.runtime, ctx.runtime.getModule("MessagePack").getClass("Packer"), extRegistry, hasSymbolExtType, hasBigintExtType);
     packer.initialize(ctx, args);
     return packer;
   }

--- a/lib/msgpack/bigint.rb
+++ b/lib/msgpack/bigint.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module MessagePack
+  module Bigint
+    TYPE = -142
+
+    # We split the bigint in 32bits chunks so that individual part fits into
+    # a MRI immediate Integer.
+    CHUNK_BITLENGTH = 32
+    FORMAT = 'CL>*'
+
+    if Integer.instance_method(:[]).arity != 1 # Ruby 2.7 and newer
+      # Starting from Ruby 2.7 we can address arbitrary bitranges inside an Integer with Integer#[]
+      # This allows to not allocate any Integer.
+      def self.to_msgpack_ext(bigint)
+        members = []
+
+        if bigint < 0
+          bigint = -bigint
+          members << 1
+        else
+          members << 0
+        end
+
+        offset = 0
+        length = bigint.bit_length
+        while offset < length
+          members << bigint[offset, CHUNK_BITLENGTH]
+          offset += CHUNK_BITLENGTH
+        end
+
+        members.pack(FORMAT)
+      end
+    else
+      # On 2.6 and older since we can't address arbitrary bitranges, so we fallback to shifting the bigint.
+      # This means that after each shift, we may allocate another Integer instance.
+      BASE = (2**CHUNK_BITLENGTH) - 1
+      def self.to_msgpack_ext(bigint)
+        members = []
+
+        if bigint < 0
+          bigint = -bigint
+          members << 1
+        else
+          members << 0
+        end
+
+        while bigint > 0
+          members << (bigint & BASE)
+          bigint = bigint >> CHUNK_BITLENGTH
+        end
+
+        members.pack(FORMAT)
+      end
+    end
+
+    def self.from_msgpack_ext(data)
+      parts = data.unpack(FORMAT)
+
+      sign = parts.shift
+      sum = parts.pop.to_i
+
+      parts.reverse_each do |part|
+        sum = sum << CHUNK_BITLENGTH
+        sum += part
+      end
+
+      sign == 0 ? sum : -sum
+    end
+  end
+end

--- a/spec/bigint_spec.rb
+++ b/spec/bigint_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe MessagePack::Bigint do
+  it 'serialize and deserialize arbitrary sized integer' do
+    [
+      1,
+      -1,
+      120938120391283122132313,
+      -21903120391203912391023920332103,
+      210290021321301203912933021323,
+    ].each do |int|
+      expect(MessagePack::Bigint.from_msgpack_ext(MessagePack::Bigint.to_msgpack_ext(int))).to be == int
+    end
+  end
+
+  it 'has a stable format' do
+    {
+      120938120391283122132313 => "\x00\x9F\xF4UY\x11\x92\x9A?\x00\x00\x19\x9C".b,
+      -21903120391203912391023920332103 => "\x01/\xB2\xBDG\xBD\xDE\xAA\xEBt\xCC\x8A\xC1\x00\x00\x01\x14".b,
+      210290021321301203912933021323 => "\x00\xC4\xD8\x96\x8Bm\xCB\xC7\x03\xA7{\xD4\"\x00\x00\x00\x02".b,
+    }.each do |int, payload|
+      expect(MessagePack::Bigint.to_msgpack_ext(int)).to be == payload
+      expect(MessagePack::Bigint.from_msgpack_ext(payload)).to be == int
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ if ENV['GC_STRESS']
 end
 
 require 'msgpack'
+require "msgpack/bigint"
 
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/issues/243

```ruby
factory = MessagePack::Factory.new
factory.register_type(
  0x42,
  Integer,
  packer: ->(int) { int.to_s },
  unpacker: -> (payload) { Integer(payload) }
)

factory.dump(42) # Use the native integer type
factory.dump(2**400) # Use the registered packer
```