### PR TITLE
Implement Write Barrier for MessagePack::Factory

### DIFF
--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -106,8 +106,8 @@ VALUE MessagePack_Packer_initialize(int argc, VALUE* argv, VALUE self)
 
     msgpack_packer_t *pk = MessagePack_Packer_get(self);
 
-    msgpack_packer_ext_registry_init(&pk->ext_registry);
-    pk->buffer_ref = Qnil;
+    msgpack_packer_ext_registry_init(self, &pk->ext_registry);
+    pk->buffer_ref = MessagePack_Buffer_wrap(PACKER_BUFFER_(pk), self);
 
     MessagePack_Buffer_set_options(PACKER_BUFFER_(pk), io, options);
 
@@ -391,7 +391,7 @@ static VALUE Packer_register_type(int argc, VALUE* argv, VALUE self)
         rb_raise(rb_eArgError, "expected Module/Class but found %s.", rb_obj_classname(ext_module));
     }
 
-    msgpack_packer_ext_registry_put(&pk->ext_registry, ext_module, ext_type, 0, proc, arg);
+    msgpack_packer_ext_registry_put(self, &pk->ext_registry, ext_module, ext_type, 0, proc, arg);
 
     if (ext_module == rb_cSymbol) {
         pk->has_symbol_ext_type = true;

--- a/ext/msgpack/packer_ext_registry.h
+++ b/ext/msgpack/packer_ext_registry.h
@@ -35,17 +35,20 @@ void msgpack_packer_ext_registry_static_init(void);
 
 void msgpack_packer_ext_registry_static_destroy(void);
 
-void msgpack_packer_ext_registry_init(msgpack_packer_ext_registry_t* pkrg);
+void msgpack_packer_ext_registry_init(VALUE owner, msgpack_packer_ext_registry_t* pkrg);
 
 static inline void msgpack_packer_ext_registry_destroy(msgpack_packer_ext_registry_t* pkrg)
 { }
 
 void msgpack_packer_ext_registry_mark(msgpack_packer_ext_registry_t* pkrg);
 
-void msgpack_packer_ext_registry_dup(msgpack_packer_ext_registry_t* src,
+void msgpack_packer_ext_registry_borrow(VALUE owner, msgpack_packer_ext_registry_t* src,
         msgpack_packer_ext_registry_t* dst);
 
-VALUE msgpack_packer_ext_registry_put(msgpack_packer_ext_registry_t* pkrg,
+void msgpack_packer_ext_registry_dup(VALUE owner, msgpack_packer_ext_registry_t* src,
+        msgpack_packer_ext_registry_t* dst);
+
+void msgpack_packer_ext_registry_put(VALUE owner, msgpack_packer_ext_registry_t* pkrg,
         VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg);
 
 static int msgpack_packer_ext_find_superclass(VALUE key, VALUE value, VALUE arg)
@@ -129,9 +132,6 @@ static inline VALUE msgpack_packer_ext_registry_lookup(msgpack_packer_ext_regist
     VALUE superclass = args[1];
     if(superclass != Qnil) {
         VALUE superclass_type = rb_hash_lookup(pkrg->hash, superclass);
-        if (!RTEST(pkrg->cache)) {
-            pkrg->cache = rb_hash_new();
-        }
         rb_hash_aset(pkrg->cache, lookup_class, superclass_type);
         *ext_type_result = FIX2INT(rb_ary_entry(superclass_type, 0));
         *ext_flags_result = FIX2INT(rb_ary_entry(superclass_type, 3));

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -382,7 +382,7 @@ static VALUE Unpacker_register_type(int argc, VALUE* argv, VALUE self)
         rb_raise(rb_eRangeError, "integer %d too big to convert to `signed char'", ext_type);
     }
 
-    msgpack_unpacker_ext_registry_put(&uk->ext_registry, ext_module, ext_type, 0, proc, arg);
+    msgpack_unpacker_ext_registry_put(self, &uk->ext_registry, ext_module, ext_type, 0, proc, arg);
 
     return Qnil;
 }

--- a/ext/msgpack/unpacker_ext_registry.c
+++ b/ext/msgpack/unpacker_ext_registry.c
@@ -76,11 +76,12 @@ void msgpack_unpacker_ext_registry_release(msgpack_unpacker_ext_registry_t* ukrg
     }
 }
 
-void msgpack_unpacker_ext_registry_put(msgpack_unpacker_ext_registry_t** ukrg,
+void msgpack_unpacker_ext_registry_put(VALUE owner, msgpack_unpacker_ext_registry_t** ukrg,
         VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg)
 {
     msgpack_unpacker_ext_registry_t* ext_registry = msgpack_unpacker_ext_registry_cow(*ukrg);
 
-    ext_registry->array[ext_type + 128] = rb_ary_new3(4, ext_module, proc, arg, INT2FIX(flags));
+    VALUE entry = rb_ary_new3(4, ext_module, proc, arg, INT2FIX(flags));
+    RB_OBJ_WRITE(owner, &ext_registry->array[ext_type + 128], entry);
     *ukrg = ext_registry;
 }

--- a/ext/msgpack/unpacker_ext_registry.h
+++ b/ext/msgpack/unpacker_ext_registry.h
@@ -47,7 +47,7 @@ static inline void msgpack_unpacker_ext_registry_borrow(msgpack_unpacker_ext_reg
 
 void msgpack_unpacker_ext_registry_mark(msgpack_unpacker_ext_registry_t* ukrg);
 
-void msgpack_unpacker_ext_registry_put(msgpack_unpacker_ext_registry_t** ukrg,
+void msgpack_unpacker_ext_registry_put(VALUE owner, msgpack_unpacker_ext_registry_t** ukrg,
         VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg);
 
 static inline VALUE msgpack_unpacker_ext_registry_lookup(msgpack_unpacker_ext_registry_t* ukrg,


### PR DESCRIPTION
All the references are in `msgpack_unpacker_ext_registry_t` and `msgpack_packer_ext_registry_t` which are shared with `Packer` and `Unpacker` classes.

So we sometimes fire write barriers on these two other types that aren't protected.