### PR TITLE
Fix MessagePack::Bigint::TYPE being too large

### DIFF
--- a/lib/msgpack/bigint.rb
+++ b/lib/msgpack/bigint.rb
@@ -2,7 +2,7 @@
 
 module MessagePack
   module Bigint
-    TYPE = -142
+    TYPE = -122
 
     # We split the bigint in 32bits chunks so that individual part fits into
     # a MRI immediate Integer.


### PR DESCRIPTION
I noticed this mistake while integrating it.

I can also remove that constant, it's merely a suggestion so that different app can more easily interoperate.