### PR TITLE
Add a spec to ensure behavior on multiple packers remain stable

### DIFF
--- a/ext/java/org/msgpack/jruby/ExtensionRegistry.java
+++ b/ext/java/org/msgpack/jruby/ExtensionRegistry.java
@@ -18,22 +18,17 @@ public class ExtensionRegistry {
   private final ExtensionEntry[] extensionsByTypeId;
 
   public ExtensionRegistry() {
-    this(new HashMap<RubyModule, ExtensionEntry>());
+    this(new HashMap<RubyModule, ExtensionEntry>(), new ExtensionEntry[256]);
   }
 
-  private ExtensionRegistry(Map<RubyModule, ExtensionEntry> extensionsByModule) {
+  private ExtensionRegistry(Map<RubyModule, ExtensionEntry> extensionsByModule, ExtensionEntry[] extensionsByTypeId) {
     this.extensionsByModule = new HashMap<RubyModule, ExtensionEntry>(extensionsByModule);
     this.extensionsByAncestor = new HashMap<RubyModule, ExtensionEntry>();
-    this.extensionsByTypeId = new ExtensionEntry[256];
-    for (ExtensionEntry entry : extensionsByModule.values()) {
-      if (entry.hasUnpacker()) {
-        extensionsByTypeId[entry.getTypeId() + 128] = entry;
-      }
-    }
+    this.extensionsByTypeId = extensionsByTypeId.clone();
   }
 
   public ExtensionRegistry dup() {
-    return new ExtensionRegistry(extensionsByModule);
+    return new ExtensionRegistry(extensionsByModule, extensionsByTypeId);
   }
 
   public IRubyObject toInternalPackerRegistry(ThreadContext ctx) {


### PR DESCRIPTION
Currently if multiple packers are registered for the same class, the last one is the one that will be used for serialization.

This test is added to make sure this won't change in the future.