### PR TITLE
Fix recursive extensions nesting

### DIFF
--- a/ext/java/org/msgpack/jruby/Encoder.java
+++ b/ext/java/org/msgpack/jruby/Encoder.java
@@ -415,6 +415,7 @@ public class Encoder {
         if (entry.isRecursive()) {
           ByteBuffer oldBuffer = buffer;
           buffer = ByteBuffer.allocate(CACHE_LINE_SIZE - ARRAY_HEADER_SIZE);
+          boolean previousRecursiveExtension = recursiveExtension;
           recursiveExtension = true;
 
           ByteList payload;
@@ -423,7 +424,7 @@ public class Encoder {
             proc.callMethod(runtime.getCurrentContext(), "call", args);
             payload = new ByteList(buffer.array(), 0, buffer.position(), binaryEncoding, false);
           } finally {
-            recursiveExtension = false;
+            recursiveExtension = previousRecursiveExtension;
             buffer = oldBuffer;
           }
           appendExt(type, payload);

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -423,6 +423,27 @@ describe MessagePack::Factory do
           3,
         ]
       end
+
+      it 'can be nested' do
+        factory = MessagePack::Factory.new
+        factory.register_type(
+          0x02,
+          Set,
+          packer: ->(set, packer) do
+            packer.write(set.to_a)
+            nil
+          end,
+          unpacker: ->(unpacker) do
+            unpacker.read.to_set
+          end,
+          recursive: true,
+        )
+
+        expected = Set[1, Set[2, Set[3]]]
+        payload = factory.dump(expected)
+        expect(payload).to be == "\xC7\v\x02\x92\x01\xC7\x06\x02\x92\x02\xD5\x02\x91\x03".b
+        expect(factory.load(factory.dump(expected))).to be == expected
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "set"
 
 if ENV['SIMPLE_COV']
   require 'simplecov'


### PR DESCRIPTION
I discovered a bug while integrating https://github.com/msgpack/msgpack-ruby/pull/261

I'm trying to figure out a fix, but so far I must admit I don't quite understand what's happening. It has something to do with the stack being set with `type = STACK_TYPE_ARRAY` which cause the native array to be returned instread of the return value of the extension proc.

I'll keep digging, but figured I should let you know of this bug sooner rather than later. cc @tagomoris 