### PR TITLE
Test JRuby 9.4 and fix compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: ['jruby-9.2.19.0', 'jruby-9.3.3.0', 'truffleruby']
+        ruby: ['jruby-9.2', 'jruby-9.3', 'jruby-9.4', 'truffleruby']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2

--- a/ext/java/org/msgpack/jruby/Buffer.java
+++ b/ext/java/org/msgpack/jruby/Buffer.java
@@ -22,10 +22,10 @@ import org.jcodings.Encoding;
 @JRubyClass(name="MessagePack::Buffer")
 public class Buffer extends RubyObject {
   private static final long serialVersionUID = 8441244627425629412L;
-  private IRubyObject io;
-  private ByteBuffer buffer;
+  private transient IRubyObject io;
+  private transient ByteBuffer buffer;
   private boolean writeMode;
-  private Encoding binaryEncoding;
+  private transient Encoding binaryEncoding;
 
   private static final int CACHE_LINE_SIZE = 64;
   private static final int ARRAY_HEADER_SIZE = 24;

--- a/ext/java/org/msgpack/jruby/ExtensionValue.java
+++ b/ext/java/org/msgpack/jruby/ExtensionValue.java
@@ -26,7 +26,7 @@ import static org.msgpack.jruby.Types.*;
 @JRubyClass(name="MessagePack::ExtensionValue")
 public class ExtensionValue extends RubyObject {
   private static final long serialVersionUID = 8451274621449322492L;
-  private final Encoding binaryEncoding;
+  private transient final Encoding binaryEncoding;
 
   private RubyFixnum type;
   private RubyString payload;

--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -26,8 +26,8 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 @JRubyClass(name="MessagePack::Factory")
 public class Factory extends RubyObject {
   private static final long serialVersionUID = 8441284623445322492L;
-  private final Ruby runtime;
-  private ExtensionRegistry extensionRegistry;
+  private transient final Ruby runtime;
+  private transient ExtensionRegistry extensionRegistry;
   private boolean hasSymbolExtType;
   private boolean hasBigIntExtType;
 
@@ -82,6 +82,8 @@ public class Factory extends RubyObject {
 
   @JRubyMethod(name = "register_type", required = 2, optional = 1)
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args) {
+    testFrozen("MessagePack::Factory");
+
     Ruby runtime = ctx.runtime;
     IRubyObject type = args[0];
     IRubyObject mod = args[1];
@@ -90,10 +92,6 @@ public class Factory extends RubyObject {
     IRubyObject unpackerArg;
 
     RubyHash options = null;
-
-    if (isFrozen()) {
-        throw runtime.newFrozenError("MessagePack::Factory");
-    }
 
     if (args.length == 2) {
       packerArg = runtime.newSymbol("to_msgpack_ext");

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -28,12 +28,12 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 @JRubyClass(name="MessagePack::Packer")
 public class Packer extends RubyObject {
   private static final long serialVersionUID = 8451274621499362492L;
-  public ExtensionRegistry registry;
+  public transient ExtensionRegistry registry;
   private Buffer buffer;
-  private Encoder encoder;
+  private transient Encoder encoder;
   private boolean hasSymbolExtType;
   private boolean hasBigintExtType;
-  private Encoding binaryEncoding;
+  private transient Encoding binaryEncoding;
 
   public Packer(Ruby runtime, RubyClass type, ExtensionRegistry registry, boolean hasSymbolExtType, boolean hasBigintExtType) {
     super(runtime, type);
@@ -95,10 +95,9 @@ public class Packer extends RubyObject {
 
   @JRubyMethod(name = "register_type", required = 2, optional = 1)
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args, final Block block) {
+    testFrozen("MessagePack::Packer");
+
     Ruby runtime = ctx.runtime;
-    if (isFrozen()) {
-        throw runtime.newFrozenError("MessagePack::Packer");
-    }
     IRubyObject type = args[0];
     IRubyObject mod = args[1];
 

--- a/ext/java/org/msgpack/jruby/Unpacker.java
+++ b/ext/java/org/msgpack/jruby/Unpacker.java
@@ -21,18 +21,17 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.util.ByteList;
-import org.jruby.ext.stringio.StringIO;
 
 import static org.jruby.runtime.Visibility.PRIVATE;
 
 @JRubyClass(name="MessagePack::Unpacker")
 public class Unpacker extends RubyObject {
   private static final long serialVersionUID = 8451264671199362492L;
-  private final ExtensionRegistry registry;
+  private transient final ExtensionRegistry registry;
 
-  private IRubyObject stream;
-  private IRubyObject data;
-  private Decoder decoder;
+  private transient IRubyObject stream;
+  private transient IRubyObject data;
+  private transient Decoder decoder;
   private final RubyClass underflowErrorClass;
   private boolean symbolizeKeys;
   private boolean freeze;
@@ -129,10 +128,9 @@ public class Unpacker extends RubyObject {
 
   @JRubyMethod(name = "register_type", required = 1, optional = 2)
   public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args, final Block block) {
+    testFrozen("MessagePack::Unpacker");
+
     Ruby runtime = ctx.runtime;
-    if (isFrozen()) {
-        throw runtime.newFrozenError("MessagePack::Unpacker");
-    }
     IRubyObject type = args[0];
 
     RubyModule extModule;
@@ -334,9 +332,7 @@ public class Unpacker extends RubyObject {
   @JRubyMethod(name = "stream=", required = 1)
   public IRubyObject setStream(ThreadContext ctx, IRubyObject stream) {
     RubyString str;
-    if (stream instanceof StringIO) {
-      str = stream.callMethod(ctx, "string").asString();
-    } else if (stream instanceof RubyIO) {
+    if (stream instanceof RubyIO) {
       str = stream.callMethod(ctx, "read").asString();
     } else if (stream.respondsTo("read")) {
       str = stream.callMethod(ctx, "read").asString();


### PR DESCRIPTION
Seems like referencing StringIO directly no longer works.

```
ext/java/org/msgpack/jruby/Unpacker.java:337: error: cannot find symbol
    if (stream instanceof StringIO) {
```
While I was at it I also fixed most compilation warnings.