### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@
 # versions of RuboCop, may require this file to be generated again.
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 # Offense count: 3
 Lint/AmbiguousOperator:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+* Require Ruby 2.5+.
+
 2023-03-03 1.6.1:
 
 * Undefine `#clone` and `#dup` on `MessagePack::Buffer`, `MessagePack::Packer` and `MessagePack::Unpacker`.

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -473,7 +473,6 @@ static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_
         result = rb_str_new(b->read_buffer, length);
     }
 
-#if STR_UMINUS_DEDUPE
     if (will_be_frozen) {
 #if STR_UMINUS_DEDUPE_FROZEN
         // Starting from MRI 2.8 it is preferable to freeze the string
@@ -485,7 +484,6 @@ static inline VALUE msgpack_buffer_read_top_as_string(msgpack_buffer_t* b, size_
         // frozen.
         result = rb_funcall(result, s_uminus, 0);
     }
-#endif // STR_UMINUS_DEDUPE
     _msgpack_buffer_consumed(b, length);
     return result;
 

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -28,20 +28,6 @@ else
   $CFLAGS << ' -DHASH_ASET_DEDUPE=0 '
 end
 
-
-# checking if String#-@ (str_uminus) dedupes... ' (Ruby 2.5+)
-begin
-  a = -(%w(t e s t).join)
-  b = -(%w(t e s t).join)
-  if a.equal?(b)
-    $CFLAGS << ' -DSTR_UMINUS_DEDUPE=1 '
-  else
-    $CFLAGS += ' -DSTR_UMINUS_DEDUPE=0 '
-  end
-rescue NoMethodError
-  $CFLAGS << ' -DSTR_UMINUS_DEDUPE=0 '
-end
-
 # checking if String#-@ (str_uminus) directly interns frozen strings... ' (Ruby 3.0+)
 begin
   s = rand.to_s.freeze

--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     s.extensions = ["ext/msgpack/extconf.rb"]
   end
 
-  s.required_ruby_version = ">= 2.4"
+  s.required_ruby_version = ">= 2.5"
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
It breaks https://github.com/msgpack/msgpack-ruby/pull/325 because `rb_eFrozenError` isn't defined.

It would be relatively trivial to handle that, but I thin 2.4 is now old enough that we can just stop supporting it.