### PR TITLE
Optimize Packer and Unpacker initialize methods

### DIFF
--- a/doclib/msgpack/factory.rb
+++ b/doclib/msgpack/factory.rb
@@ -31,7 +31,7 @@ module MessagePack
     #
     # See Packer#initialize for supported options.
     #
-    def dump(obj, options={})
+    def dump(obj, options=nil)
     end
     alias pack dump
 
@@ -57,7 +57,7 @@ module MessagePack
     #
     # See Unpacker#initialize for supported options.
     #
-    def load(data, options={})
+    def load(data, options=nil)
     end
     alias unpack load
 

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -50,7 +50,7 @@ public class Factory extends RubyObject {
     return this;
   }
 
-  @JRubyMethod(name = "packer", optional = 1)
+  @JRubyMethod(name = "packer", optional = 2)
   public Packer packer(ThreadContext ctx, IRubyObject[] args) {
     return Packer.newPacker(ctx, extensionRegistry(), hasSymbolExtType, args);
   }

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -50,10 +50,18 @@ public class Packer extends RubyObject {
   public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
     boolean compatibilityMode = false;
     Ruby runtime = ctx.runtime;
-    if (args.length > 0 && args[args.length - 1] instanceof RubyHash) {
-      RubyHash options = (RubyHash) args[args.length - 1];
-      IRubyObject mode = options.fastARef(runtime.newSymbol("compatibility_mode"));
-      compatibilityMode = (mode != null) && mode.isTrue();
+    if (args.length > 0) {
+      RubyHash options = null;
+      if (args[args.length - 1] instanceof RubyHash) {
+        options = (RubyHash) args[args.length - 1];
+      } else if (args.length > 1 && args[args.length - 2] instanceof RubyHash) {
+        options = (RubyHash) args[args.length - 2];
+      }
+
+      if (options != null) {
+        IRubyObject mode = options.fastARef(runtime.newSymbol("compatibility_mode"));
+        compatibilityMode = (mode != null) && mode.isTrue();
+      }
     }
     if (registry == null) {
         // registry is null when allocate -> initialize

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -56,30 +56,48 @@ public class Unpacker extends RubyObject {
 
   @JRubyMethod(name = "initialize", optional = 2, visibility = PRIVATE)
   public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
+    Ruby runtime = ctx.runtime;
+
     symbolizeKeys = false;
     allowUnknownExt = false;
     freeze = false;
-    if (args.length > 0) {
-      Ruby runtime = ctx.runtime;
-      if (args[args.length - 1] instanceof RubyHash) {
-        RubyHash options = (RubyHash) args[args.length - 1];
-        IRubyObject sk = options.fastARef(runtime.newSymbol("symbolize_keys"));
-        if (sk != null) {
-          symbolizeKeys = sk.isTrue();
-        }
-        IRubyObject f = options.fastARef(runtime.newSymbol("freeze"));
-        if (f != null) {
-          freeze = f.isTrue();
-        }
-        IRubyObject au = options.fastARef(runtime.newSymbol("allow_unknown_ext"));
-        if (au != null) {
-          allowUnknownExt = au.isTrue();
-        }
-      }
-      if (args[0] != runtime.getNil() && !(args[0] instanceof RubyHash)) {
-        setStream(ctx, args[0]);
-      }
+
+    IRubyObject io = null;
+    RubyHash options = null;
+
+    if (args.length >= 1) {
+      io = args[0];
     }
+
+    if (args.length >= 2 && args[1] != runtime.getNil()) {
+      options = (RubyHash)args[1];
+    }
+
+    if (options == null && io != null && io instanceof RubyHash) {
+      options = (RubyHash)io;
+      io = null;
+    }
+
+    if (options != null) {
+      IRubyObject sk = options.fastARef(runtime.newSymbol("symbolize_keys"));
+      if (sk != null) {
+        symbolizeKeys = sk.isTrue();
+      }
+      IRubyObject f = options.fastARef(runtime.newSymbol("freeze"));
+      if (f != null) {
+        freeze = f.isTrue();
+      }
+      IRubyObject au = options.fastARef(runtime.newSymbol("allow_unknown_ext"));
+      if (au != null) {
+        allowUnknownExt = au.isTrue();
+      }
+
+    }
+
+    if (io != null && io != runtime.getNil()) {
+      setStream(ctx, io);
+    }
+
     return this;
   }
 

--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -29,6 +29,11 @@ static ID s_write;
 static ID s_append;
 static ID s_close;
 
+static VALUE sym_read_reference_threshold;
+static VALUE sym_write_reference_threshold;
+static VALUE sym_io_buffer_size;
+
+
 #define BUFFER(from, name) \
     msgpack_buffer_t *name = NULL; \
     Data_Get_Struct(from, msgpack_buffer_t, name); \
@@ -89,17 +94,17 @@ void MessagePack_Buffer_set_options(msgpack_buffer_t* b, VALUE io, VALUE options
     if(options != Qnil) {
         VALUE v;
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("read_reference_threshold")));
+        v = rb_hash_aref(options, sym_read_reference_threshold);
         if(v != Qnil) {
             msgpack_buffer_set_read_reference_threshold(b, NUM2ULONG(v));
         }
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("write_reference_threshold")));
+        v = rb_hash_aref(options, sym_write_reference_threshold);
         if(v != Qnil) {
             msgpack_buffer_set_write_reference_threshold(b, NUM2ULONG(v));
         }
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("io_buffer_size")));
+        v = rb_hash_aref(options, sym_io_buffer_size);
         if(v != Qnil) {
             msgpack_buffer_set_io_buffer_size(b, NUM2ULONG(v));
         }
@@ -478,6 +483,10 @@ void MessagePack_Buffer_module_init(VALUE mMessagePack)
     s_write = rb_intern("write");
     s_append = rb_intern("<<");
     s_close = rb_intern("close");
+
+    sym_read_reference_threshold = ID2SYM(rb_intern("read_reference_threshold"));
+    sym_write_reference_threshold = ID2SYM(rb_intern("write_reference_threshold"));
+    sym_io_buffer_size = ID2SYM(rb_intern("io_buffer_size"));
 
     msgpack_buffer_static_init();
 

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -33,6 +33,10 @@ static VALUE eUnexpectedTypeError;
 static VALUE eUnknownExtTypeError;
 static VALUE mTypeError;  // obsoleted. only for backward compatibility. See #86.
 
+static VALUE sym_symbolize_keys;
+static VALUE sym_freeze;
+static VALUE sym_allow_unknown_ext;
+
 #define UNPACKER(from, name) \
     msgpack_unpacker_t *name = NULL; \
     Data_Get_Struct(from, msgpack_unpacker_t, name); \
@@ -83,7 +87,7 @@ VALUE MessagePack_Unpacker_initialize(int argc, VALUE* argv, VALUE self)
     } else if(argc == 2) {
         io = argv[0];
         options = argv[1];
-        if(rb_type(options) != T_HASH) {
+        if(options != Qnil && rb_type(options) != T_HASH) {
             rb_raise(rb_eArgError, "expected Hash but found %s.", rb_obj_classname(options));
         }
 
@@ -100,13 +104,13 @@ VALUE MessagePack_Unpacker_initialize(int argc, VALUE* argv, VALUE self)
     if(options != Qnil) {
         VALUE v;
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("symbolize_keys")));
+        v = rb_hash_aref(options, sym_symbolize_keys);
         msgpack_unpacker_set_symbolized_keys(uk, RTEST(v));
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("freeze")));
+        v = rb_hash_aref(options, sym_freeze);
         msgpack_unpacker_set_freeze(uk, RTEST(v));
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("allow_unknown_ext")));
+        v = rb_hash_aref(options, sym_allow_unknown_ext);
         msgpack_unpacker_set_allow_unknown_ext(uk, RTEST(v));
     }
 
@@ -410,6 +414,10 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
     rb_include_module(eUnexpectedTypeError, mTypeError);
 
     eUnknownExtTypeError = rb_define_class_under(mMessagePack, "UnknownExtTypeError", eUnpackError);
+
+    sym_symbolize_keys = ID2SYM(rb_intern("symbolize_keys"));
+    sym_freeze = ID2SYM(rb_intern("freeze"));
+    sym_allow_unknown_ext = ID2SYM(rb_intern("allow_unknown_ext"));
 
     rb_define_alloc_func(cMessagePack_Unpacker, MessagePack_Unpacker_alloc);
 

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -17,16 +17,15 @@ require "msgpack/time"
 
 module MessagePack
   DefaultFactory = MessagePack::Factory.new
-  DEFAULT_EMPTY_PARAMS = {}.freeze
 
   def load(src, param = nil)
     unpacker = nil
 
     if src.is_a? String
-      unpacker = DefaultFactory.unpacker param || DEFAULT_EMPTY_PARAMS
+      unpacker = DefaultFactory.unpacker param
       unpacker.feed_reference src
     else
-      unpacker = DefaultFactory.unpacker src, param || DEFAULT_EMPTY_PARAMS
+      unpacker = DefaultFactory.unpacker src, param
     end
 
     unpacker.full_unpack
@@ -36,8 +35,8 @@ module MessagePack
   module_function :load
   module_function :unpack
 
-  def pack(v, *rest)
-    packer = DefaultFactory.packer(*rest)
+  def pack(v, io = nil, options = nil)
+    packer = DefaultFactory.packer(io, options)
     packer.write v
     packer.full_pack
   end


### PR DESCRIPTION
Particularly through the common `MessagePack.load / dump`.

```ruby
require 'msgpack'
payload = MessagePack.dump([1, "2", 3.4])

1_000_000.times do
  MessagePack.load(payload)
end
```

<img width="757" alt="Capture d’écran, le 2022-02-08 à 13 23 22" src="https://user-images.githubusercontent.com/19192189/152986331-70551cca-912f-46d0-8297-83c55123b2a7.png">


First we accept `nil` in place of the option hash, which allows to skip several hash lookup when no option is passed.

Then if we actually pass an option hash, we used static symbols instead of goign through the ID2SYM every time.

Finally for MessagePack.pack, we accept `nil` in place of var args, as to avoid a costly `*rest` forwarding.