### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -12,10 +12,12 @@ Gem::Specification.new do |s|
   s.homepage = "http://msgpack.org/"
   s.require_paths = ["lib"]
   if /java/ =~ RUBY_PLATFORM
-    s.files = Dir['lib/**/*.rb', 'lib/**/*.jar']
+    s.files = Dir['lib/**/*.rb', 'lib/**/*.jar', 'LICENSE']
     s.platform = Gem::Platform.new('java')
   else
-    s.files = `git ls-files`.split("\n")
+    s.files = `git ls-files -z`.split("\x0").reject do |f|
+      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features|bench|doclib|msgpack.org.md|Gemfile|Rakefile)|\.(?:git|circleci|rubocop)|appveyor)})
+    end
     s.extensions = ["ext/msgpack/extconf.rb"]
   end
 


### PR DESCRIPTION
There are several files in the gem package that aren't useful for downstream projects. Removing these files reduces the gem package size from **89K** to **59K**!

<details><summary>gem contents diff</summary>

```diff
< .github/workflows/ci.yaml
< .gitignore
< .rubocop.yml
  ChangeLog
< Gemfile
  LICENSE
  README.md
< Rakefile
< appveyor.yml
< bench/bench.rb
< bin/console
< doclib/msgpack.rb
< doclib/msgpack/buffer.rb
< doclib/msgpack/core_ext.rb
< doclib/msgpack/error.rb
< doclib/msgpack/extension_value.rb
< doclib/msgpack/factory.rb
< doclib/msgpack/packer.rb
< doclib/msgpack/time.rb
< doclib/msgpack/timestamp.rb
< doclib/msgpack/unpacker.rb
  ext/java/org/msgpack/jruby/Buffer.java
  ext/java/org/msgpack/jruby/Decoder.java
  ext/java/org/msgpack/jruby/Encoder.java
  ext/java/org/msgpack/jruby/ExtensionRegistry.java
  ext/java/org/msgpack/jruby/ExtensionValue.java
  ext/java/org/msgpack/jruby/Factory.java
  ext/java/org/msgpack/jruby/MessagePackLibrary.java
  ext/java/org/msgpack/jruby/Packer.java
  ext/java/org/msgpack/jruby/Types.java
  ext/java/org/msgpack/jruby/Unpacker.java
  ext/msgpack/buffer.c
  ext/msgpack/buffer.h
  ext/msgpack/buffer_class.c
  ext/msgpack/buffer_class.h
  ext/msgpack/compat.h
  ext/msgpack/extconf.rb
  ext/msgpack/extension_value_class.c
  ext/msgpack/extension_value_class.h
  ext/msgpack/factory_class.c
  ext/msgpack/factory_class.h
  ext/msgpack/packer.c
  ext/msgpack/packer.h
  ext/msgpack/packer_class.c
  ext/msgpack/packer_class.h
  ext/msgpack/packer_ext_registry.c
  ext/msgpack/packer_ext_registry.h
  ext/msgpack/rbinit.c
  ext/msgpack/rmem.c
  ext/msgpack/rmem.h
  ext/msgpack/sysdep.h
  ext/msgpack/sysdep_endian.h
  ext/msgpack/sysdep_types.h
  ext/msgpack/unpacker.c
  ext/msgpack/unpacker.h
  ext/msgpack/unpacker_class.c
  ext/msgpack/unpacker_class.h
  ext/msgpack/unpacker_ext_registry.c
  ext/msgpack/unpacker_ext_registry.h
  lib/msgpack.rb
  lib/msgpack/bigint.rb
  lib/msgpack/core_ext.rb
  lib/msgpack/factory.rb
  lib/msgpack/packer.rb
  lib/msgpack/symbol.rb
  lib/msgpack/time.rb
  lib/msgpack/timestamp.rb
  lib/msgpack/unpacker.rb
  lib/msgpack/version.rb
< msgpack.gemspec
< msgpack.org.md
< spec/bigint_spec.rb
< spec/cases.json
< spec/cases.msg
< spec/cases_compact.msg
< spec/cases_spec.rb
< spec/cruby/buffer_io_spec.rb
< spec/cruby/buffer_packer.rb
< spec/cruby/buffer_spec.rb
< spec/cruby/buffer_unpacker.rb
< spec/cruby/unpacker_spec.rb
< spec/ext_value_spec.rb
< spec/exttypes.rb
< spec/factory_spec.rb
< spec/format_spec.rb
< spec/jruby/benchmarks/shootout_bm.rb
< spec/jruby/benchmarks/symbolize_keys_bm.rb
< spec/jruby/unpacker_spec.rb
< spec/msgpack_spec.rb
< spec/pack_spec.rb
< spec/packer_spec.rb
< spec/random_compat.rb
< spec/spec_helper.rb
< spec/timestamp_spec.rb
< spec/unpack_spec.rb
< spec/unpacker_spec.rb
```

</details>