### PR TITLE
Fix potential use-after-free in Buffer_free

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+* Fix a potential use-after-free bug in Buffer_free when accessing a packer or unpacker buffer. 
+
 2022-08-23 1.5.6:
 
 * No actual code change, just re-release the `java` version properly.

--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -127,8 +127,6 @@ void msgpack_buffer_mark(void *ptr)
 
     rb_gc_mark(b->io);
     rb_gc_mark(b->io_buffer);
-
-    rb_gc_mark(b->owner);
 }
 
 bool _msgpack_buffer_shift_chunk(msgpack_buffer_t* b)

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -116,8 +116,6 @@ struct msgpack_buffer_t {
     size_t write_reference_threshold;
     size_t read_reference_threshold;
     size_t io_buffer_size;
-
-    VALUE owner;
 };
 
 /*

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -322,7 +322,7 @@ static inline int read_raw_body_begin(msgpack_unpacker_t* uk, int raw_type)
             child_stack->parent = uk->stack;
             uk->stack = child_stack;
 
-            obj = rb_funcall(proc, s_call, 1, uk->buffer.owner);
+            obj = rb_funcall(proc, s_call, 1, uk->self);
 
             uk->stack = child_stack->parent;
             _msgpack_unpacker_free_stack(child_stack);

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -56,6 +56,7 @@ struct msgpack_unpacker_t {
     msgpack_unpacker_stack_t *stack;
     unsigned int head_byte;
 
+    VALUE self;
     VALUE last_object;
 
     VALUE reading_raw;

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -84,6 +84,7 @@ VALUE MessagePack_Unpacker_alloc(VALUE klass)
     msgpack_unpacker_t* uk;
     VALUE self = TypedData_Make_Struct(klass, msgpack_unpacker_t, &unpacker_data_type, uk);
     _msgpack_unpacker_init(uk);
+    uk->self = self;
     return self;
 }
 


### PR DESCRIPTION
`Buffer_free` rely on msgpack_buffer_t.owner to know wether it should free the struct or if it's owned by another object.

This assumes that the "view" buffer will be freed before the object that actually owns the buffer, but that's never guaranteed.

Instead we create view buffer without a `free` function, as they have nothing to free anyway.

The only complexity is that when calling a method on a buffer, we need to know if it's a direct buffer or a "view". To know this we store that information in a regular instance variable.

Co-Authored-By: @peterzhu2118 

cc @chrisseaton 