### PR TITLE
Implement Factory::Pool #packer and #unpacker methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+* Implement `Factory::Pool#unpacker` and `Factory::Pool#packer` to allow for more precise serialization.
 * Require Ruby 2.5+.
 
 2023-03-03 1.6.1:

--- a/doclib/msgpack/factory.rb
+++ b/doclib/msgpack/factory.rb
@@ -124,8 +124,6 @@ module MessagePack
       # @param data [String]
       # @return [Object] deserialized object
       #
-      # See Unpacker#initialize for supported options.
-      #
       def load(data)
       end
 
@@ -139,6 +137,28 @@ module MessagePack
       # @return [String] serialized object
       #
       def dump(object)
+      end
+
+      #
+      # Yields an Unpacker from the pool, and check it back in.
+      #
+      # The unpacker should no longer be held after the block has returned.
+      #
+      # @yieldparam unpacker [MessagePack::Unpacker]
+      # @returns [Object] the block return value
+      #
+      def unpacker(&block)
+      end
+
+      #
+      # Yields a Packer from the pool, and check it back in.
+      #
+      # The packer should no longer be held after the block has returned.
+      #
+      # @yieldparam packer [MessagePack::Packer]
+      # @returns [Object] the block return value
+      #
+      def packer(&block)
       end
     end
   end

--- a/doclib/msgpack/packer.rb
+++ b/doclib/msgpack/packer.rb
@@ -177,7 +177,17 @@ module MessagePack
     end
 
     #
+    # Returns all data in the buffer as a string, and reset the buffer.
+    #
+    # @return [String]
+    #
+    def full_pack
+    end
+
+    #
     # Returns all data in the buffer as a string. Same as buffer.to_str.
+    #
+    # Does not empty the buffer, in most case _full_pack_ is prefered.
     #
     # @return [String]
     #

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -92,7 +92,7 @@ public class Factory extends RubyObject {
     RubyHash options = null;
 
     if (isFrozen()) {
-        throw runtime.newRuntimeError("can't modify frozen Factory");
+        throw runtime.newFrozenError("MessagePack::Factory");
     }
 
     if (args.length == 2) {

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -96,6 +96,9 @@ public class Packer extends RubyObject {
   @JRubyMethod(name = "register_type", required = 2, optional = 1)
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args, final Block block) {
     Ruby runtime = ctx.runtime;
+    if (isFrozen()) {
+        throw runtime.newFrozenError("MessagePack::Packer");
+    }
     IRubyObject type = args[0];
     IRubyObject mod = args[1];
 

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -130,6 +130,9 @@ public class Unpacker extends RubyObject {
   @JRubyMethod(name = "register_type", required = 1, optional = 2)
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args, final Block block) {
     Ruby runtime = ctx.runtime;
+    if (isFrozen()) {
+        throw runtime.newFrozenError("MessagePack::Unpacker");
+    }
     IRubyObject type = args[0];
 
     RubyModule extModule;

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -212,7 +212,7 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
     VALUE packer_proc, unpacker_proc;
 
     if (OBJ_FROZEN(self)) {
-        rb_raise(rb_eRuntimeError, "can't modify frozen Factory");
+        rb_raise(rb_eFrozenError, "can't modify frozen MessagePack::Factory");
     }
 
     switch (argc) {

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -349,6 +349,10 @@ static VALUE Packer_registered_types_internal(VALUE self)
 
 static VALUE Packer_register_type(int argc, VALUE* argv, VALUE self)
 {
+    if (OBJ_FROZEN(self)) {
+        rb_raise(rb_eFrozenError, "can't modify frozen MessagePack::Packer");
+    }
+
     msgpack_packer_t *pk = MessagePack_Packer_get(self);
 
     int ext_type;

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -348,6 +348,10 @@ static VALUE Unpacker_registered_types_internal(VALUE self)
 
 static VALUE Unpacker_register_type(int argc, VALUE* argv, VALUE self)
 {
+    if (OBJ_FROZEN(self)) {
+        rb_raise(rb_eFrozenError, "can't modify frozen MessagePack::Unpacker");
+    }
+
     msgpack_unpacker_t *uk = MessagePack_Unpacker_get(self);
 
     int ext_type;

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -450,7 +450,7 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
     rb_define_method(cMessagePack_Unpacker, "read_array_header", Unpacker_read_array_header, 0);
     rb_define_method(cMessagePack_Unpacker, "read_map_header", Unpacker_read_map_header, 0);
     rb_define_method(cMessagePack_Unpacker, "feed", Unpacker_feed_reference, 1);
-    rb_define_method(cMessagePack_Unpacker, "feed_reference", Unpacker_feed_reference, 1);
+    rb_define_alias(cMessagePack_Unpacker, "feed_reference", "feed");
     rb_define_method(cMessagePack_Unpacker, "each", Unpacker_each, 0);
     rb_define_method(cMessagePack_Unpacker, "feed_each", Unpacker_feed_each, 1);
     rb_define_method(cMessagePack_Unpacker, "reset", Unpacker_reset, 0);

--- a/lib/msgpack/factory.rb
+++ b/lib/msgpack/factory.rb
@@ -140,8 +140,8 @@ module MessagePack
       def initialize(factory, size, options = nil)
         options = nil if !options || options.empty?
         @factory = factory
-        @packers = MemberPool.new(size) { factory.packer(options) }
-        @unpackers = MemberPool.new(size) { factory.unpacker(options) }
+        @packers = MemberPool.new(size) { factory.packer(options).freeze }
+        @unpackers = MemberPool.new(size) { factory.unpacker(options).freeze }
       end
 
       def load(data)

--- a/lib/msgpack/factory.rb
+++ b/lib/msgpack/factory.rb
@@ -127,9 +127,9 @@ module MessagePack
           end
 
           def checkin(member)
+            member.reset
             @mutex.synchronize do
               if member && @members.size < @size
-                member.reset
                 @members << member
               end
             end
@@ -159,6 +159,24 @@ module MessagePack
         begin
           packer.write(object)
           packer.full_pack
+        ensure
+          @packers.checkin(packer)
+        end
+      end
+
+      def unpacker
+        unpacker = @unpackers.checkout
+        begin
+          yield unpacker
+        ensure
+          @unpackers.checkin(unpacker)
+        end
+      end
+
+      def packer
+        packer = @packers.checkout
+        begin
+          yield packer
         ensure
           @packers.checkin(packer)
         end

--- a/lib/msgpack/factory.rb
+++ b/lib/msgpack/factory.rb
@@ -88,7 +88,7 @@ module MessagePack
 
     class Pool
       if RUBY_ENGINE == "ruby"
-        class AbstractPool
+        class MemberPool
           def initialize(size, &block)
             @size = size
             @new_member = block
@@ -114,7 +114,7 @@ module MessagePack
           end
         end
       else
-        class AbstractPool
+        class MemberPool
           def initialize(size, &block)
             @size = size
             @new_member = block
@@ -137,27 +137,11 @@ module MessagePack
         end
       end
 
-      class PackerPool < AbstractPool
-        private
-
-        def reset(packer)
-          packer.clear
-        end
-      end
-
-      class UnpackerPool < AbstractPool
-        private
-
-        def reset(unpacker)
-          unpacker.reset
-        end
-      end
-
       def initialize(factory, size, options = nil)
         options = nil if !options || options.empty?
         @factory = factory
-        @packers = PackerPool.new(size) { factory.packer(options) }
-        @unpackers = UnpackerPool.new(size) { factory.unpacker(options) }
+        @packers = MemberPool.new(size) { factory.packer(options) }
+        @unpackers = MemberPool.new(size) { factory.unpacker(options) }
       end
 
       def load(data)

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -80,7 +80,7 @@ describe MessagePack::Factory do
       subject.register_type(0x00, Symbol)
       subject.freeze
       expect(subject.frozen?).to be_truthy
-      expect{ subject.register_type(0x01, Array) }.to raise_error(RuntimeError, "can't modify frozen Factory")
+      expect{ subject.register_type(0x01, Array) }.to raise_error(FrozenError, "can't modify frozen MessagePack::Factory")
     end
   end
 
@@ -704,6 +704,24 @@ describe MessagePack::Factory do
         unpacker.read
       end
       expect(object).to be == 42
+    end
+
+    it '#packer does not allow to register types' do
+      pool = factory.pool(1)
+      expect do
+        pool.packer do |packer|
+          packer.register_type(0x20, ::MyType) { "type" }
+        end
+      end.to raise_error(FrozenError, "can't modify frozen MessagePack::Packer")
+    end
+
+    it '#unpacker does not allow to register types' do
+      pool = factory.pool(1)
+      expect do
+        pool.unpacker do |unpacker|
+          unpacker.register_type(0x20, ::MyType) { "type" }
+        end
+      end.to raise_error(FrozenError, "can't modify frozen MessagePack::Unpacker")
     end
 
     it 'types can be registered before the pool is created' do

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -686,6 +686,26 @@ describe MessagePack::Factory do
       expect(pool.load(pool.dump(42))).to be == 42
     end
 
+    it 'responds to #packer with a block' do
+      pool = factory.pool(1)
+      payload = pool.packer do |packer|
+        packer.write(42)
+        packer.full_pack
+      end
+      expect(payload).to be == factory.dump(42)
+    end
+
+    it 'responds to #unpacker with a block' do
+      pool = factory.pool(1)
+      payload = factory.dump(42)
+
+      object = pool.unpacker do |unpacker|
+        unpacker.feed(payload)
+        unpacker.read
+      end
+      expect(object).to be == 42
+    end
+
     it 'types can be registered before the pool is created' do
       factory.register_type(0x00, Symbol)
       pool = factory.pool(1)


### PR DESCRIPTION
This make pooling usable when simple `dump/load` isn't.

e.g. 

```ruby
pool.packer do |packer|
  packer.write(1)
  packer.write(2)
  packer.full_pack
end
```

@peterzhu2118 @felix-d