### PR TITLE
Avoid zeroing msgpack_unpacker_t twice

### DIFF
--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -52,9 +52,9 @@ void msgpack_unpacker_static_destroy()
 
 #define HEAD_BYTE_REQUIRED 0xc1
 
-void _msgpack_unpacker_init(msgpack_unpacker_t* uk)
+msgpack_unpacker_t* _msgpack_unpacker_new(void)
 {
-    memset(uk, 0, sizeof(msgpack_unpacker_t));
+    msgpack_unpacker_t* uk = ZALLOC_N(msgpack_unpacker_t, 1);
 
     msgpack_buffer_init(UNPACKER_BUFFER_(uk));
 
@@ -71,6 +71,8 @@ void _msgpack_unpacker_init(msgpack_unpacker_t* uk)
     uk->stack = xmalloc(MSGPACK_UNPACKER_STACK_CAPACITY * sizeof(msgpack_unpacker_stack_t));
 #endif
     uk->stack_capacity = MSGPACK_UNPACKER_STACK_CAPACITY;
+
+    return uk;
 }
 
 void _msgpack_unpacker_destroy(msgpack_unpacker_t* uk)

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -86,7 +86,7 @@ void msgpack_unpacker_static_init();
 
 void msgpack_unpacker_static_destroy();
 
-void _msgpack_unpacker_init(msgpack_unpacker_t* uk);
+msgpack_unpacker_t* _msgpack_unpacker_new(void);
 
 void _msgpack_unpacker_destroy(msgpack_unpacker_t* uk);
 

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -58,8 +58,7 @@ static void Unpacker_mark(msgpack_unpacker_t* uk)
 
 VALUE MessagePack_Unpacker_alloc(VALUE klass)
 {
-    msgpack_unpacker_t* uk = ZALLOC_N(msgpack_unpacker_t, 1);
-    _msgpack_unpacker_init(uk);
+    msgpack_unpacker_t* uk = _msgpack_unpacker_new();
 
     VALUE self = Data_Wrap_Struct(klass, Unpacker_mark, Unpacker_free, uk);
     return self;


### PR DESCRIPTION
It's already zero-ed by `ZALLOC`, no need to call `memset(0, ...)` again.

Before / After

<img width="1495" alt="Capture d’écran, le 2022-02-08 à 15 31 12" src="https://user-images.githubusercontent.com/19192189/153007788-4aacc688-23fc-4663-86c9-21c4d85656fd.png">

This gets rid of about 5% of the execution time spent in zeroing a second time.