### PR TITLE
Add ruby_memcheck

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,17 @@ jobs:
           bundler-cache: true # 'bundle install' and cache
       - run: bundle exec rake
 
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true # 'bundle install' and cache
+      - run: sudo apt-get install -y valgrind
+      - run: bundle exec rake spec:valgrind
+
   other:
     strategy:
       fail-fast: false

--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rake-compiler', ['>= 1.1.9']
   s.add_development_dependency 'rspec', ['~> 3.3']
+  s.add_development_dependency 'ruby_memcheck'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'json'
   s.add_development_dependency 'benchmark-ips', ['~> 2.10.0']


### PR DESCRIPTION
ruby_memcheck is a tool that helps find memory leaks and errors using Valgrind memcheck. ruby_memcheck helped discover the bug fixed in #307.

This PR adds a `spec:valgrind` target to run the test suite using ruby_memcheck and adds a CI pipeline that runs the target.