### PR TITLE
Run rake spec instead of rake and add truffleruby release in the non-head jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # 'bundle install' and cache
-      - run: bundle exec rake
+      - run: bundle exec rake spec
 
   head-versions:
     continue-on-error: true
@@ -54,4 +54,4 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # 'bundle install' and cache
-      - run: bundle exec rake || echo "failed, but ignore it"
+      - run: bundle exec rake spec || echo "failed, but ignore it"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,12 +25,12 @@ jobs:
           bundler-cache: true # 'bundle install' and cache
       - run: bundle exec rake
 
-  jruby:
+  other:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: ['jruby-9.2.19.0', 'jruby-9.3.3.0']
+        ruby: ['jruby-9.2.19.0', 'jruby-9.3.3.0', 'truffleruby']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: ['ruby-head', 'jruby-head', 'truffleruby']
+        ruby: ['ruby-head', 'jruby-head']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I noticed truffleruby fails in https://github.com/msgpack/msgpack-ruby/runs/6416790321?check_suite_focus=true during doc generation, but doc generation is not relevant for being to run this gem correctly. So `rake spec` is a better target.
The failure is also completely hidden due to ` || echo "failed, but ignore it"`.

Since `truffleruby` it the latest truffleruby and not a head version, and it should be stable, I moved it to the stable releases job.