### PR TITLE
Implement lazy instantiation and Copy on Write for unpacker registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   mri:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
@@ -26,6 +27,7 @@ jobs:
 
   jruby:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu]
         # TODO: update to 9.3.3.0 once supported
@@ -43,6 +45,7 @@ jobs:
   head-versions:
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu]
         ruby: ['ruby-head', 'jruby-head', 'truffleruby']

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -166,7 +166,7 @@ static inline int object_complete_ext(msgpack_unpacker_t* uk, int ext_type, VALU
         return object_complete_symbol(uk, rb_str_intern(str));
     }
 
-    VALUE proc = msgpack_unpacker_ext_registry_lookup(&uk->ext_registry, ext_type);
+    VALUE proc = msgpack_unpacker_ext_registry_lookup(uk->ext_registry, ext_type);
     if(proc != Qnil) {
         VALUE obj = rb_funcall(proc, s_call, 1, str);
         return object_complete(uk, obj);

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -60,7 +60,7 @@ struct msgpack_unpacker_t {
 
     VALUE buffer_ref;
 
-    msgpack_unpacker_ext_registry_t ext_registry;
+    msgpack_unpacker_ext_registry_t *ext_registry;
 
     /* options */
     bool symbolize_keys;

--- a/ext/msgpack/unpacker_ext_registry.c
+++ b/ext/msgpack/unpacker_ext_registry.c
@@ -27,36 +27,59 @@ void msgpack_unpacker_ext_registry_static_init()
     s_dup = rb_intern("dup");
 }
 
+
 void msgpack_unpacker_ext_registry_static_destroy()
 { }
 
-void msgpack_unpacker_ext_registry_init(msgpack_unpacker_ext_registry_t* ukrg)
-{
-    for(int i=0; i < 256; i++) {
-        ukrg->array[i] = Qnil;
-    }
-}
-
 void msgpack_unpacker_ext_registry_mark(msgpack_unpacker_ext_registry_t* ukrg)
 {
-    for(int i=0; i < 256; i++) {
-        rb_gc_mark(ukrg->array[i]);
+    if (ukrg) {
+        for(int i=0; i < 256; i++) {
+            if (ukrg->array[i] != Qnil) {
+                rb_gc_mark(ukrg->array[i]);
+            }
+        }
     }
 }
 
-void msgpack_unpacker_ext_registry_dup(msgpack_unpacker_ext_registry_t* src,
-        msgpack_unpacker_ext_registry_t* dst)
+msgpack_unpacker_ext_registry_t* msgpack_unpacker_ext_registry_cow(msgpack_unpacker_ext_registry_t* src)
 {
-    for(int i=0; i < 256; i++) {
-        dst->array[i] = src->array[i];
+    msgpack_unpacker_ext_registry_t* dst;
+    if (src) {
+        if (src->borrow_count) {
+            dst = ALLOC(msgpack_unpacker_ext_registry_t);
+            dst->borrow_count = 0;
+            MEMCPY(dst->array, src->array, VALUE, 256);
+            msgpack_unpacker_ext_registry_release(src);
+            return dst;
+        } else {
+            return src;
+        }
+    } else {
+        dst = ALLOC(msgpack_unpacker_ext_registry_t);
+        dst->borrow_count = 0;
+        for(int i=0; i < 256; i++) {
+            dst->array[i] = Qnil;
+        }
+        return dst;
     }
 }
 
-VALUE msgpack_unpacker_ext_registry_put(msgpack_unpacker_ext_registry_t* ukrg,
+void msgpack_unpacker_ext_registry_release(msgpack_unpacker_ext_registry_t* ukrg)
+{
+    if (ukrg) {
+        if (ukrg->borrow_count) {
+            ukrg->borrow_count--;
+        } else {
+            xfree(ukrg);
+        }
+    }
+}
+
+void msgpack_unpacker_ext_registry_put(msgpack_unpacker_ext_registry_t** ukrg,
         VALUE ext_module, int ext_type, VALUE proc, VALUE arg)
 {
-    VALUE e = rb_ary_new3(3, ext_module, proc, arg);
-    VALUE before = ukrg->array[ext_type + 128];
-    ukrg->array[ext_type + 128] = e;
-    return before;
+    msgpack_unpacker_ext_registry_t* ext_registry = msgpack_unpacker_ext_registry_cow(*ukrg);
+    ext_registry->array[ext_type + 128] = rb_ary_new3(3, ext_module, proc, arg);
+    *ukrg = ext_registry;
 }

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -41,6 +41,21 @@ describe MessagePack::Factory do
       unpacker.feed(MessagePack::ExtensionValue.new(1, 'a').to_msgpack)
       expect{ unpacker.read }.to raise_error(MessagePack::UnknownExtTypeError)
     end
+
+    it 'does not share the extension registry with unpackers' do
+      subject.register_type(0x00, Symbol)
+      expect do
+        unpacker = subject.unpacker
+        expect do
+          unpacker.register_type(0x01) {}
+        end.to change { unpacker.registered_types }
+
+        second_unpacker = subject.unpacker
+        expect do
+          second_unpacker.register_type(0x01) {}
+        end.to_not change { unpacker.registered_types }
+      end.to_not change { subject.registered_types }
+    end
   end
 
   describe '#dump and #load' do


### PR DESCRIPTION
Every time an `Unpacker` is instantiated we have to copy over a `VALUE[256]` so `1kiB`.
That's quite a lot of memory usage for such short lived objects, and copying isn't
that cheap.

So first we can only allocate that array when the first type is registered.
So in cases where no extension is used we simply don't incur the cost for it.

Then if we actually do need one, we can only copy it when it happens to be mutated.
In most cases, types are registered once during boot, but very rarely at runtime. So
in the vast majority of cases we should be able to just pass a pointer.

Every time we share a registry we increment it's `borrow_count`, every time a holder
is garbage collected, it decreate the counter, and the last one is in charge of freeing the registry.

Finally when registering a type in the registry, if it isn't yet shared, we
directly mutate it.

```ruby
require 'benchmark/ips'
require 'msgpack'

payload = MessagePack.dump([1, "2", 3.4])

Benchmark.ips do |x|
  x.report("load") { MessagePack.load(payload) }
  x.compare!
end
```

master:
```
$ ruby -Ilib bench/load.rb
Warming up --------------------------------------
                load    95.076k i/100ms
Calculating -------------------------------------
                load    931.850k (± 3.3%) i/s -      4.659M in   5.005056s
```

this branch:
```
Warming up --------------------------------------
                load   142.119k i/100ms
Calculating -------------------------------------
                load      1.442M (± 2.1%) i/s -      7.248M in   5.027389s
```