### PR TITLE
Run less macOS and Windows CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu]
         ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        include:
+          - os: macos
+            ruby: '2.5'
+          - os: macos
+            ruby: '3.2'
+          - os: windows
+            ruby: '2.5'
+          - os: windows
+            ruby: '3.2'
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: '3.1'
           bundler-cache: true # 'bundle install' and cache
       - run: sudo apt-get install -y valgrind
       - run: bundle exec rake spec:valgrind


### PR DESCRIPTION
They are very subject to timeouts and such.
By testing only the oldest and newest versions on them we might have less flakiness.

@peterzhu2118 