### PR TITLE
Fix all old-style function definitions

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -31,7 +31,7 @@ ID s_uminus;
 
 static msgpack_rmem_t s_rmem;
 
-void msgpack_buffer_static_init()
+void msgpack_buffer_static_init(void)
 {
     s_uminus = rb_intern("-@");
 
@@ -46,7 +46,7 @@ void msgpack_buffer_static_init()
 #endif
 }
 
-void msgpack_buffer_static_destroy()
+void msgpack_buffer_static_destroy(void)
 {
     msgpack_rmem_destroy(&s_rmem);
 }

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -123,9 +123,9 @@ struct msgpack_buffer_t {
 /*
  * initialization functions
  */
-void msgpack_buffer_static_init();
+void msgpack_buffer_static_init(void);
 
-void msgpack_buffer_static_destroy();
+void msgpack_buffer_static_destroy(void);
 
 void msgpack_buffer_init(msgpack_buffer_t* b);
 

--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -20,12 +20,12 @@
 
 static ID s_call;
 
-void msgpack_packer_static_init()
+void msgpack_packer_static_init(void)
 {
     s_call = rb_intern("call");
 }
 
-void msgpack_packer_static_destroy()
+void msgpack_packer_static_destroy(void)
 { }
 
 void msgpack_packer_init(msgpack_packer_t* pk)

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -47,9 +47,9 @@ struct msgpack_packer_t {
 
 #define PACKER_BUFFER_(pk) (&(pk)->buffer)
 
-void msgpack_packer_static_init();
+void msgpack_packer_static_init(void);
 
-void msgpack_packer_static_destroy();
+void msgpack_packer_static_destroy(void);
 
 void msgpack_packer_init(msgpack_packer_t* pk);
 

--- a/ext/msgpack/packer_ext_registry.c
+++ b/ext/msgpack/packer_ext_registry.c
@@ -20,12 +20,12 @@
 
 static ID s_call;
 
-void msgpack_packer_ext_registry_static_init()
+void msgpack_packer_ext_registry_static_init(void)
 {
     s_call = rb_intern("call");
 }
 
-void msgpack_packer_ext_registry_static_destroy()
+void msgpack_packer_ext_registry_static_destroy(void)
 { }
 
 void msgpack_packer_ext_registry_init(msgpack_packer_ext_registry_t* pkrg)

--- a/ext/msgpack/packer_ext_registry.h
+++ b/ext/msgpack/packer_ext_registry.h
@@ -31,9 +31,9 @@ struct msgpack_packer_ext_registry_t {
     VALUE cache; // lookup cache for ext types inherited from a super class
 };
 
-void msgpack_packer_ext_registry_static_init();
+void msgpack_packer_ext_registry_static_init(void);
 
-void msgpack_packer_ext_registry_static_destroy();
+void msgpack_packer_ext_registry_static_destroy(void);
 
 void msgpack_packer_ext_registry_init(msgpack_packer_ext_registry_t* pkrg);
 

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -41,7 +41,7 @@ static inline VALUE rb_hash_new_capa(long capa)
 }
 #endif
 
-void msgpack_unpacker_static_init()
+void msgpack_unpacker_static_init(void)
 {
 #ifdef UNPACKER_STACK_RMEM
     msgpack_rmem_init(&s_stack_rmem);
@@ -50,7 +50,7 @@ void msgpack_unpacker_static_init()
     s_call = rb_intern("call");
 }
 
-void msgpack_unpacker_static_destroy()
+void msgpack_unpacker_static_destroy(void)
 {
 #ifdef UNPACKER_STACK_RMEM
     msgpack_rmem_destroy(&s_stack_rmem);

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -86,9 +86,9 @@ enum msgpack_unpacker_object_type {
     TYPE_MAP,
 };
 
-void msgpack_unpacker_static_init();
+void msgpack_unpacker_static_init(void);
 
-void msgpack_unpacker_static_destroy();
+void msgpack_unpacker_static_destroy(void);
 
 void _msgpack_unpacker_init(msgpack_unpacker_t*);
 

--- a/ext/msgpack/unpacker_ext_registry.c
+++ b/ext/msgpack/unpacker_ext_registry.c
@@ -21,14 +21,14 @@
 static ID s_call;
 static ID s_dup;
 
-void msgpack_unpacker_ext_registry_static_init()
+void msgpack_unpacker_ext_registry_static_init(void)
 {
     s_call = rb_intern("call");
     s_dup = rb_intern("dup");
 }
 
 
-void msgpack_unpacker_ext_registry_static_destroy()
+void msgpack_unpacker_ext_registry_static_destroy(void)
 { }
 
 void msgpack_unpacker_ext_registry_mark(msgpack_unpacker_ext_registry_t* ukrg)

--- a/ext/msgpack/unpacker_ext_registry.h
+++ b/ext/msgpack/unpacker_ext_registry.h
@@ -31,9 +31,9 @@ struct msgpack_unpacker_ext_registry_t {
     VALUE array[256];
 };
 
-void msgpack_unpacker_ext_registry_static_init();
+void msgpack_unpacker_ext_registry_static_init(void);
 
-void msgpack_unpacker_ext_registry_static_destroy();
+void msgpack_unpacker_ext_registry_static_destroy(void);
 
 void msgpack_unpacker_ext_registry_release(msgpack_unpacker_ext_registry_t* ukrg);
 


### PR DESCRIPTION
Ruby 3.2 compiles with -Wold-style-definition which will generate warnings for all old-style function definitions.