### PR TITLE
Remove MessagePack::Bigint::TYPE constant

### DIFF
--- a/lib/msgpack/bigint.rb
+++ b/lib/msgpack/bigint.rb
@@ -2,8 +2,6 @@
 
 module MessagePack
   module Bigint
-    TYPE = -142
-
     # We split the bigint in 32bits chunks so that individual part fits into
     # a MRI immediate Integer.
     CHUNK_BITLENGTH = 32


### PR DESCRIPTION
See: https://github.com/msgpack/msgpack-ruby/pull/270#issuecomment-1061744463