### PR TITLE
Optimize `MessagePack_Buffer_set_options`

### DIFF
--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -62,24 +62,22 @@ static VALUE Buffer_alloc(VALUE klass)
 
 static ID get_partial_read_method(VALUE io)
 {
-    if(rb_respond_to(io, s_readpartial)) {
+    if(io != Qnil && rb_respond_to(io, s_readpartial)) {
         return s_readpartial;
-    } else if(rb_respond_to(io, s_read)) {
-        return s_read;
-    } else {
-        return s_read;
     }
+    return s_read;
 }
 
 static ID get_write_all_method(VALUE io)
 {
-    if(rb_respond_to(io, s_write)) {
-        return s_write;
-    } else if(rb_respond_to(io, s_append)) {
-        return s_append;
-    } else {
-        return s_write;
+    if(io != Qnil) {
+        if(rb_respond_to(io, s_write)) {
+            return s_write;
+        } else if(rb_respond_to(io, s_append)) {
+            return s_append;
+        }
     }
+    return s_write;
 }
 
 void MessagePack_Buffer_set_options(msgpack_buffer_t* b, VALUE io, VALUE options)


### PR DESCRIPTION
### Context

`msgpack` is quite fast at serializing/deserializing, however instantiating the packer and unpacker is relatively slow. So on smaller payloads it often end up slower than much less optimized serializers. So I'm looking at optimizing this part.

### Profiling

Starting with the following script:

```ruby
FACTORY = MessagePack::Factory.new
1_000_000.times do
  FACTORY.unpacker
end
```

<img width="946" alt="Capture d’écran, le 2022-02-04 à 16 09 07" src="https://user-images.githubusercontent.com/19192189/152554837-b58628da-795c-45a4-b12d-fdb64113a880.png">

About 20% of the time is spent in `MessagePack_Buffer_set_options` which is surprising.

After a quick look, we're calling `rb_respond_to` a lot, and it isn't very fast. So in the common case when `io` is `nil`, we can take a shortcut.

After this change it's mostly gone (`0.2%`):

<img width="853" alt="Capture d’écran, le 2022-02-04 à 16 10 38" src="https://user-images.githubusercontent.com/19192189/152555186-a7676dd8-a5c2-4f6b-81a0-edb6ed9cbf69.png">
