### PR TITLE
Use TypedData structs

### DIFF
--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -56,6 +56,8 @@ rescue NoMethodError
   $CFLAGS << ' -DSTR_UMINUS_DEDUPE_FROZEN=0 '
 end
 
+$CFLAGS << ' -DHAS_GC_COMPACT' if GC.respond_to?(:compact)
+
 if warnflags = CONFIG['warnflags']
   warnflags.slice!(/ -Wdeclaration-after-statement/)
 end

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -30,8 +30,6 @@ void msgpack_packer_static_destroy()
 
 void msgpack_packer_init(msgpack_packer_t* pk)
 {
-    memset(pk, 0, sizeof(msgpack_packer_t));
-
     msgpack_buffer_init(PACKER_BUFFER_(pk));
 }
 

--- a/ext/msgpack/packer_class.h
+++ b/ext/msgpack/packer_class.h
@@ -20,7 +20,16 @@
 
 #include "packer.h"
 
+#define PACKER(from, name) \
+    msgpack_packer_t* name; \
+    TypedData_Get_Struct(from, msgpack_packer_t, &packer_data_type, name); \
+    if(name == NULL) { \
+        rb_raise(rb_eArgError, "NULL found for " # name " when shouldn't be."); \
+    }
+
 extern VALUE cMessagePack_Packer;
+
+extern const rb_data_type_t packer_data_type;
 
 void MessagePack_Packer_module_init(VALUE mMessagePack);
 

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -72,10 +72,8 @@ static inline msgpack_unpacker_stack_t* _msgpack_unpacker_new_stack(void) {
     return stack;
 }
 
-msgpack_unpacker_t* _msgpack_unpacker_new(void)
+void _msgpack_unpacker_init(msgpack_unpacker_t* uk)
 {
-    msgpack_unpacker_t* uk = ZALLOC_N(msgpack_unpacker_t, 1);
-
     msgpack_buffer_init(UNPACKER_BUFFER_(uk));
 
     uk->head_byte = HEAD_BYTE_REQUIRED;
@@ -84,8 +82,6 @@ msgpack_unpacker_t* _msgpack_unpacker_new(void)
     uk->reading_raw = Qnil;
 
     uk->stack = _msgpack_unpacker_new_stack();
-
-    return uk;
 }
 
 static inline void _msgpack_unpacker_free_stack(msgpack_unpacker_stack_t* stack) {

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -90,7 +90,7 @@ void msgpack_unpacker_static_init();
 
 void msgpack_unpacker_static_destroy();
 
-msgpack_unpacker_t* _msgpack_unpacker_new(void);
+void _msgpack_unpacker_init(msgpack_unpacker_t*);
 
 void _msgpack_unpacker_destroy(msgpack_unpacker_t* uk);
 

--- a/ext/msgpack/unpacker_class.h
+++ b/ext/msgpack/unpacker_class.h
@@ -20,6 +20,15 @@
 
 #include "unpacker.h"
 
+#define UNPACKER(from, name) \
+    msgpack_unpacker_t *name = NULL; \
+    TypedData_Get_Struct(from, msgpack_unpacker_t, &unpacker_data_type, name); \
+    if(name == NULL) { \
+        rb_raise(rb_eArgError, "NULL found for " # name " when shouldn't be."); \
+    }
+
+extern const rb_data_type_t unpacker_data_type;
+
 extern VALUE cMessagePack_Unpacker;
 
 void MessagePack_Unpacker_module_init(VALUE mMessagePack);

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -613,6 +613,24 @@ describe MessagePack::Factory do
     end
   end
 
+  describe 'memsize' do
+    it 'works on a fresh factory' do
+      skip "JRuby doesn't support ObjectSpace.memsize_of" if IS_JRUBY
+
+      f = MessagePack::Factory.new
+      expect(ObjectSpace.memsize_of(f)).to be_an(Integer)
+    end
+
+    it 'works on a factory with registered types' do
+      skip "JRuby doesn't support ObjectSpace.memsize_of" if IS_JRUBY
+
+      f = MessagePack::Factory.new
+      base_size = ObjectSpace.memsize_of(f)
+      f.register_type(0x0a, Symbol)
+      expect(ObjectSpace.memsize_of(f)).to be > base_size
+    end
+  end
+
   describe 'DefaultFactory' do
     it 'is a factory' do
       MessagePack::DefaultFactory.should be_kind_of(MessagePack::Factory)

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -515,6 +515,15 @@ describe MessagePack::Packer do
     end
   end
 
+  context 'memsize' do
+    it 'works on a fresh Packer' do
+      skip "JRuby doesn't support ObjectSpace.memsize_of" if IS_JRUBY
+
+      unpacker = MessagePack::Packer.new
+      expect(ObjectSpace.memsize_of(unpacker)).to be_an(Integer)
+    end
+  end
+
   describe "fixnum and bignum" do
     it "fixnum.to_msgpack" do
       23.to_msgpack.should == "\x17"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ end
 
 require 'msgpack'
 require "msgpack/bigint"
+require 'objspace'
 
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -651,6 +651,24 @@ describe MessagePack::Unpacker do
     end
   end
 
+  describe 'memsize' do
+    it 'works on a fresh Unpacker' do
+      skip "JRuby doesn't support ObjectSpace.memsize_of" if IS_JRUBY
+
+      unpacker = MessagePack::Unpacker.new
+      expect(ObjectSpace.memsize_of(unpacker)).to be_an(Integer)
+    end
+
+    it 'works on a Unpacker with registered types' do
+      skip "JRuby doesn't support ObjectSpace.memsize_of" if IS_JRUBY
+
+      unpacker = MessagePack::Unpacker.new
+      base_size = ObjectSpace.memsize_of(unpacker)
+      unpacker.register_type(0x0) { }
+      expect(ObjectSpace.memsize_of(unpacker)).to be > base_size
+    end
+  end
+
   context 'regressions' do
     it 'handles massive arrays (issue #2)' do
       array = ['foo'] * 10_000


### PR DESCRIPTION
The API is a bit more modern and open the door to several features such as `memsize`, write barriers etc.

The main addition for now is support for `memsize_of`:

```ruby
>> ObjectSpace.memsize_of(f)
=> 2128
```

Note: `Buffer` is still "untyped" because there is actually two types of buffer. Some with their own memory region, and in charge of freeing it, and some that point to the `Unpacker` memory and need to not have a `free` function. 

For now I don't see how to do this with `TypedData` structs.