### PR TITLE
Mark `packer->to_msgpack_arg` and `unpacker->self`

### DIFF
--- a/ext/msgpack/packer.c
+++ b/ext/msgpack/packer.c
@@ -43,6 +43,7 @@ void msgpack_packer_mark(msgpack_packer_t* pk)
     /* See MessagePack_Buffer_wrap */
     /* msgpack_buffer_mark(PACKER_BUFFER_(pk)); */
     rb_gc_mark(pk->buffer_ref);
+    rb_gc_mark(pk->to_msgpack_arg);
 }
 
 void msgpack_packer_reset(msgpack_packer_t* pk)

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -120,6 +120,7 @@ void msgpack_unpacker_mark(msgpack_unpacker_t* uk)
     /* See MessagePack_Buffer_wrap */
     /* msgpack_buffer_mark(UNPACKER_BUFFER_(uk)); */
     rb_gc_mark(uk->buffer_ref);
+    rb_gc_mark(uk->self);
 }
 
 void _msgpack_unpacker_reset(msgpack_unpacker_t* uk)


### PR DESCRIPTION
Prior to https://github.com/msgpack/msgpack-ruby/pull/318 they'd be indirectly marked via the Buffer object which holds a reference on the same object, but that's no longer the case so we need to explictly mark them.

And it's more correct anyway.

