### PR TITLE
Handle platforms without compaction support

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,11 @@ require "msgpack/bigint"
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
   # move objects around, helping to find object movement bugs.
-  GC.verify_compaction_references(double_heap: true, toward: :empty)
+  begin
+    GC.verify_compaction_references(double_heap: true, toward: :empty)
+  rescue NotImplementedError
+    # Some platforms don't support compaction
+  end
 end
 
 if GC.respond_to?(:auto_compact=)


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/issues/265

That's a test only concern, so no big deal.

cc @pvalena