### PR TITLE
Properly report buffers memory footprint through ObjectSpace.memsize_of

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "msgpack"
+
+require "irb"
+IRB.start(__FILE__)

--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -98,6 +98,20 @@ void msgpack_buffer_destroy(msgpack_buffer_t* b)
     }
 }
 
+size_t msgpack_buffer_memsize(const msgpack_buffer_t* b)
+{
+    size_t memsize = 0;
+    msgpack_buffer_chunk_t* c = b->head;
+
+    while(c) {
+        memsize += sizeof(msgpack_buffer_chunk_t);
+        memsize += (c->last - c->first);
+        c = c->next;
+    }
+
+    return memsize;
+}
+
 void msgpack_buffer_mark(void *ptr)
 {
     msgpack_buffer_t* b = ptr;

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -135,6 +135,8 @@ void msgpack_buffer_mark(void* b);
 
 void msgpack_buffer_clear(msgpack_buffer_t* b);
 
+size_t msgpack_buffer_memsize(const msgpack_buffer_t* b);
+
 static inline void msgpack_buffer_set_write_reference_threshold(msgpack_buffer_t* b, size_t length)
 {
     if(length < MSGPACK_BUFFER_STRING_WRITE_REFERENCE_MINIMUM) {

--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -55,17 +55,29 @@ static void Buffer_free(void* data)
     xfree(b);
 }
 
+static size_t Buffer_memsize(const void *data)
+{
+    const msgpack_buffer_t* b = data;
+
+    if (RTEST(b->owner)) {
+        return 0;
+    }
+
+    return sizeof(msgpack_buffer_t) + msgpack_buffer_memsize(data);
+}
+
 const rb_data_type_t buffer_data_type = {
     .wrap_struct_name = "msgpack:buffer",
     .function = {
         .dmark = msgpack_buffer_mark,
         .dfree = Buffer_free,
-        .dsize = NULL, // TODO: memsie func would be nice
+        .dsize = Buffer_memsize,
     },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };
 
-static inline msgpack_buffer_t *MessagePack_Buffer_get(VALUE object) {
+static inline msgpack_buffer_t *MessagePack_Buffer_get(VALUE object)
+{
     msgpack_buffer_t *buffer;
     TypedData_Get_Struct(object, msgpack_buffer_t, &buffer_data_type, buffer);
     if (!buffer) {

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -53,7 +53,8 @@ static void Packer_mark(void *ptr)
 
 static size_t Packer_memsize(const void *ptr)
 {
-    return sizeof(msgpack_packer_t);
+    const msgpack_packer_t* pk = ptr;
+    return sizeof(msgpack_packer_t) + msgpack_buffer_memsize(&pk->buffer);
 }
 
 const rb_data_type_t packer_data_type = {

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -66,7 +66,7 @@ static size_t Unpacker_memsize(const void *ptr)
 
     total_size += (uk->stack->depth + 1) * sizeof(msgpack_unpacker_stack_t);
 
-    return total_size;
+    return total_size + msgpack_buffer_memsize(&uk->buffer);
 }
 
 const rb_data_type_t unpacker_data_type = {

--- a/spec/cruby/buffer_spec.rb
+++ b/spec/cruby/buffer_spec.rb
@@ -572,4 +572,19 @@ describe Buffer do
       end
     }
   end
+
+  it "defines a function for ObjectSpace.memsize_of" do
+    skip "JRuby doesn't support ObjectSpace.memsize_of" if IS_JRUBY
+
+    buffer = MessagePack::Buffer.new
+    empty_size = ObjectSpace.memsize_of(buffer)
+    expect(empty_size).to be < 400
+    buffer << "a" * 10_000
+    memsize = ObjectSpace.memsize_of(buffer)
+    expect(memsize).to be > 10_000
+    buffer.read(10)
+    expect(ObjectSpace.memsize_of(buffer)).to be == memsize
+    buffer.read_all
+    expect(ObjectSpace.memsize_of(buffer)).to be == empty_size
+  end
 end


### PR DESCRIPTION
When the buffer is embeded in a packer or unpacker, we report its size on the owner object.