### PR TITLE
fix: _msgpack_be16 to not overflow (resolves #127)

### DIFF
--- a/ext/msgpack/sysdep.h
+++ b/ext/msgpack/sysdep.h
@@ -35,8 +35,11 @@
 #    define _msgpack_be16(x) ((uint16_t)_byteswap_ushort((unsigned short)x))
 #  else
 #    define _msgpack_be16(x) ( \
-        ((((uint16_t)x) <<  8) ) | \
-        ((((uint16_t)x) >>  8) ) )
+        ( \
+          ((((uint16_t)x) <<  8) ) | \
+          ((((uint16_t)x) >>  8) ) \
+        ) \
+          & 0x0000FFFF )
 #  endif
 #else
 #  define _msgpack_be16(x) ntohs(x)

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -664,6 +664,16 @@ describe MessagePack::Unpacker do
       string *= 256
       MessagePack.unpack(MessagePack.pack(string)).encoding.should == string.encoding
     end
+
+    it 'returns correct size for array16 (issue #127)' do
+      unpacker.feed("\xdc\x00\x01\x01")
+      unpacker.read_array_header.should == 1
+    end
+
+    it 'returns correct size for map16 (issue #127)' do
+      unpacker.feed("\xde\x00\x02\x01\x02\x03\x04")
+      unpacker.read_map_header.should == 2
+    end
   end
 
   context 'extensions' do


### PR DESCRIPTION
Fixes _msgpack_be16 on Windows to force calculated value to have only 16 bits instead of overflowing into 32 bits and returning the wrong result. This is the root cause for the problem in #127

Added regression spec for the failing examples from #127.

Replaces #297.