### PR TITLE
[Documentation]: Fix small typos

### DIFF
--- a/doclib/msgpack/factory.rb
+++ b/doclib/msgpack/factory.rb
@@ -63,7 +63,7 @@ module MessagePack
 
     #
     # Register a type and Class to be registered for packer and/or unpacker.
-    # If options are not speicified, factory will use :to_msgpack_ext for packer, and
+    # If options are not specified, factory will use :to_msgpack_ext for packer, and
     # :from_msgpack_ext for unpacker.
     #
     # @param type [Fixnum] type id of registered Class (0-127)

--- a/doclib/msgpack/packer.rb
+++ b/doclib/msgpack/packer.rb
@@ -14,7 +14,7 @@ module MessagePack
     # @overload initialize(io, options={})
     #   @param io [IO]
     #   @param options [Hash]
-    #   This packer writes serialzied objects into the IO when the internal buffer is filled.
+    #   This packer writes serialized objects into the IO when the internal buffer is filled.
     #   _io_ must respond to write(string) or append(string) method.
     #
     # Supported options:
@@ -33,12 +33,12 @@ module MessagePack
     #
     # @overload register_type(type, klass, &block)
     #   @param type [Fixnum] type id (0-127) user defined type id for specified Class
-    #   @param klass [Class] Class to be serialized with speicifed type id
+    #   @param klass [Class] Class to be serialized with specified type id
     #   @yieldparam object [Object] object to be serialized
     #
     # @overload register_type(type, klass, method_name)
     #   @param type [Fixnum] type id (0-127) user defined type id for specified Class
-    #   @param klass [Class] Class to be serialized with speicifed type id
+    #   @param klass [Class] Class to be serialized with specified type id
     #   @param method_name [Symbol] method which returns bytes of serialized representation
     #
     # @return nil

--- a/doclib/msgpack/unpacker.rb
+++ b/doclib/msgpack/unpacker.rb
@@ -36,7 +36,7 @@ module MessagePack
     #
     # @overload register_type(type, klass, class_method_name)
     #   @param type [Fixnum] type id (0-127) user defined type id for specified Class
-    #   @param klass [Class] Class to be serialized with speicifed type id
+    #   @param klass [Class] Class to be serialized with specified type id
     #   @param class_method_name [Symbol] class method which returns an instance object
     #
     # @return nil
@@ -149,7 +149,7 @@ module MessagePack
     #
     # It repeats until the io or internal buffer does not include any complete objects.
     #
-    # If the an IO is set, it repeats to read data from the IO when the buffer
+    # If an IO is set, it repeats to read data from the IO when the buffer
     # becomes empty until the IO raises EOFError.
     #
     # This method could raise same errors with _read_ excepting EOFError.


### PR DESCRIPTION
Noticed some small spelling errors as I was reading the documentation.