### PR TITLE
Fix `symbolize_keys: true` to properly create UTF-8 symbols

### DIFF
--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -494,9 +494,9 @@ static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_
 #endif // HAVE_RB_ENC_INTERNED_STR
 }
 
-static inline VALUE msgpack_buffer_read_top_as_symbol(msgpack_buffer_t* b, size_t length)
+static inline VALUE msgpack_buffer_read_top_as_symbol(msgpack_buffer_t* b, size_t length, bool utf8)
 {
-    return rb_str_intern(msgpack_buffer_read_top_as_string(b, length, true, false));
+    return rb_str_intern(msgpack_buffer_read_top_as_string(b, length, true, utf8));
 }
 
 #endif

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -286,7 +286,7 @@ static inline int read_raw_body_begin(msgpack_unpacker_t* uk, int raw_type)
     if(length <= msgpack_buffer_top_readable_size(UNPACKER_BUFFER_(uk))) {
         int ret;
         if ((uk->optimized_symbol_ext_type && uk->symbol_ext_type == raw_type) || (uk->symbolize_keys && is_reading_map_key(uk))) {
-            VALUE symbol = msgpack_buffer_read_top_as_symbol(UNPACKER_BUFFER_(uk), length);
+            VALUE symbol = msgpack_buffer_read_top_as_symbol(UNPACKER_BUFFER_(uk), length, raw_type == RAW_TYPE_STRING);
             ret = object_complete_symbol(uk, symbol);
         } else {
             /* don't use zerocopy for hash keys but get a frozen string directly


### PR DESCRIPTION
When `symbolize_keys: true` was set, we'd already read the string as binary, even if the native type is UTF-8. This was causing non-ASCII keys to be improperly deserialized.

`rb_str_intern` will still notice strings that are ASCII only, and return ASCII symbol for them. So there's no backward compatibility concerns.

This fixes: https://github.com/ruby-i18n/i18n/issues/606