### PR TITLE
Fix recursive extension parsing skipping too many bytes

### DIFF
--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -302,7 +302,6 @@ static inline int read_raw_body_begin(msgpack_unpacker_t* uk, int raw_type)
             VALUE obj;
             uk->last_object = Qnil;
             reset_head_byte(uk);
-            size_t ext_size = uk->reading_raw_remaining;
             uk->reading_raw_remaining = 0;
 
             msgpack_unpacker_stack_t* stack = uk->stack;
@@ -320,7 +319,6 @@ static inline int read_raw_body_begin(msgpack_unpacker_t* uk, int raw_type)
             uk->stack_depth = stack_depth;
             uk->stack_capacity = stack_capacity;
 
-            msgpack_buffer_skip(UNPACKER_BUFFER_(uk), ext_size);
             return object_complete(uk, obj);
         }
     }

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -422,6 +422,12 @@ describe MessagePack::Factory do
           MessagePack::ExtensionValue.new(1, factory.dump(x: 1, y: 2, z: 3)),
           3,
         ]
+
+        expect(factory.load(payload)).to be == [
+          1,
+          Point.new(1, 2, 3),
+          3,
+        ]
       end
 
       it 'can be nested' do


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/pull/261

The recursive call to `read` already consume the buffer so we shouldn't skip anything.

Apologies for not catching this either.

cc @tagomoris 