### PR TITLE
_msgpack_rmem_alloc2: reset `head.pages` pointer before allocating them.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+* Fix a possible double-free issue when GC triggers inside `_msgpack_rmem_alloc2`.
 * `Unpacker#feed` now always directly read in provided strings instead of copying content in its buffer.
 * `Unpacker#feed` is now an alias of `Unpacker#feed_reference`.
 * Implement `Factory::Pool#unpacker` and `Factory::Pool#packer` to allow for more precise serialization.

--- a/ext/msgpack/rmem.c
+++ b/ext/msgpack/rmem.c
@@ -70,6 +70,7 @@ void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
     pm->head = *c;
     *c = tmp;
 
+    pm->head.pages = NULL; /* make sure we don't point to another chunk's pages in case xmalloc triggers GC */
     pm->head.mask = 0xffffffff & (~1);  /* "& (~1)" means first chunk is already allocated */
     pm->head.pages = xmalloc(MSGPACK_RMEM_PAGE_SIZE * 32);
 


### PR DESCRIPTION
`xmalloc` may trigger GC, if it does, some buffers may be freed by ruby and if they were in the previous head, they'll free themselves out of the head.

Fix: https://github.com/msgpack/msgpack-ruby/issues/327

I also suspect this will solve https://github.com/msgpack/msgpack-ruby/issues/309, but I'm not 100% certain (FYI @qcn). 

@peterzhu2118 