### PR TITLE
Remove some compilation flags

### DIFF
--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -102,11 +102,9 @@ struct msgpack_buffer_t {
     msgpack_buffer_chunk_t* head;
     msgpack_buffer_chunk_t* free_list;
 
-#ifndef DISABLE_RMEM
     char* rmem_last;
     char* rmem_end;
     void** rmem_owner;
-#endif
 
     union msgpack_buffer_cast_block_t cast_block;
 
@@ -444,7 +442,6 @@ static inline VALUE _msgpack_buffer_refer_head_mapped_string(msgpack_buffer_t* b
 
 static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_t length, bool will_be_frozen, bool utf8)
 {
-#ifndef DISABLE_BUFFER_READ_REFERENCE_OPTIMIZE
     /* optimize */
     if(!will_be_frozen &&
             b->head->mapped_string != NO_MAPPED_STRING &&
@@ -454,7 +451,6 @@ static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_
         _msgpack_buffer_consumed(b, length);
         return result;
     }
-#endif
 
     VALUE result;
 

--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -297,14 +297,13 @@ static inline size_t read_until_eof(msgpack_buffer_t* b, VALUE out, unsigned lon
 
 static inline VALUE read_all(msgpack_buffer_t* b, VALUE out)
 {
-#ifndef DISABLE_BUFFER_READ_TO_S_OPTIMIZE
     if(out == Qnil && !msgpack_buffer_has_io(b)) {
         /* same as to_s && clear; optimize */
         VALUE str = msgpack_buffer_all_as_string(b);
         msgpack_buffer_clear(b);
         return str;
     }
-#endif
+
     MAKE_EMPTY_STRING(out);
     read_until_eof(b, out, 0);
     return out;
@@ -427,7 +426,6 @@ static VALUE Buffer_read(int argc, VALUE* argv, VALUE self)
         return out;
     }
 
-#ifndef DISABLE_BUFFER_READ_TO_S_OPTIMIZE
     if(!msgpack_buffer_has_io(b) && out == Qnil &&
             msgpack_buffer_all_readable_size(b) <= n) {
         /* same as to_s && clear; optimize */
@@ -440,7 +438,6 @@ static VALUE Buffer_read(int argc, VALUE* argv, VALUE self)
             return str;
         }
     }
-#endif
 
     MAKE_EMPTY_STRING(out);
     read_until_eof(b, out, n);

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -8,10 +8,6 @@ have_func("rb_hash_new_capa", "ruby.h") # Ruby 3.2+
 unless RUBY_PLATFORM.include? 'mswin'
   $CFLAGS << %[ -I.. -Wall -O3 #{RbConfig::CONFIG["debugflags"]} -std=gnu99]
 end
-#$CFLAGS << %[ -DDISABLE_RMEM]
-#$CFLAGS << %[ -DDISABLE_RMEM_REUSE_INTERNAL_FRAGMENT]
-#$CFLAGS << %[ -DDISABLE_BUFFER_READ_REFERENCE_OPTIMIZE]
-#$CFLAGS << %[ -DDISABLE_BUFFER_READ_TO_S_OPTIMIZE]
 
 if RUBY_VERSION.start_with?('3.0.')
   # https://bugs.ruby-lang.org/issues/18772

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -20,7 +20,7 @@
 #include "rmem.h"
 #include "extension_value_class.h"
 
-#if !defined(DISABLE_RMEM) && !defined(DISABLE_UNPACKER_STACK_RMEM) && \
+#if !defined(DISABLE_UNPACKER_STACK_RMEM) && \
         MSGPACK_UNPACKER_STACK_CAPACITY * MSGPACK_UNPACKER_STACK_SIZE <= MSGPACK_RMEM_PAGE_SIZE
 #define UNPACKER_STACK_RMEM
 #endif


### PR DESCRIPTION
I was looking into measuring the memory footprint of buffers, and these flags makes the code much harder to understand.

They're not documented in the README, and it's particularly hard to set compilation flags when using bundler & such.

I think it's preferable to reduce the number of compilation conditionals.

@chrisseaton any thoughts?