### PR TITLE
Packer_initialize: lazily allocate the extension and cache hashes

### DIFF
--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -132,7 +132,11 @@ static VALUE Factory_registered_types_internal(VALUE self)
             rb_hash_aset(uk_mapping, INT2FIX(i - 128), fc->ukrg.array[i]);
         }
     }
-    return rb_ary_new3(2, rb_hash_dup(fc->pkrg.hash), uk_mapping);
+    return rb_ary_new3(
+        2,
+        RTEST(fc->pkrg.hash) ? rb_hash_dup(fc->pkrg.hash) : rb_hash_new(),
+        uk_mapping
+    );
 }
 
 static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -339,7 +339,10 @@ static VALUE Packer_write_to(VALUE self, VALUE io)
 static VALUE Packer_registered_types_internal(VALUE self)
 {
     PACKER(self, pk);
-    return rb_hash_dup(pk->ext_registry.hash);
+    if (RTEST(pk->ext_registry.hash)) {
+        return rb_hash_dup(pk->ext_registry.hash);
+    }
+    return rb_hash_new();
 }
 
 static VALUE Packer_register_type(int argc, VALUE* argv, VALUE self)


### PR DESCRIPTION
Each packer eagerly allocate two hashes, one for it's extension registry another to act as a cache for lookup and it's expensive.

Assuming no extension type is used, we can significantly speedup the packer instantiation by skipping these two allocations.

And in case extension types are used, we can still delay the cache allocation until it is actually needed.

benchmark (`Object.new` is used as a comparison point):

```ruby
require "benchmark/ips"
require "msgpack"

FACTORY = MessagePack::Factory.new
Benchmark.ips do |x|
  x.report("Object.new") { Object.new }
  x.report("FACTORY.packer") { FACTORY.packer }
  x.compare!
end
```

before:
```
Calculating -------------------------------------
          Object.new      8.512M (± 0.7%) i/s -     42.709M in   5.017901s
      FACTORY.packer      1.932M (± 0.8%) i/s -      9.697M in   5.019840s

Comparison:
          Object.new:  8511619.9 i/s
      FACTORY.packer:  1931874.0 i/s - 4.41x  (± 0.00) slower
```

after:
```
Calculating -------------------------------------
          Object.new      8.484M (± 1.7%) i/s -     42.680M in   5.032470s
      FACTORY.packer      3.399M (± 1.7%) i/s -     17.159M in   5.049362s

Comparison:
          Object.new:  8483734.5 i/s
      FACTORY.packer:  3399232.3 i/s - 2.50x  (± 0.00) slower
```