### PR TITLE
Restore referenced buffers feature

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -105,7 +105,9 @@ size_t msgpack_buffer_memsize(const msgpack_buffer_t* b)
 
     while(c) {
         memsize += sizeof(msgpack_buffer_chunk_t);
-        memsize += (c->last - c->first);
+        if(c->mapped_string != NO_MAPPED_STRING) {
+            memsize += (c->last - c->first);
+        }
         c = c->next;
     }
 
@@ -301,8 +303,13 @@ static inline void _msgpack_buffer_add_new_chunk(msgpack_buffer_t* b)
 
 static inline void _msgpack_buffer_append_reference(msgpack_buffer_t* b, VALUE string)
 {
-    VALUE mapped_string = rb_str_dup(string);
-    ENCODING_SET(mapped_string, msgpack_rb_encindex_ascii8bit);
+    VALUE mapped_string;
+    if(ENCODING_GET(string) == msgpack_rb_encindex_ascii8bit && RTEST(rb_obj_frozen_p(string))) {
+        mapped_string = string;
+    } else {
+        mapped_string = rb_str_dup(string);
+        ENCODING_SET(mapped_string, msgpack_rb_encindex_ascii8bit);
+    }
 
     _msgpack_buffer_add_new_chunk(b);
 
@@ -335,7 +342,7 @@ void _msgpack_buffer_append_long_string(msgpack_buffer_t* b, VALUE string)
             msgpack_buffer_append(b, RSTRING_PTR(string), length);
         }
     } else {
-        msgpack_buffer_append(b, RSTRING_PTR(string), length);
+       _msgpack_buffer_append_reference(b, string);
     }
 }
 

--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -299,6 +299,30 @@ static inline void _msgpack_buffer_add_new_chunk(msgpack_buffer_t* b)
     }
 }
 
+static inline void _msgpack_buffer_append_reference(msgpack_buffer_t* b, VALUE string)
+{
+    VALUE mapped_string = rb_str_dup(string);
+    ENCODING_SET(mapped_string, msgpack_rb_encindex_ascii8bit);
+
+    _msgpack_buffer_add_new_chunk(b);
+
+    char* data = RSTRING_PTR(mapped_string);
+    size_t length = RSTRING_LEN(mapped_string);
+
+    b->tail.first = (char*) data;
+    b->tail.last = (char*) data + length;
+    b->tail.mapped_string = mapped_string;
+    b->tail.mem = NULL;
+
+    /* msgpack_buffer_writable_size should return 0 for mapped chunk */
+    b->tail_buffer_end = b->tail.last;
+
+    /* consider read_buffer */
+    if(b->head == &b->tail) {
+        b->read_buffer = b->tail.first;
+    }
+}
+
 void _msgpack_buffer_append_long_string(msgpack_buffer_t* b, VALUE string)
 {
     size_t length = RSTRING_LEN(string);

--- a/spec/cruby/buffer_spec.rb
+++ b/spec/cruby/buffer_spec.rb
@@ -579,9 +579,11 @@ describe Buffer do
     buffer = MessagePack::Buffer.new
     empty_size = ObjectSpace.memsize_of(buffer)
     expect(empty_size).to be < 400
-    buffer << "a" * 10_000
+    10.times do
+      buffer << "a" * 500
+    end
     memsize = ObjectSpace.memsize_of(buffer)
-    expect(memsize).to be > 10_000
+    expect(memsize).to be > empty_size
     buffer.read(10)
     expect(ObjectSpace.memsize_of(buffer)).to be == memsize
     buffer.read_all


### PR DESCRIPTION
Restore referenced buffers feature
    
I think this feature was accidentally removed in https://github.com/msgpack/msgpack-ruby/pull/213
    
On the MRI versions we support `rb_str_dup` won't copy the string but return a shared string. So it's safe to always append a reference when we are provided a string.
    
So instead of copying the RString content into the buffer, we simply keep a reference to it, and point to its RSTRING_PTR().

From some quick benchmarking, it doesn't seem to make a very big difference, but since we already have all the facilities for it, might as well use it.

FYI @chrisseaton (for when you get back, no rush)