### PR TITLE
Hide all the symbols by defaults to avoid conflict

### DIFF
--- a/ext/msgpack/buffer_class.c
+++ b/ext/msgpack/buffer_class.c
@@ -56,7 +56,7 @@ static size_t Buffer_memsize(const void *data)
     return sizeof(msgpack_buffer_t) + msgpack_buffer_memsize(data);
 }
 
-const rb_data_type_t buffer_data_type = {
+static const rb_data_type_t buffer_data_type = {
     .wrap_struct_name = "msgpack:buffer",
     .function = {
         .dmark = msgpack_buffer_mark,
@@ -66,7 +66,7 @@ const rb_data_type_t buffer_data_type = {
     .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };
 
-const rb_data_type_t buffer_view_data_type = {
+static const rb_data_type_t buffer_view_data_type = {
     .wrap_struct_name = "msgpack:buffer_view",
     .function = {
         .dmark = msgpack_buffer_mark,

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -5,6 +5,8 @@ have_header("st.h")
 have_func("rb_enc_interned_str", "ruby.h") # Ruby 3.0+
 have_func("rb_hash_new_capa", "ruby.h") # Ruby 3.2+
 
+$CFLAGS << " -fvisibility=hidden "
+
 unless RUBY_PLATFORM.include? 'mswin'
   $CFLAGS << %[ -I.. -Wall -O3 #{RbConfig::CONFIG["debugflags"]} -std=gnu99]
 end

--- a/ext/msgpack/rbinit.c
+++ b/ext/msgpack/rbinit.c
@@ -22,7 +22,7 @@
 #include "factory_class.h"
 #include "extension_value_class.h"
 
-void Init_msgpack(void)
+RUBY_FUNC_EXPORTED void Init_msgpack(void)
 {
     VALUE mMessagePack = rb_define_module("MessagePack");
 


### PR DESCRIPTION
We recently experienced segfaults because `buffer_data_type` was name clashing with another gem (https://github.com/msgpack/msgpack-ruby/pull/314#issuecomment-1450366135).

Generally speaking, there is very few use cases for gems to expose any of their symbols, so we should just hide them all by default and avoid this problem entirely.

@peterzhu2118 

CC @flavorjones, as this may be of interest to you.