### PR TITLE
No need to call `rb_intern()` during initialization

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -19,15 +19,9 @@
 #include "buffer.h"
 #include "rmem.h"
 
-#ifndef HAVE_RB_STR_REPLACE
-static ID s_replace;
-#endif
-
 int msgpack_rb_encindex_utf8;
 int msgpack_rb_encindex_usascii;
 int msgpack_rb_encindex_ascii8bit;
-
-ID s_uminus;
 
 #ifndef DISABLE_RMEM
 static msgpack_rmem_t s_rmem;
@@ -35,7 +29,6 @@ static msgpack_rmem_t s_rmem;
 
 void msgpack_buffer_static_init()
 {
-    s_uminus = rb_intern("-@");
 
     msgpack_rb_encindex_utf8 = rb_utf8_encindex();
     msgpack_rb_encindex_usascii = rb_usascii_encindex();
@@ -43,10 +36,6 @@ void msgpack_buffer_static_init()
 
 #ifndef DISABLE_RMEM
     msgpack_rmem_init(&s_rmem);
-#endif
-
-#ifndef HAVE_RB_STR_REPLACE
-    s_replace = rb_intern("replace");
 #endif
 }
 

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -53,8 +53,6 @@ extern int msgpack_rb_encindex_utf8;
 extern int msgpack_rb_encindex_usascii;
 extern int msgpack_rb_encindex_ascii8bit;
 
-extern ID s_uminus;
-
 struct msgpack_buffer_chunk_t;
 typedef struct msgpack_buffer_chunk_t msgpack_buffer_chunk_t;
 
@@ -485,7 +483,7 @@ static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_
 #endif //STR_UMINUS_DEDUPE_FROZEN
         // MRI 2.5 and older do not deduplicate strings that are already
         // frozen.
-        result = rb_funcall(result, s_uminus, 0);
+        result = rb_funcall(result, rb_intern("-@"), 0);
     }
 #endif // STR_UMINUS_DEDUPE
     _msgpack_buffer_consumed(b, length);

--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -23,16 +23,9 @@
 
 VALUE cMessagePack_Buffer;
 
-static ID s_read;
-static ID s_readpartial;
-static ID s_write;
-static ID s_append;
-static ID s_close;
-
 static VALUE sym_read_reference_threshold;
 static VALUE sym_write_reference_threshold;
 static VALUE sym_io_buffer_size;
-
 
 #define BUFFER(from, name) \
     msgpack_buffer_t *name = NULL; \
@@ -67,22 +60,22 @@ static VALUE Buffer_alloc(VALUE klass)
 
 static ID get_partial_read_method(VALUE io)
 {
-    if(io != Qnil && rb_respond_to(io, s_readpartial)) {
-        return s_readpartial;
+    if(io != Qnil && rb_respond_to(io, rb_intern("readpartial"))) {
+        return rb_intern("readpartial");
     }
-    return s_read;
+    return rb_intern("read");
 }
 
 static ID get_write_all_method(VALUE io)
 {
     if(io != Qnil) {
-        if(rb_respond_to(io, s_write)) {
-            return s_write;
-        } else if(rb_respond_to(io, s_append)) {
-            return s_append;
+        if(rb_respond_to(io, rb_intern("write"))) {
+            return rb_intern("write");
+        } else if(rb_respond_to(io, rb_intern("<<"))) {
+            return rb_intern("<<");
         }
     }
-    return s_write;
+    return rb_intern("write");
 }
 
 void MessagePack_Buffer_set_options(msgpack_buffer_t* b, VALUE io, VALUE options)
@@ -464,7 +457,7 @@ static VALUE Buffer_close(VALUE self)
 {
     BUFFER(self, b);
     if(b->io != Qnil) {
-        return rb_funcall(b->io, s_close, 0);
+        return rb_funcall(b->io, rb_intern("close"), 0);
     }
     return Qnil;
 }
@@ -472,18 +465,12 @@ static VALUE Buffer_close(VALUE self)
 static VALUE Buffer_write_to(VALUE self, VALUE io)
 {
     BUFFER(self, b);
-    size_t sz = msgpack_buffer_flush_to_io(b, io, s_write, true);
+    size_t sz = msgpack_buffer_flush_to_io(b, io, rb_intern("write"), true);
     return ULONG2NUM(sz);
 }
 
 void MessagePack_Buffer_module_init(VALUE mMessagePack)
 {
-    s_read = rb_intern("read");
-    s_readpartial = rb_intern("readpartial");
-    s_write = rb_intern("write");
-    s_append = rb_intern("<<");
-    s_close = rb_intern("close");
-
     sym_read_reference_threshold = ID2SYM(rb_intern("read_reference_threshold"));
     sym_write_reference_threshold = ID2SYM(rb_intern("write_reference_threshold"));
     sym_io_buffer_size = ID2SYM(rb_intern("io_buffer_size"));

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -25,8 +25,6 @@ static ID s_key;
 static ID s_value;
 #endif
 
-static ID s_call;
-
 void msgpack_packer_static_init()
 {
 #ifdef RUBINIUS
@@ -35,8 +33,6 @@ void msgpack_packer_static_init()
     s_key = rb_intern("key");
     s_value = rb_intern("value");
 #endif
-
-    s_call = rb_intern("call");
 }
 
 void msgpack_packer_static_destroy()
@@ -128,7 +124,7 @@ bool msgpack_packer_try_write_with_ext_type_lookup(msgpack_packer_t* pk, VALUE v
     VALUE proc = msgpack_packer_ext_registry_lookup(&pk->ext_registry, v, &ext_type);
 
     if(proc != Qnil) {
-        VALUE payload = rb_funcall(proc, s_call, 1, v);
+        VALUE payload = rb_funcall(proc, rb_intern("call"), 1, v);
         StringValue(payload);
         msgpack_packer_write_ext(pk, ext_type, payload);
         return true;

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -25,9 +25,6 @@
 
 VALUE cMessagePack_Packer;
 
-static ID s_to_msgpack;
-static ID s_write;
-
 static VALUE sym_compatibility_mode;
 
 //static VALUE s_packer_value;
@@ -63,7 +60,7 @@ VALUE MessagePack_Packer_alloc(VALUE klass)
 
     VALUE self = Data_Wrap_Struct(klass, Packer_mark, Packer_free, pk);
 
-    msgpack_packer_set_to_msgpack_method(pk, s_to_msgpack, self);
+    msgpack_packer_set_to_msgpack_method(pk, rb_intern("to_msgpack"), self);
 
     return self;
 }
@@ -321,7 +318,7 @@ static VALUE Packer_to_a(VALUE self)
 static VALUE Packer_write_to(VALUE self, VALUE io)
 {
     PACKER(self, pk);
-    size_t sz = msgpack_buffer_flush_to_io(PACKER_BUFFER_(pk), io, s_write, true);
+    size_t sz = msgpack_buffer_flush_to_io(PACKER_BUFFER_(pk), io, rb_intern("write"), true);
     return ULONG2NUM(sz);
 }
 
@@ -410,9 +407,6 @@ VALUE Packer_full_pack(VALUE self)
 
 void MessagePack_Packer_module_init(VALUE mMessagePack)
 {
-    s_to_msgpack = rb_intern("to_msgpack");
-    s_write = rb_intern("write");
-
     sym_compatibility_mode = ID2SYM(rb_intern("compatibility_mode"));
 
     msgpack_packer_static_init();

--- a/ext/msgpack/packer_ext_registry.c
+++ b/ext/msgpack/packer_ext_registry.c
@@ -18,11 +18,8 @@
 
 #include "packer_ext_registry.h"
 
-static ID s_call;
-
 void msgpack_packer_ext_registry_static_init()
 {
-    s_call = rb_intern("call");
 }
 
 void msgpack_packer_ext_registry_static_destroy()

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -28,8 +28,6 @@
 static int RAW_TYPE_STRING = 256;
 static int RAW_TYPE_BINARY = 257;
 
-static ID s_call;
-
 #ifdef UNPACKER_STACK_RMEM
 static msgpack_rmem_t s_stack_rmem;
 #endif
@@ -39,8 +37,6 @@ void msgpack_unpacker_static_init()
 #ifdef UNPACKER_STACK_RMEM
     msgpack_rmem_init(&s_stack_rmem);
 #endif
-
-    s_call = rb_intern("call");
 }
 
 void msgpack_unpacker_static_destroy()
@@ -168,7 +164,7 @@ static inline int object_complete_ext(msgpack_unpacker_t* uk, int ext_type, VALU
 
     VALUE proc = msgpack_unpacker_ext_registry_lookup(uk->ext_registry, ext_type);
     if(proc != Qnil) {
-        VALUE obj = rb_funcall(proc, s_call, 1, str);
+        VALUE obj = rb_funcall(proc, rb_intern("call"), 1, str);
         return object_complete(uk, obj);
     }
 

--- a/ext/msgpack/unpacker_ext_registry.c
+++ b/ext/msgpack/unpacker_ext_registry.c
@@ -18,13 +18,8 @@
 
 #include "unpacker_ext_registry.h"
 
-static ID s_call;
-static ID s_dup;
-
 void msgpack_unpacker_ext_registry_static_init()
 {
-    s_call = rb_intern("call");
-    s_dup = rb_intern("dup");
 }
 
 


### PR DESCRIPTION
That macro has an optimization so that it's properly
cached when called with a constant string:

```
/* __builtin_constant_p and statement expression is available
 * since gcc-2.7.2.3 at least. */
    (RBIMPL_CONSTANT_P(str) ? \
     __extension__ ({ \
         static ID rbimpl_id; \
         rbimpl_intern_const(&rbimpl_id, (str)); \
     }) : \
     (rb_intern)(str))
```