### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! For confidence in compatibility, let's add it to the build matrix.