### PR TITLE
Make compat code simpler (smaller if-clause)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        # TODO: update to 9.3.3.0 once supported
-        # https://github.com/ruby/setup-ruby#supported-versions
-        ruby: ['jruby-9.2.19.0', 'jruby-9.3.2.0']
+        ruby: ['jruby-9.2.19.0', 'jruby-9.3.3.0']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2022-02-15 version 1.4.5:
+
+* Fix to create UTF-8 Symbol keys when symbolize_keys: true
+* Fix to assume Symbols as US-ASCII or UTF-8
+* Optimize Packer/Unpacker initialization
+* Optimize extension class lookup
+* Rename Packer#clear as Packer#reset (#clear is still available as an alias)
+
 2022-01-22 version 1.4.4:
 
 * Specify the build option --platform=8 for older Java platforms

--- a/doclib/msgpack/factory.rb
+++ b/doclib/msgpack/factory.rb
@@ -31,7 +31,7 @@ module MessagePack
     #
     # See Packer#initialize for supported options.
     #
-    def dump(obj, options={})
+    def dump(obj, options=nil)
     end
     alias pack dump
 
@@ -57,7 +57,7 @@ module MessagePack
     #
     # See Unpacker#initialize for supported options.
     #
-    def load(data, options={})
+    def load(data, options=nil)
     end
     alias unpack load
 

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -52,7 +52,7 @@ public class Factory extends RubyObject {
     return this;
   }
 
-  @JRubyMethod(name = "packer", optional = 1)
+  @JRubyMethod(name = "packer", optional = 2)
   public Packer packer(ThreadContext ctx, IRubyObject[] args) {
     return Packer.newPacker(ctx, extensionRegistry(), hasSymbolExtType, hasBigIntExtType, args);
   }

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -27,12 +27,14 @@ public class Factory extends RubyObject {
   private final Ruby runtime;
   private final ExtensionRegistry extensionRegistry;
   private boolean hasSymbolExtType;
+  private boolean hasBigIntExtType;
 
   public Factory(Ruby runtime, RubyClass type) {
     super(runtime, type);
     this.runtime = runtime;
     this.extensionRegistry = new ExtensionRegistry();
     this.hasSymbolExtType = false;
+    this.hasBigIntExtType = false;
   }
 
   static class FactoryAllocator implements ObjectAllocator {
@@ -52,7 +54,7 @@ public class Factory extends RubyObject {
 
   @JRubyMethod(name = "packer", optional = 1)
   public Packer packer(ThreadContext ctx, IRubyObject[] args) {
-    return Packer.newPacker(ctx, extensionRegistry(), hasSymbolExtType, args);
+    return Packer.newPacker(ctx, extensionRegistry(), hasSymbolExtType, hasBigIntExtType, args);
   }
 
   @JRubyMethod(name = "unpacker", optional = 2)
@@ -77,6 +79,8 @@ public class Factory extends RubyObject {
     IRubyObject packerArg;
     IRubyObject unpackerArg;
 
+    RubyHash options = null;
+
     if (isFrozen()) {
         throw runtime.newRuntimeError("can't modify frozen Factory");
     }
@@ -86,7 +90,7 @@ public class Factory extends RubyObject {
       unpackerArg = runtime.newSymbol("from_msgpack_ext");
     } else if (args.length == 3) {
       if (args[args.length - 1] instanceof RubyHash) {
-        RubyHash options = (RubyHash) args[args.length - 1];
+        options = (RubyHash) args[args.length - 1];
         packerArg = options.fastARef(runtime.newSymbol("packer"));
         unpackerArg = options.fastARef(runtime.newSymbol("unpacker"));
         IRubyObject optimizedSymbolsParsingArg = options.fastARef(runtime.newSymbol("optimized_symbols_parsing"));
@@ -127,6 +131,17 @@ public class Factory extends RubyObject {
 
     if (extModule == runtime.getSymbol()) {
       hasSymbolExtType = true;
+    }
+
+    if (options != null) {
+      IRubyObject oversizedIntegerExtensionArg = options.fastARef(runtime.newSymbol("oversized_integer_extension"));
+      if (oversizedIntegerExtensionArg != null && oversizedIntegerExtensionArg.isTrue()) {
+        if (extModule == runtime.getModule("Integer")) {
+          hasBigIntExtType = true;
+        } else {
+          throw runtime.newArgumentError("oversized_integer_extension: true is only for Integer class");
+        }
+      }
     }
 
     return runtime.getNil();

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -52,10 +52,18 @@ public class Packer extends RubyObject {
   public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
     boolean compatibilityMode = false;
     Ruby runtime = ctx.runtime;
-    if (args.length > 0 && args[args.length - 1] instanceof RubyHash) {
-      RubyHash options = (RubyHash) args[args.length - 1];
-      IRubyObject mode = options.fastARef(runtime.newSymbol("compatibility_mode"));
-      compatibilityMode = (mode != null) && mode.isTrue();
+    if (args.length > 0) {
+      RubyHash options = null;
+      if (args[args.length - 1] instanceof RubyHash) {
+        options = (RubyHash) args[args.length - 1];
+      } else if (args.length > 1 && args[args.length - 2] instanceof RubyHash) {
+        options = (RubyHash) args[args.length - 2];
+      }
+
+      if (options != null) {
+        IRubyObject mode = options.fastARef(runtime.newSymbol("compatibility_mode"));
+        compatibilityMode = (mode != null) && mode.isTrue();
+      }
     }
     if (registry == null) {
         // registry is null when allocate -> initialize

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -32,17 +32,19 @@ public class Packer extends RubyObject {
   private Buffer buffer;
   private Encoder encoder;
   private boolean hasSymbolExtType;
+  private boolean hasBigintExtType;
   private Encoding binaryEncoding;
 
-  public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry, boolean hasSymbolExtType) {
+  public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry, boolean hasSymbolExtType, boolean hasBigintExtType) {
     super(runtime, type);
     this.registry = registry;
     this.hasSymbolExtType = hasSymbolExtType;
+    this.hasBigintExtType = hasBigintExtType;
   }
 
   static class PackerAllocator implements ObjectAllocator {
     public IRubyObject allocate(Ruby runtime, RubyClass type) {
-      return new Packer(runtime, type, null, false);
+      return new Packer(runtime, type, null, false, false);
     }
   }
 
@@ -60,15 +62,15 @@ public class Packer extends RubyObject {
         // registry is already initialized (and somthing might be registered) when newPacker from Factory
         this.registry = new ExtensionRegistry();
     }
-    this.encoder = new Encoder(runtime, compatibilityMode, registry, hasSymbolExtType);
+    this.encoder = new Encoder(runtime, compatibilityMode, registry, hasSymbolExtType, hasBigintExtType);
     this.buffer = new Buffer(runtime, runtime.getModule("MessagePack").getClass("Buffer"));
     this.buffer.initialize(ctx, args);
     this.binaryEncoding = runtime.getEncodingService().getAscii8bitEncoding();
     return this;
   }
 
-  public static Packer newPacker(ThreadContext ctx, ExtensionRegistry extRegistry, boolean hasSymbolExtType, IRubyObject[] args) {
-    Packer packer = new Packer(ctx.runtime, ctx.runtime.getModule("MessagePack").getClass("Packer"), extRegistry, hasSymbolExtType);
+  public static Packer newPacker(ThreadContext ctx, ExtensionRegistry extRegistry, boolean hasSymbolExtType, boolean hasBigintExtType, IRubyObject[] args) {
+    Packer packer = new Packer(ctx.runtime, ctx.runtime.getModule("MessagePack").getClass("Packer"), extRegistry, hasSymbolExtType, hasBigintExtType);
     packer.initialize(ctx, args);
     return packer;
   }

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -56,30 +56,48 @@ public class Unpacker extends RubyObject {
 
   @JRubyMethod(name = "initialize", optional = 2, visibility = PRIVATE)
   public IRubyObject initialize(ThreadContext ctx, IRubyObject[] args) {
+    Ruby runtime = ctx.runtime;
+
     symbolizeKeys = false;
     allowUnknownExt = false;
     freeze = false;
-    if (args.length > 0) {
-      Ruby runtime = ctx.runtime;
-      if (args[args.length - 1] instanceof RubyHash) {
-        RubyHash options = (RubyHash) args[args.length - 1];
-        IRubyObject sk = options.fastARef(runtime.newSymbol("symbolize_keys"));
-        if (sk != null) {
-          symbolizeKeys = sk.isTrue();
-        }
-        IRubyObject f = options.fastARef(runtime.newSymbol("freeze"));
-        if (f != null) {
-          freeze = f.isTrue();
-        }
-        IRubyObject au = options.fastARef(runtime.newSymbol("allow_unknown_ext"));
-        if (au != null) {
-          allowUnknownExt = au.isTrue();
-        }
-      }
-      if (args[0] != runtime.getNil() && !(args[0] instanceof RubyHash)) {
-        setStream(ctx, args[0]);
-      }
+
+    IRubyObject io = null;
+    RubyHash options = null;
+
+    if (args.length >= 1) {
+      io = args[0];
     }
+
+    if (args.length >= 2 && args[1] != runtime.getNil()) {
+      options = (RubyHash)args[1];
+    }
+
+    if (options == null && io != null && io instanceof RubyHash) {
+      options = (RubyHash)io;
+      io = null;
+    }
+
+    if (options != null) {
+      IRubyObject sk = options.fastARef(runtime.newSymbol("symbolize_keys"));
+      if (sk != null) {
+        symbolizeKeys = sk.isTrue();
+      }
+      IRubyObject f = options.fastARef(runtime.newSymbol("freeze"));
+      if (f != null) {
+        freeze = f.isTrue();
+      }
+      IRubyObject au = options.fastARef(runtime.newSymbol("allow_unknown_ext"));
+      if (au != null) {
+        allowUnknownExt = au.isTrue();
+      }
+
+    }
+
+    if (io != null && io != runtime.getNil()) {
+      setStream(ctx, io);
+    }
+
     return this;
   }
 

--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -29,6 +29,11 @@ static ID s_write;
 static ID s_append;
 static ID s_close;
 
+static VALUE sym_read_reference_threshold;
+static VALUE sym_write_reference_threshold;
+static VALUE sym_io_buffer_size;
+
+
 #define BUFFER(from, name) \
     msgpack_buffer_t *name = NULL; \
     Data_Get_Struct(from, msgpack_buffer_t, name); \
@@ -89,17 +94,17 @@ void MessagePack_Buffer_set_options(msgpack_buffer_t* b, VALUE io, VALUE options
     if(options != Qnil) {
         VALUE v;
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("read_reference_threshold")));
+        v = rb_hash_aref(options, sym_read_reference_threshold);
         if(v != Qnil) {
             msgpack_buffer_set_read_reference_threshold(b, NUM2ULONG(v));
         }
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("write_reference_threshold")));
+        v = rb_hash_aref(options, sym_write_reference_threshold);
         if(v != Qnil) {
             msgpack_buffer_set_write_reference_threshold(b, NUM2ULONG(v));
         }
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("io_buffer_size")));
+        v = rb_hash_aref(options, sym_io_buffer_size);
         if(v != Qnil) {
             msgpack_buffer_set_io_buffer_size(b, NUM2ULONG(v));
         }
@@ -478,6 +483,10 @@ void MessagePack_Buffer_module_init(VALUE mMessagePack)
     s_write = rb_intern("write");
     s_append = rb_intern("<<");
     s_close = rb_intern("close");
+
+    sym_read_reference_threshold = ID2SYM(rb_intern("read_reference_threshold"));
+    sym_write_reference_threshold = ID2SYM(rb_intern("write_reference_threshold"));
+    sym_io_buffer_size = ID2SYM(rb_intern("io_buffer_size"));
 
     msgpack_buffer_static_init();
 

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -33,6 +33,10 @@ static VALUE eUnexpectedTypeError;
 static VALUE eUnknownExtTypeError;
 static VALUE mTypeError;  // obsoleted. only for backward compatibility. See #86.
 
+static VALUE sym_symbolize_keys;
+static VALUE sym_freeze;
+static VALUE sym_allow_unknown_ext;
+
 #define UNPACKER(from, name) \
     msgpack_unpacker_t *name = NULL; \
     Data_Get_Struct(from, msgpack_unpacker_t, name); \
@@ -83,7 +87,7 @@ VALUE MessagePack_Unpacker_initialize(int argc, VALUE* argv, VALUE self)
     } else if(argc == 2) {
         io = argv[0];
         options = argv[1];
-        if(rb_type(options) != T_HASH) {
+        if(options != Qnil && rb_type(options) != T_HASH) {
             rb_raise(rb_eArgError, "expected Hash but found %s.", rb_obj_classname(options));
         }
 
@@ -100,13 +104,13 @@ VALUE MessagePack_Unpacker_initialize(int argc, VALUE* argv, VALUE self)
     if(options != Qnil) {
         VALUE v;
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("symbolize_keys")));
+        v = rb_hash_aref(options, sym_symbolize_keys);
         msgpack_unpacker_set_symbolized_keys(uk, RTEST(v));
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("freeze")));
+        v = rb_hash_aref(options, sym_freeze);
         msgpack_unpacker_set_freeze(uk, RTEST(v));
 
-        v = rb_hash_aref(options, ID2SYM(rb_intern("allow_unknown_ext")));
+        v = rb_hash_aref(options, sym_allow_unknown_ext);
         msgpack_unpacker_set_allow_unknown_ext(uk, RTEST(v));
     }
 
@@ -410,6 +414,10 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
     rb_include_module(eUnexpectedTypeError, mTypeError);
 
     eUnknownExtTypeError = rb_define_class_under(mMessagePack, "UnknownExtTypeError", eUnpackError);
+
+    sym_symbolize_keys = ID2SYM(rb_intern("symbolize_keys"));
+    sym_freeze = ID2SYM(rb_intern("freeze"));
+    sym_allow_unknown_ext = ID2SYM(rb_intern("allow_unknown_ext"));
 
     rb_define_alloc_func(cMessagePack_Unpacker, MessagePack_Unpacker_alloc);
 

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -17,16 +17,15 @@ require "msgpack/time"
 
 module MessagePack
   DefaultFactory = MessagePack::Factory.new
-  DEFAULT_EMPTY_PARAMS = {}.freeze
 
   def load(src, param = nil)
     unpacker = nil
 
     if src.is_a? String
-      unpacker = DefaultFactory.unpacker param || DEFAULT_EMPTY_PARAMS
+      unpacker = DefaultFactory.unpacker param
       unpacker.feed_reference src
     else
-      unpacker = DefaultFactory.unpacker src, param || DEFAULT_EMPTY_PARAMS
+      unpacker = DefaultFactory.unpacker src, param
     end
 
     unpacker.full_unpack
@@ -36,8 +35,8 @@ module MessagePack
   module_function :load
   module_function :unpack
 
-  def pack(v, *rest)
-    packer = DefaultFactory.packer(*rest)
+  def pack(v, io = nil, options = nil)
+    packer = DefaultFactory.packer(io, options)
     packer.write v
     packer.full_pack
   end

--- a/lib/msgpack/bigint.rb
+++ b/lib/msgpack/bigint.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module MessagePack
+  module Bigint
+    TYPE = -142
+
+    # We split the bigint in 32bits chunks so that individual part fits into
+    # a MRI immediate Integer.
+    CHUNK_BITLENGTH = 32
+    BASE = (2**CHUNK_BITLENGTH) - 1
+    FORMAT = 'CL>*'
+
+    if Integer.instance_method(:[]).arity == 1 # Ruby 2.6 and older
+      def self.to_msgpack_ext(bigint)
+        members = []
+
+        if bigint < 0
+          bigint = -bigint
+          members << 1
+        else
+          members << 0
+        end
+
+        while bigint > 0
+          members << (bigint & BASE)
+          bigint = bigint >> CHUNK_BITLENGTH
+        end
+
+        members.pack(FORMAT)
+      end
+    else
+      def self.to_msgpack_ext(bigint)
+        members = []
+
+        if bigint < 0
+          bigint = -bigint
+          members << 1
+        else
+          members << 0
+        end
+
+        offset = 0
+        length = bigint.bit_length
+        while offset < length
+          members << bigint[offset, CHUNK_BITLENGTH]
+          offset += CHUNK_BITLENGTH
+        end
+
+        members.pack(FORMAT)
+      end
+    end
+
+    def self.from_msgpack_ext(data)
+      parts = data.unpack(FORMAT)
+
+      sign = parts.shift
+      sum = parts.pop.to_i
+
+      parts.reverse_each do |part|
+        sum = sum << CHUNK_BITLENGTH
+        sum += part
+      end
+
+      sign == 0 ? sum : -sum
+    end
+  end
+end

--- a/lib/msgpack/version.rb
+++ b/lib/msgpack/version.rb
@@ -1,5 +1,5 @@
 module MessagePack
-  VERSION = "1.4.4"
+  VERSION = "1.4.5"
   # Note for maintainers:
   #  Don't miss building/releasing the JRuby version (rake buld:java)
   #  See "How to build -java rubygems" in README for more details.

--- a/spec/bigint_spec.rb
+++ b/spec/bigint_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe MessagePack::Bigint do
+  it 'serialize and deserialize arbitrary sized integer' do
+    [
+      1,
+      -1,
+      120938120391283122132313,
+      -21903120391203912391023920332103,
+      210290021321301203912933021323,
+    ].each do |int|
+      expect(MessagePack::Bigint.from_msgpack_ext(MessagePack::Bigint.to_msgpack_ext(int))).to be == int
+    end
+  end
+
+  it 'has a stable format' do
+    {
+      120938120391283122132313 => "\x00\x9F\xF4UY\x11\x92\x9A?\x00\x00\x19\x9C".b,
+      -21903120391203912391023920332103 => "\x01/\xB2\xBDG\xBD\xDE\xAA\xEBt\xCC\x8A\xC1\x00\x00\x01\x14".b,
+      210290021321301203912933021323 => "\x00\xC4\xD8\x96\x8Bm\xCB\xC7\x03\xA7{\xD4\"\x00\x00\x00\x02".b,
+    }.each do |int, payload|
+      expect(MessagePack::Bigint.to_msgpack_ext(int)).to be == payload
+      expect(MessagePack::Bigint.from_msgpack_ext(payload)).to be == int
+    end
+  end
+end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -323,8 +323,8 @@ describe MessagePack::Factory do
   end
 
   describe 'the special treatment of symbols with ext type' do
-    def roundtrip(object)
-      subject.load(subject.dump(object))
+    def roundtrip(object, options = nil)
+      subject.load(subject.dump(object), options)
     end
 
     context 'using the optimized symbol unpacker' do
@@ -368,6 +368,14 @@ describe MessagePack::Factory do
 
         it 'lets symbols survive a roundtrip' do
           expect(roundtrip(:symbol)).to be :symbol
+        end
+
+        it 'works with hash keys' do
+          expect(roundtrip(symbol: 1)).to be == { symbol: 1 }
+        end
+
+        it 'works with frozen: true option' do
+          expect(roundtrip(:symbol, freeze: true)).to be :symbol
         end
 
         it 'preserves encoding for ASCII symbols' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ if ENV['GC_STRESS']
 end
 
 require 'msgpack'
+require "msgpack/bigint"
 
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to


### PR DESCRIPTION
See #244 

This change is to try making if-clause for older ruby versions as small as possible.
