### PR TITLE
Refactor MessagePack::Buffer to use TypedData_Get_Struct

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -108,8 +108,9 @@ void msgpack_buffer_destroy(msgpack_buffer_t* b)
     }
 }
 
-void msgpack_buffer_mark(msgpack_buffer_t* b)
+void msgpack_buffer_mark(void *ptr)
 {
+    msgpack_buffer_t* b = ptr;
     /* head is always available */
     msgpack_buffer_chunk_t* c = b->head;
     while(c != &b->tail) {

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -133,7 +133,7 @@ void msgpack_buffer_init(msgpack_buffer_t* b);
 
 void msgpack_buffer_destroy(msgpack_buffer_t* b);
 
-void msgpack_buffer_mark(msgpack_buffer_t* b);
+void msgpack_buffer_mark(void* b);
 
 void msgpack_buffer_clear(msgpack_buffer_t* b);
 


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/pull/264

This one is a bit more subtle than the other two classes.

The reason is that the Buffer class can be used in two distinct ways.

If you call `Buffer.new`, and independant `msgpack_buffer_t` is allocated. In this case, the class is responsible for freeing it.

However you can also call `Packer#buffer` or `Unpacker#buffer`. In this case, the `msgpack_buffer_t` is actually inline inside the Packer / Unpacker struct. So the class shouldn't free it.

Previously that was done by conditionally passing the `free` function to `Data_Wrap_Struct`, but that's no longer possible with `TypedData_*`.

So instead `Buffer_free` now check wether the `msgpack_buffer_t` has an `owner` member, and use that to know wether it should free the buffer or not when it is collected.

cc @peterzhu2118 