### PR TITLE
Debug: keep track of how buffer chunks were allocated.

### DIFF
--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -78,6 +78,7 @@ struct msgpack_buffer_chunk_t {
     void* mem;
     msgpack_buffer_chunk_t* next;
     VALUE mapped_string;  /* RBString or NO_MAPPED_STRING */
+    bool rmem;
 };
 
 union msgpack_buffer_cast_block_t {

--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -86,7 +86,9 @@ void _msgpack_unpacker_init(msgpack_unpacker_t* uk)
 
 static inline void _msgpack_unpacker_free_stack(msgpack_unpacker_stack_t* stack) {
     #ifdef UNPACKER_STACK_RMEM
-        msgpack_rmem_free(&s_stack_rmem, stack->data);
+        if (!msgpack_rmem_free(&s_stack_rmem, stack->data)) {
+            rb_bug("Failed to free an rmem pointer, memory leak?");
+        }
     #else
         xfree(stack->data);
     #endif


### PR DESCRIPTION
### Context

We've observed some hard crashes, and based on the backtrace in the core dump, it seems that we're either double freeing a pointer, or trying to free in the middle of the reserved memory region.

From the original code:

```c
if(!msgpack_rmem_free(&s_rmem, c->mem)) {
    if(!msgpack_rmem_free(&s_rmem, c->mem)) {
        xfree(c->mem);
    }
}
```

So all we know is that `rmem` didn't recognize that pointer, and that trying to free it caused a crash.

We don't know if it was an actual `rmem` pointer we lost track of, or a generic pointer we already freed.

### This PR

I don't know if I wish to merge this PR, but I think it would at least be useful for debugging. If we can observe that crash again with this PR, we should be able to narrow down where the pointer is expected to have come from, which may help us figure the bug.

But also more generally, I'm not a fan of that original code, going over the memory arena to figure out what kind of pointer we have seem fragile to me. I think it would be cleaner to record it's type. I don't think it's that much memory overhead, and we could probably optimize it as well.

@peterzhu2118 what do you think?