### PR TITLE
Fix #127: Unpacker#read_array_header and Unpacker#read_map_header to return correct size

### DIFF
--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -678,7 +678,7 @@ int msgpack_unpacker_read_array_header(msgpack_unpacker_t* uk, uint32_t* result_
     } else if(b == 0xdc) {
         /* array 16 */
         READ_CAST_BLOCK_OR_RETURN_EOF(cb, uk, 2);
-        *result_size = _msgpack_be16(cb->u16);
+        *result_size = _msgpack_be16(cb->u16) & 0x0000FFFF; /* expand value to 32 bits */
 
     } else if(b == 0xdd) {
         /* array 32 */
@@ -706,7 +706,7 @@ int msgpack_unpacker_read_map_header(msgpack_unpacker_t* uk, uint32_t* result_si
     } else if(b == 0xde) {
         /* map 16 */
         READ_CAST_BLOCK_OR_RETURN_EOF(cb, uk, 2);
-        *result_size = _msgpack_be16(cb->u16);
+        *result_size = _msgpack_be16(cb->u16) & 0x0000FFFF; /* expand value to 32 bits */
 
     } else if(b == 0xdf) {
         /* map 32 */


### PR DESCRIPTION
Fixes the problem outlined here https://github.com/msgpack/msgpack-ruby/issues/127 by expanding the returned `be16` value safely into a `uint32_t` before writing it to the memory pointed to by `result_size`.

I have verified that the test spec runs correctly on Ruby 2.6.6 (Windows) and the output for the program in #127 is as below (ignore the version since I changed it to be different from the installed version on my computer):

```
"1.5.7"
read_array_header : 1
read_map_header : 2
```

The installed 1.5.6 returns the erroneous output.

```
"1.5.6"
read_array_header : 10001
read_map_header : 20002
```