### PR TITLE
Stop allowing to customize MSGPACK_UNPACKER_STACK_CAPACITY

### DIFF
--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -21,9 +21,7 @@
 #include "buffer.h"
 #include "unpacker_ext_registry.h"
 
-#ifndef MSGPACK_UNPACKER_STACK_CAPACITY
 #define MSGPACK_UNPACKER_STACK_CAPACITY 128
-#endif
 
 struct msgpack_unpacker_t;
 typedef struct msgpack_unpacker_t msgpack_unpacker_t;
@@ -48,8 +46,6 @@ struct msgpack_unpacker_stack_t {
     msgpack_unpacker_stack_entry_t *data;
     msgpack_unpacker_stack_t *parent;
 };
-
-#define MSGPACK_UNPACKER_STACK_SIZE (8+4+8+8)  /* assumes size_t <= 64bit, enum <= 32bit, VALUE <= 64bit */
 
 struct msgpack_unpacker_t {
     msgpack_buffer_t buffer;


### PR DESCRIPTION
Allowing to define it forces us to maintain a fallback codepath in case it wouldn't fit in a 4kB page.

That codepath is unstested, and passing compilation flags to gems in so wonky I really don't think we should allow this.

Superseeds: https://github.com/msgpack/msgpack-ruby/pull/321

@peterzhu2118 