### PR TITLE
Don't define RB_ENC_INTERNED_STR_NULL_CHECK on Ruby 3.0.5+

### DIFF
--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -9,7 +9,7 @@ unless RUBY_PLATFORM.include? 'mswin'
   $CFLAGS << %[ -I.. -Wall -O3 #{RbConfig::CONFIG["debugflags"]} -std=gnu99]
 end
 
-if RUBY_VERSION.start_with?('3.0.')
+if RUBY_VERSION.start_with?('3.0.') && RUBY_VERSION <= '3.0.5'
   # https://bugs.ruby-lang.org/issues/18772
   $CFLAGS << ' -DRB_ENC_INTERNED_STR_NULL_CHECK=1 '
 end


### PR DESCRIPTION
The fix was backported as part of 3.0.5.

cc @peterzhu2118 