### PR TITLE
Implement Factory#pool

### DIFF
--- a/doclib/msgpack/factory.rb
+++ b/doclib/msgpack/factory.rb
@@ -98,5 +98,47 @@ module MessagePack
     #
     def type_registered?(klass_or_type, selector=:both)
     end
+
+    #
+    # Creates a MessagePack::PooledFactory instance of the given size.
+    #
+    # PooledFactory keeps Packer and Unpacker instance in a pool for improved performance.
+    # Note that the size defines how many instances are kept in cache, not the maximum of instances
+    # that can be created. If the pool limit is reached, a new instance is created anyway.
+    #
+    # @param size [Fixnum] specify how many Packer and Unpacker to keep in cache (default 1)
+    # @param options [Hash] Combined options for Packer and Unpacker. See Packer#initialize and Unpacker#initialize
+    #                       for supported options.
+    def pool(size=1, **options)
+    end
+
+    class Pool
+      #
+      # Deserializes an object from the string or io and returns it.
+      #
+      # If there're not enough data to deserialize one object, this method raises EOFError.
+      # If data format is invalid, this method raises MessagePack::MalformedFormatError.
+      # If the object nests too deeply, this method raises MessagePack::StackError.
+      #
+      # @param data [String]
+      # @return [Object] deserialized object
+      #
+      # See Unpacker#initialize for supported options.
+      #
+      def load(data)
+      end
+
+      #
+      # Serialize the passed value
+      #
+      # If it could not serialize the object, it raises
+      # NoMethodError: undefined method `to_msgpack' for #<the_object>.
+      #
+      # @param obj [Object] object to serialize
+      # @return [String] serialized object
+      #
+      def dump(object)
+      end
+    end
   end
 end

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -25,7 +25,7 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 public class Factory extends RubyObject {
   private static final long serialVersionUID = 8441284623445322492L;
   private final Ruby runtime;
-  private final ExtensionRegistry extensionRegistry;
+  private ExtensionRegistry extensionRegistry;
   private boolean hasSymbolExtType;
   private boolean hasBigIntExtType;
 
@@ -50,6 +50,14 @@ public class Factory extends RubyObject {
   @JRubyMethod(name = "initialize")
   public IRubyObject initialize(ThreadContext ctx) {
     return this;
+  }
+
+  @JRubyMethod(name = "dup")
+  public IRubyObject dup() {
+    Factory clone = (Factory)super.dup();
+    clone.extensionRegistry = extensionRegistry();
+    clone.hasSymbolExtType = hasSymbolExtType;
+    return clone;
   }
 
   @JRubyMethod(name = "packer", optional = 2)

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -267,7 +267,7 @@ public class Packer extends RubyObject {
     return buffer.size(ctx);
   }
 
-  @JRubyMethod(name = "clear")
+  @JRubyMethod(name = "clear", alias = { "reset" })
   public IRubyObject clear(ThreadContext ctx) {
     return buffer.clear(ctx);
   }

--- a/ext/msgpack/packer_ext_registry.c
+++ b/ext/msgpack/packer_ext_registry.c
@@ -43,8 +43,14 @@ void msgpack_packer_ext_registry_mark(msgpack_packer_ext_registry_t* pkrg)
 void msgpack_packer_ext_registry_dup(msgpack_packer_ext_registry_t* src,
         msgpack_packer_ext_registry_t* dst)
 {
-    dst->hash = RTEST(src->hash) ? rb_hash_dup(src->hash) : Qnil;
-    dst->cache = RTEST(src->cache) ? rb_hash_dup(src->cache): Qnil;
+    if(RTEST(src->hash) && !rb_obj_frozen_p(src->hash)) {
+        dst->hash = rb_hash_dup(src->hash);
+        dst->cache = RTEST(src->cache) ? rb_hash_dup(src->cache) : Qnil;
+    } else {
+        // If the type registry is frozen we can safely share it, and share the cache as well.
+        dst->hash = src->hash;
+        dst->cache = src->cache;
+    }
 }
 
 VALUE msgpack_packer_ext_registry_put(msgpack_packer_ext_registry_t* pkrg,


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/issues/255

When handling small payload creating the Packer and Unpacker
instance can easily account for the majority of the serialization
and deserialization time.

For this reason it is recommended to reuse these objects, and
`Factory#pool` is a helper for that.