### PR TITLE
Remove dead code in _msgpack_rmem_alloc2

### DIFF
--- a/ext/msgpack/rmem.c
+++ b/ext/msgpack/rmem.c
@@ -65,10 +65,8 @@ void* _msgpack_rmem_alloc2(msgpack_rmem_t* pm)
     /* allocate new chunk */
     c = pm->array_last++;
 
-    /* move to head */
-    msgpack_rmem_chunk_t tmp = pm->head;
-    pm->head = *c;
-    *c = tmp;
+    /* move head to array */
+    *c = pm->head;
 
     pm->head.mask = 0xffffffff & (~1);  /* "& (~1)" means first chunk is already allocated */
     pm->head.pages = xmalloc(MSGPACK_RMEM_PAGE_SIZE * 32);


### PR DESCRIPTION
We overwrite `pm->head` in the lines following it, so we don't need to copy `c` to `pm->head`.