### PR TITLE
Handle empty symbol in optimized symbol parser

### DIFF
--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -177,6 +177,9 @@ static inline int object_complete_symbol(msgpack_unpacker_t* uk, VALUE object)
 static inline int object_complete_ext(msgpack_unpacker_t* uk, int ext_type, VALUE str)
 {
     if (uk->optimized_symbol_ext_type && ext_type == uk->symbol_ext_type) {
+        if (RB_UNLIKELY(NIL_P(str))) { // empty extension is returned as Qnil
+            return object_complete_symbol(uk, ID2SYM(rb_intern3("", 0, rb_utf8_encoding())));
+        }
         return object_complete_symbol(uk, rb_str_intern(str));
     }
 

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -474,6 +474,10 @@ describe MessagePack::Factory do
         expect(roundtrip(:symbol)).to be :symbol
       end
 
+      it 'works with empty symbol' do
+        expect(roundtrip(:"")).to be :""
+      end
+
       it 'preserves encoding for ASCII symbols' do
         expect(:symbol.encoding).to be Encoding::US_ASCII
         expect(roundtrip(:symbol)).to be :symbol


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/issues/291

To avoid allocating garbage, the parser return Qnil for `ext` types if the byte array is empty.

So we were missing a nil check.

cc @chrisseaton @larry-reid-shopify 