### PR TITLE
Allow extension procs to operate the packer/unpacker manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,28 @@ MessagePack::DefaultFactory.register_type(0x03, MyClass3)
 MessagePack.unpack(data_with_ext_typeid_03) #=> MyClass3 instance
 ```
 
+Alternatively, extension types can call the packer or unpacker recursively to generate the extension data:
+
+```ruby
+Point = Struct.new(:x, :y)
+factory = MessagePack::Factory.new
+factory.register_type(
+  0x01,
+  Point,
+  packer: ->(point, packer) {
+    packer.write(point.x)
+    packer.write(point.y)
+  },
+  unpacker: ->(unpacker) {
+    x = unpacker.read
+    y = unpacker.read
+    Point.new(x, y)
+  },
+  recursive: true,
+)
+factory.load(factory.dump(Point.new(12, 34))) # => #<struct Point x=12, y=34>
+```
+
 ## Buffer API
 
 MessagePack for Ruby provides a buffer API so that you can read or write data by hand, not via Packer or Unpacker API.

--- a/doclib/msgpack/factory.rb
+++ b/doclib/msgpack/factory.rb
@@ -76,6 +76,7 @@ module MessagePack
     # * *:packer* specify symbol or proc object for packer
     # * *:unpacker* specify symbol or proc object for unpacker
     # * *:optimized_symbols_parsing* specify true to use the optimized symbols parsing (not supported on JRuby now)
+    # * *recursive* specify true to receive the packer or unpacker as argument to generate the extension body manually.
     #
     def register_type(type, klass, options={})
     end

--- a/ext/java/org/msgpack/jruby/Buffer.java
+++ b/ext/java/org/msgpack/jruby/Buffer.java
@@ -224,4 +224,10 @@ public class Buffer extends RubyObject {
   public IRubyObject writeTo(ThreadContext ctx, IRubyObject io) {
     return io.callMethod(ctx, "write", readCommon(ctx, null, false));
   }
+
+  public ByteList getBytes() {
+    byte[] bytes = new byte[rawSize()];
+    buffer.get(bytes);
+    return new ByteList(bytes, binaryEncoding);
+  }
 }

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -12,6 +12,8 @@ import org.jruby.RubyInteger;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
+import org.jruby.RubyProc;
+import org.jruby.RubyMethod;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
@@ -130,12 +132,22 @@ public class Factory extends RubyObject {
     if (unpackerArg != null) {
       if (unpackerArg instanceof RubyString || unpackerArg instanceof RubySymbol) {
         unpackerProc = extModule.method(unpackerArg.callMethod(ctx, "to_sym"));
+      } else if (unpackerArg instanceof RubyProc || unpackerArg instanceof RubyMethod) {
+        unpackerProc = unpackerArg;
       } else {
         unpackerProc = unpackerArg.callMethod(ctx, "method", runtime.newSymbol("call"));
       }
     }
 
-    extensionRegistry.put(extModule, (int) typeId, packerProc, packerArg, unpackerProc, unpackerArg);
+    boolean recursive = false;
+    if (options != null) {
+      IRubyObject recursiveExtensionArg = options.fastARef(runtime.newSymbol("recursive"));
+      if (recursiveExtensionArg != null && recursiveExtensionArg.isTrue()) {
+        recursive = true;
+      }
+    }
+
+    extensionRegistry.put(extModule, (int) typeId, recursive, packerProc, packerArg, unpackerProc, unpackerArg);
 
     if (extModule == runtime.getSymbol()) {
       hasSymbolExtType = true;

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -70,7 +70,7 @@ public class Packer extends RubyObject {
         // registry is already initialized (and somthing might be registered) when newPacker from Factory
         this.registry = new ExtensionRegistry();
     }
-    this.encoder = new Encoder(runtime, compatibilityMode, registry, hasSymbolExtType, hasBigintExtType);
+    this.encoder = new Encoder(runtime, this, compatibilityMode, registry, hasSymbolExtType, hasBigintExtType);
     this.buffer = new Buffer(runtime, runtime.getModule("MessagePack").getClass("Buffer"));
     this.buffer.initialize(ctx, args);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
@@ -124,7 +124,7 @@ public class Packer extends RubyObject {
     }
     RubyModule extModule = (RubyModule) mod;
 
-    registry.put(extModule, (int) typeId, proc, arg, null, null);
+    registry.put(extModule, (int) typeId, false, proc, arg, null, null);
 
     if (extModule == runtime.getSymbol()) {
       encoder.hasSymbolExtType = true;

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -157,7 +157,7 @@ public class Unpacker extends RubyObject {
       throw runtime.newRangeError(String.format("integer %d too big to convert to `signed char'", typeId));
     }
 
-    registry.put(extModule, (int) typeId, null, null, proc, arg);
+    registry.put(extModule, (int) typeId, false, null, null, proc, arg);
     return runtime.getNil();
   }
 
@@ -175,7 +175,7 @@ public class Unpacker extends RubyObject {
     if (limit == -1) {
       limit = byteList.length() - offset;
     }
-    Decoder decoder = new Decoder(ctx.runtime, registry, byteList.unsafeBytes(), byteList.begin() + offset, limit, symbolizeKeys, freeze, allowUnknownExt);
+    Decoder decoder = new Decoder(ctx.runtime, this, byteList.unsafeBytes(), byteList.begin() + offset, limit, symbolizeKeys, freeze, allowUnknownExt);
     try {
       data = null;
       data = decoder.next();
@@ -205,7 +205,7 @@ public class Unpacker extends RubyObject {
   public IRubyObject feed(ThreadContext ctx, IRubyObject data) {
     ByteList byteList = data.asString().getByteList();
     if (decoder == null) {
-      decoder = new Decoder(ctx.runtime, registry, byteList.unsafeBytes(), byteList.begin(), byteList.length(), symbolizeKeys, freeze, allowUnknownExt);
+      decoder = new Decoder(ctx.runtime, this, byteList.unsafeBytes(), byteList.begin(), byteList.length(), symbolizeKeys, freeze, allowUnknownExt);
     } else {
       decoder.feed(byteList.unsafeBytes(), byteList.begin(), byteList.length());
     }
@@ -343,7 +343,11 @@ public class Unpacker extends RubyObject {
     ByteList byteList = str.getByteList();
     this.stream = stream;
     this.decoder = null;
-    this.decoder = new Decoder(ctx.runtime, registry, byteList.unsafeBytes(), byteList.begin(), byteList.length(), symbolizeKeys, freeze, allowUnknownExt);
+    this.decoder = new Decoder(ctx.runtime, this, byteList.unsafeBytes(), byteList.begin(), byteList.length(), symbolizeKeys, freeze, allowUnknownExt);
     return getStream(ctx);
+  }
+
+  public ExtensionRegistry.ExtensionEntry lookupExtensionByTypeId(int typeId) {
+    return registry.lookupExtensionByTypeId(typeId);
   }
 }

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -381,7 +381,7 @@ static VALUE Packer_register_type(int argc, VALUE* argv, VALUE self)
         rb_raise(rb_eArgError, "expected Module/Class but found %s.", rb_obj_classname(ext_module));
     }
 
-    msgpack_packer_ext_registry_put(&pk->ext_registry, ext_module, ext_type, proc, arg);
+    msgpack_packer_ext_registry_put(&pk->ext_registry, ext_module, ext_type, 0, proc, arg);
 
     if (ext_module == rb_cSymbol) {
         pk->has_symbol_ext_type = true;

--- a/ext/msgpack/packer_ext_registry.c
+++ b/ext/msgpack/packer_ext_registry.c
@@ -54,7 +54,7 @@ void msgpack_packer_ext_registry_dup(msgpack_packer_ext_registry_t* src,
 }
 
 VALUE msgpack_packer_ext_registry_put(msgpack_packer_ext_registry_t* pkrg,
-        VALUE ext_module, int ext_type, VALUE proc, VALUE arg)
+        VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg)
 {
     if (!RTEST(pkrg->hash)) {
         pkrg->hash = rb_hash_new();
@@ -64,5 +64,8 @@ VALUE msgpack_packer_ext_registry_put(msgpack_packer_ext_registry_t* pkrg,
         /* clear lookup cache not to miss added type */
         rb_hash_clear(pkrg->cache);
     }
-    return rb_hash_aset(pkrg->hash, ext_module, rb_ary_new3(3, INT2FIX(ext_type), proc, arg));
+
+    // TODO: Ruby embeded array limit is 3, merging `proc` and `arg` would be good.
+    VALUE entry = rb_ary_new3(4, INT2FIX(ext_type), proc, arg, INT2FIX(flags));
+    return rb_hash_aset(pkrg->hash, ext_module, entry);
 }

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -147,6 +147,7 @@ NORETURN(static void raise_unpacker_error(int r))
     case PRIMITIVE_UNEXPECTED_TYPE:
         rb_raise(eUnexpectedTypeError, "unexpected type");
     case PRIMITIVE_UNEXPECTED_EXT_TYPE:
+    // rb_bug("unexpected extension type");
         rb_raise(eUnknownExtTypeError, "unexpected extension type");
     default:
         rb_raise(eUnpackError, "logically unknown error %d", r);
@@ -365,7 +366,7 @@ static VALUE Unpacker_register_type(int argc, VALUE* argv, VALUE self)
         rb_raise(rb_eRangeError, "integer %d too big to convert to `signed char'", ext_type);
     }
 
-    msgpack_unpacker_ext_registry_put(&uk->ext_registry, ext_module, ext_type, proc, arg);
+    msgpack_unpacker_ext_registry_put(&uk->ext_registry, ext_module, ext_type, 0, proc, arg);
 
     return Qnil;
 }

--- a/ext/msgpack/unpacker_ext_registry.c
+++ b/ext/msgpack/unpacker_ext_registry.c
@@ -77,9 +77,10 @@ void msgpack_unpacker_ext_registry_release(msgpack_unpacker_ext_registry_t* ukrg
 }
 
 void msgpack_unpacker_ext_registry_put(msgpack_unpacker_ext_registry_t** ukrg,
-        VALUE ext_module, int ext_type, VALUE proc, VALUE arg)
+        VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg)
 {
     msgpack_unpacker_ext_registry_t* ext_registry = msgpack_unpacker_ext_registry_cow(*ukrg);
-    ext_registry->array[ext_type + 128] = rb_ary_new3(3, ext_module, proc, arg);
+
+    ext_registry->array[ext_type + 128] = rb_ary_new3(4, ext_module, proc, arg, INT2FIX(flags));
     *ukrg = ext_registry;
 }

--- a/ext/msgpack/unpacker_ext_registry.h
+++ b/ext/msgpack/unpacker_ext_registry.h
@@ -21,6 +21,8 @@
 #include "compat.h"
 #include "ruby.h"
 
+#define MSGPACK_EXT_RECURSIVE 0b0001
+
 struct msgpack_unpacker_ext_registry_t;
 typedef struct msgpack_unpacker_ext_registry_t msgpack_unpacker_ext_registry_t;
 
@@ -46,14 +48,15 @@ static inline void msgpack_unpacker_ext_registry_borrow(msgpack_unpacker_ext_reg
 void msgpack_unpacker_ext_registry_mark(msgpack_unpacker_ext_registry_t* ukrg);
 
 void msgpack_unpacker_ext_registry_put(msgpack_unpacker_ext_registry_t** ukrg,
-        VALUE ext_module, int ext_type, VALUE proc, VALUE arg);
+        VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg);
 
 static inline VALUE msgpack_unpacker_ext_registry_lookup(msgpack_unpacker_ext_registry_t* ukrg,
-        int ext_type)
+        int ext_type, int* ext_flags_result)
 {
     if (ukrg) {
         VALUE entry = ukrg->array[ext_type + 128];
         if (entry != Qnil) {
+            *ext_flags_result = FIX2INT(rb_ary_entry(entry, 3));
             return rb_ary_entry(entry, 1);
         }
     }


### PR DESCRIPTION
Proof of concept implementation for https://github.com/msgpack/msgpack-ruby/issues/224#issuecomment-1034518270

The goal here is mostly to prove the implementation is possible and wouldn't require too much code.

I'm not sure wether the API is the best that could be done, if we wish to move the idea forward we should take the time to think wether that "proc arity" based behavior is what we want.

cc @tagomoris 
