### PR TITLE
Clean JRuby detection in test suite

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,7 @@ if GC.respond_to?(:auto_compact=)
   GC.auto_compact = true
 end
 
-def java?
-  /java/ =~ RUBY_PLATFORM
-end
+IS_JRUBY = RUBY_ENGINE == 'jruby'
 
 # checking if Hash#[]= (rb_hash_aset) dedupes string keys
 def automatic_string_keys_deduplication?
@@ -46,7 +44,7 @@ def string_deduplication?
   (-r1).equal?(-r2)
 end
 
-if java?
+if IS_JRUBY
   RSpec.configure do |c|
     c.treat_symbols_as_metadata_keys_with_true_values = true
     c.filter_run_excluding :encodings => !(defined? Encoding)

--- a/spec/timestamp_spec.rb
+++ b/spec/timestamp_spec.rb
@@ -2,8 +2,6 @@
 
 require 'spec_helper'
 
-IS_JRUBY = Kernel.const_defined?(:JRUBY_VERSION)
-
 describe MessagePack::Timestamp do
   describe 'malformed format' do
     it do


### PR DESCRIPTION
Extracted out of: https://github.com/msgpack/msgpack-ruby/pull/248

IS_JRUBY was defined in `timestamp_spec` but also used in `factory_spec`.

So running `factory_spec` alone would fail.

cc @ahorek.