### PR TITLE
Fix a GC bug in recursive extensions

### DIFF
--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -59,14 +59,17 @@ void msgpack_unpacker_static_destroy()
 
 #define HEAD_BYTE_REQUIRED 0xc1
 
-static inline msgpack_unpacker_stack_entry_t* _msgpack_unpacker_new_stack(void) {
+static inline msgpack_unpacker_stack_t* _msgpack_unpacker_new_stack(void) {
+    msgpack_unpacker_stack_t *stack = ALLOC(msgpack_unpacker_stack_t);
+    stack->capacity = MSGPACK_UNPACKER_STACK_CAPACITY;
 #ifdef UNPACKER_STACK_RMEM
-    return msgpack_rmem_alloc(&s_stack_rmem);
+    stack->data = msgpack_rmem_alloc(&s_stack_rmem);
     /*memset(uk->stack, 0, MSGPACK_UNPACKER_STACK_CAPACITY);*/
 #else
     /*uk->stack = calloc(MSGPACK_UNPACKER_STACK_CAPACITY, sizeof(msgpack_unpacker_stack_entry_t));*/
-    return xmalloc(MSGPACK_UNPACKER_STACK_CAPACITY * sizeof(msgpack_unpacker_stack_entry_t));
+    stack->data = xmalloc(MSGPACK_UNPACKER_STACK_CAPACITY * sizeof(msgpack_unpacker_stack_entry_t));
 #endif
+    return stack;
 }
 
 msgpack_unpacker_t* _msgpack_unpacker_new(void)
@@ -81,17 +84,17 @@ msgpack_unpacker_t* _msgpack_unpacker_new(void)
     uk->reading_raw = Qnil;
 
     uk->stack = _msgpack_unpacker_new_stack();
-    uk->stack_capacity = MSGPACK_UNPACKER_STACK_CAPACITY;
 
     return uk;
 }
 
-static inline void _msgpack_unpacker_free_stack(msgpack_unpacker_stack_entry_t* stack) {
+static inline void _msgpack_unpacker_free_stack(msgpack_unpacker_stack_t* stack) {
     #ifdef UNPACKER_STACK_RMEM
-        msgpack_rmem_free(&s_stack_rmem, stack);
+        msgpack_rmem_free(&s_stack_rmem, stack->data);
     #else
-        xfree(stack);
+        xfree(stack->data);
     #endif
+    xfree(stack);
 }
 
 void _msgpack_unpacker_destroy(msgpack_unpacker_t* uk)
@@ -100,18 +103,23 @@ void _msgpack_unpacker_destroy(msgpack_unpacker_t* uk)
     msgpack_buffer_destroy(UNPACKER_BUFFER_(uk));
 }
 
+void msgpack_unpacker_mark_stack(msgpack_unpacker_stack_t* stack)
+{
+    if (stack) {
+        msgpack_unpacker_stack_entry_t* s = stack->data;
+        msgpack_unpacker_stack_entry_t* send = stack->data + stack->depth;
+        for(; s < send; s++) {
+            rb_gc_mark(s->object);
+            rb_gc_mark(s->key);
+        }
+    }
+}
+
 void msgpack_unpacker_mark(msgpack_unpacker_t* uk)
 {
     rb_gc_mark(uk->last_object);
     rb_gc_mark(uk->reading_raw);
-
-    msgpack_unpacker_stack_entry_t* s = uk->stack;
-    msgpack_unpacker_stack_entry_t* send = uk->stack + uk->stack_depth;
-    for(; s < send; s++) {
-        rb_gc_mark(s->object);
-        rb_gc_mark(s->key);
-    }
-
+    msgpack_unpacker_mark_stack(uk->stack);
     /* See MessagePack_Buffer_wrap */
     /* msgpack_buffer_mark(UNPACKER_BUFFER_(uk)); */
     rb_gc_mark(uk->buffer_ref);
@@ -123,9 +131,8 @@ void _msgpack_unpacker_reset(msgpack_unpacker_t* uk)
 
     uk->head_byte = HEAD_BYTE_REQUIRED;
 
-    /*memset(uk->stack, 0, sizeof(msgpack_unpacker_t) * uk->stack_depth);*/
-    uk->stack_depth = 0;
-
+    /*memset(uk->stack, 0, sizeof(msgpack_unpacker_t) * uk->stack->depth);*/
+    uk->stack->depth = 0;
     uk->last_object = Qnil;
     uk->reading_raw = Qnil;
     uk->reading_raw_remaining = 0;
@@ -203,35 +210,35 @@ static inline int object_complete_ext(msgpack_unpacker_t* uk, int ext_type, VALU
 /* stack funcs */
 static inline msgpack_unpacker_stack_entry_t* _msgpack_unpacker_stack_entry_top(msgpack_unpacker_t* uk)
 {
-    return &uk->stack[uk->stack_depth-1];
+    return &uk->stack->data[uk->stack->depth-1];
 }
 
 static inline int _msgpack_unpacker_stack_push(msgpack_unpacker_t* uk, enum stack_type_t type, size_t count, VALUE object)
 {
     reset_head_byte(uk);
 
-    if(uk->stack_capacity - uk->stack_depth <= 0) {
+    if(uk->stack->capacity - uk->stack->depth <= 0) {
         return PRIMITIVE_STACK_TOO_DEEP;
     }
 
-    msgpack_unpacker_stack_entry_t* next = &uk->stack[uk->stack_depth];
+    msgpack_unpacker_stack_entry_t* next = &uk->stack->data[uk->stack->depth];
     next->count = count;
     next->type = type;
     next->object = object;
     next->key = Qnil;
 
-    uk->stack_depth++;
+    uk->stack->depth++;
     return PRIMITIVE_CONTAINER_START;
 }
 
 static inline VALUE msgpack_unpacker_stack_pop(msgpack_unpacker_t* uk)
 {
-    return --uk->stack_depth;
+    return --uk->stack->depth;
 }
 
 static inline bool msgpack_unpacker_stack_is_empty(msgpack_unpacker_t* uk)
 {
-    return uk->stack_depth == 0;
+    return uk->stack->depth == 0;
 }
 
 #ifdef USE_CASE_RANGE
@@ -259,7 +266,7 @@ static inline bool msgpack_unpacker_stack_is_empty(msgpack_unpacker_t* uk)
 
 static inline bool is_reading_map_key(msgpack_unpacker_t* uk)
 {
-    if(uk->stack_depth > 0) {
+    if(uk->stack->depth > 0) {
         msgpack_unpacker_stack_entry_t* top = _msgpack_unpacker_stack_entry_top(uk);
         if(top->type == STACK_TYPE_MAP_KEY) {
             return true;
@@ -314,21 +321,12 @@ static inline int read_raw_body_begin(msgpack_unpacker_t* uk, int raw_type)
             reset_head_byte(uk);
             uk->reading_raw_remaining = 0;
 
-            msgpack_unpacker_stack_entry_t* stack = uk->stack;
-            size_t stack_depth = uk->stack_depth;
-            size_t stack_capacity = uk->stack_capacity;
-
-            uk->stack = _msgpack_unpacker_new_stack();
-            uk->stack_depth = 0;
-            uk->stack_capacity = MSGPACK_UNPACKER_STACK_CAPACITY;
-
+            msgpack_unpacker_stack_t* parent_stack = uk->stack;
+            msgpack_unpacker_stack_t* child_stack = _msgpack_unpacker_new_stack();
+            uk->stack = child_stack;
             obj = rb_funcall(proc, s_call, 1, uk->buffer.owner);
-
-            _msgpack_unpacker_free_stack(uk->stack);
-            uk->stack = stack;
-            uk->stack_depth = stack_depth;
-            uk->stack_capacity = stack_capacity;
-
+            uk->stack = parent_stack;
+            _msgpack_unpacker_free_stack(child_stack);
             return object_complete(uk, obj);
         }
     }

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -27,6 +27,7 @@
 
 struct msgpack_unpacker_t;
 typedef struct msgpack_unpacker_t msgpack_unpacker_t;
+typedef struct msgpack_unpacker_stack_t msgpack_unpacker_stack_t;
 
 enum stack_type_t {
     STACK_TYPE_ARRAY,
@@ -41,11 +42,12 @@ typedef struct {
     VALUE key;
 } msgpack_unpacker_stack_entry_t;
 
-typedef struct {
+struct msgpack_unpacker_stack_t {
     size_t depth;
     size_t capacity;
-    msgpack_unpacker_stack_entry_t* data;
-} msgpack_unpacker_stack_t;
+    msgpack_unpacker_stack_entry_t *data;
+    msgpack_unpacker_stack_t *parent;
+};
 
 #define MSGPACK_UNPACKER_STACK_SIZE (8+4+8+8)  /* assumes size_t <= 64bit, enum <= 32bit, VALUE <= 64bit */
 

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -41,16 +41,18 @@ typedef struct {
     VALUE key;
 } msgpack_unpacker_stack_entry_t;
 
+typedef struct {
+    size_t depth;
+    size_t capacity;
+    msgpack_unpacker_stack_entry_t* data;
+} msgpack_unpacker_stack_t;
+
 #define MSGPACK_UNPACKER_STACK_SIZE (8+4+8+8)  /* assumes size_t <= 64bit, enum <= 32bit, VALUE <= 64bit */
 
 struct msgpack_unpacker_t {
     msgpack_buffer_t buffer;
-
+    msgpack_unpacker_stack_t *stack;
     unsigned int head_byte;
-
-    msgpack_unpacker_stack_entry_t* stack;
-    size_t stack_depth;
-    size_t stack_capacity;
 
     VALUE last_object;
 

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -39,7 +39,7 @@ typedef struct {
     enum stack_type_t type;
     VALUE object;
     VALUE key;
-} msgpack_unpacker_stack_t;
+} msgpack_unpacker_stack_entry_t;
 
 #define MSGPACK_UNPACKER_STACK_SIZE (8+4+8+8)  /* assumes size_t <= 64bit, enum <= 32bit, VALUE <= 64bit */
 
@@ -48,7 +48,7 @@ struct msgpack_unpacker_t {
 
     unsigned int head_byte;
 
-    msgpack_unpacker_stack_t* stack;
+    msgpack_unpacker_stack_entry_t* stack;
     size_t stack_depth;
     size_t stack_capacity;
 


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/pull/293

When we process a recursive extension, we replace the unpack stack by a fresh one. The problem is that the stack contains VALUE references so if GC triggers, we won't mark these objects and they'll br garbage collected.
    
To solve this `msgpack_unpacker_stack_t` now has a `parent` pointer, and the unpacker mark function recursively scan the parent stacks.

I've split the PR in multiple commits so it's easier to review. The first two are a small refactoring to make the change easier, the last one is the actual fix.