### PR TITLE
Use rb_proc_call* rather than rb_funcall

### DIFF
--- a/ext/java/org/msgpack/jruby/ExtensionRegistry.java
+++ b/ext/java/org/msgpack/jruby/ExtensionRegistry.java
@@ -54,8 +54,8 @@ public class ExtensionRegistry {
     return hash;
   }
 
-  public void put(RubyModule mod, int typeId, boolean recursive, IRubyObject packerProc, IRubyObject packerArg, IRubyObject unpackerProc, IRubyObject unpackerArg) {
-    ExtensionEntry entry = new ExtensionEntry(mod, typeId, recursive, packerProc, packerArg, unpackerProc, unpackerArg);
+  public void put(RubyModule mod, int typeId, boolean recursive, IRubyObject packerProc, IRubyObject unpackerProc) {
+    ExtensionEntry entry = new ExtensionEntry(mod, typeId, recursive, packerProc, unpackerProc);
     extensionsByModule.put(mod, entry);
     extensionsByTypeId[typeId + 128] = entry;
     extensionsByAncestor.clear();
@@ -114,18 +114,14 @@ public class ExtensionRegistry {
     private final int typeId;
     private final boolean recursive;
     private final IRubyObject packerProc;
-    private final IRubyObject packerArg;
     private final IRubyObject unpackerProc;
-    private final IRubyObject unpackerArg;
 
-    public ExtensionEntry(RubyModule mod, int typeId, boolean recursive, IRubyObject packerProc, IRubyObject packerArg, IRubyObject unpackerProc, IRubyObject unpackerArg) {
+    public ExtensionEntry(RubyModule mod, int typeId, boolean recursive, IRubyObject packerProc, IRubyObject unpackerProc) {
       this.mod = mod;
       this.typeId = typeId;
       this.recursive = recursive;
       this.packerProc = packerProc;
-      this.packerArg = packerArg;
       this.unpackerProc = unpackerProc;
-      this.unpackerArg = unpackerArg;
     }
 
     public RubyModule getExtensionModule() {
@@ -157,11 +153,11 @@ public class ExtensionRegistry {
     }
 
     public RubyArray<?> toPackerTuple(ThreadContext ctx) {
-      return ctx.runtime.newArray(new IRubyObject[] {ctx.runtime.newFixnum(typeId), packerProc, packerArg});
+      return ctx.runtime.newArray(new IRubyObject[] {ctx.runtime.newFixnum(typeId), packerProc});
     }
 
     public RubyArray<?> toUnpackerTuple(ThreadContext ctx) {
-      return ctx.runtime.newArray(new IRubyObject[] {mod, unpackerProc, unpackerArg});
+      return ctx.runtime.newArray(new IRubyObject[] {mod, unpackerProc});
     }
 
     public IRubyObject[] toPackerProcTypeIdPair(ThreadContext ctx) {

--- a/ext/java/org/msgpack/jruby/Packer.java
+++ b/ext/java/org/msgpack/jruby/Packer.java
@@ -93,28 +93,11 @@ public class Packer extends RubyObject {
     return registry.toInternalPackerRegistry(ctx);
   }
 
-  @JRubyMethod(name = "register_type", required = 2, optional = 1)
-  public IRubyObject registerType(ThreadContext ctx, IRubyObject[] args, final Block block) {
+  @JRubyMethod(name = "register_type_internal", required = 3, visibility = PRIVATE)
+  public IRubyObject registerType(ThreadContext ctx, IRubyObject type, IRubyObject mod, IRubyObject proc) {
     testFrozen("MessagePack::Packer");
 
     Ruby runtime = ctx.runtime;
-    IRubyObject type = args[0];
-    IRubyObject mod = args[1];
-
-    IRubyObject arg;
-    IRubyObject proc;
-    if (args.length == 2) {
-      if (! block.isGiven()) {
-        throw runtime.newLocalJumpErrorNoBlock();
-      }
-      proc = block.getProcObject();
-      arg = proc;
-    } else if (args.length == 3) {
-      arg = args[2];
-      proc = arg.callMethod(ctx, "to_proc");
-    } else {
-      throw runtime.newArgumentError(String.format("wrong number of arguments (%d for 2..3)", 2 + args.length));
-    }
 
     long typeId = ((RubyFixnum) type).getLongValue();
     if (typeId < -128 || typeId > 127) {
@@ -126,7 +109,7 @@ public class Packer extends RubyObject {
     }
     RubyModule extModule = (RubyModule) mod;
 
-    registry.put(extModule, (int) typeId, false, proc, arg, null, null);
+    registry.put(extModule, (int) typeId, false, proc, null);
 
     if (extModule == runtime.getSymbol() && !proc.isNil()) {
       encoder.hasSymbolExtType = true;

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -4,6 +4,7 @@ have_header("ruby/st.h")
 have_header("st.h")
 have_func("rb_enc_interned_str", "ruby.h") # Ruby 3.0+
 have_func("rb_hash_new_capa", "ruby.h") # Ruby 3.2+
+have_func("rb_proc_call_with_block", "ruby.h") # CRuby (TruffleRuby doesn't have it)
 
 append_cflags([
   "-fvisibility=hidden",

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -47,10 +47,6 @@ struct msgpack_packer_t {
 
 #define PACKER_BUFFER_(pk) (&(pk)->buffer)
 
-void msgpack_packer_static_init(void);
-
-void msgpack_packer_static_destroy(void);
-
 void msgpack_packer_init(msgpack_packer_t* pk);
 
 void msgpack_packer_destroy(msgpack_packer_t* pk);

--- a/ext/msgpack/packer_ext_registry.c
+++ b/ext/msgpack/packer_ext_registry.c
@@ -18,16 +18,6 @@
 
 #include "packer_ext_registry.h"
 
-static ID s_call;
-
-void msgpack_packer_ext_registry_static_init(void)
-{
-    s_call = rb_intern("call");
-}
-
-void msgpack_packer_ext_registry_static_destroy(void)
-{ }
-
 void msgpack_packer_ext_registry_init(VALUE owner, msgpack_packer_ext_registry_t* pkrg)
 {
     RB_OBJ_WRITE(owner, &pkrg->hash, Qnil);
@@ -66,7 +56,7 @@ void msgpack_packer_ext_registry_dup(VALUE owner, msgpack_packer_ext_registry_t*
 }
 
 void msgpack_packer_ext_registry_put(VALUE owner, msgpack_packer_ext_registry_t* pkrg,
-        VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg)
+        VALUE ext_module, int ext_type, int flags, VALUE proc)
 {
     if(NIL_P(pkrg->hash)) {
         RB_OBJ_WRITE(owner, &pkrg->hash, rb_hash_new());
@@ -79,7 +69,6 @@ void msgpack_packer_ext_registry_put(VALUE owner, msgpack_packer_ext_registry_t*
         rb_hash_clear(pkrg->cache);
     }
 
-    // TODO: Ruby embeded array limit is 3, merging `proc` and `arg` would be good.
-    VALUE entry = rb_ary_new3(4, INT2FIX(ext_type), proc, arg, INT2FIX(flags));
+    VALUE entry = rb_ary_new3(3, INT2FIX(ext_type), proc, INT2FIX(flags));
     rb_hash_aset(pkrg->hash, ext_module, entry);
 }

--- a/ext/msgpack/packer_ext_registry.h
+++ b/ext/msgpack/packer_ext_registry.h
@@ -31,10 +31,6 @@ struct msgpack_packer_ext_registry_t {
     VALUE cache; // lookup cache for ext types inherited from a super class
 };
 
-void msgpack_packer_ext_registry_static_init(void);
-
-void msgpack_packer_ext_registry_static_destroy(void);
-
 void msgpack_packer_ext_registry_init(VALUE owner, msgpack_packer_ext_registry_t* pkrg);
 
 static inline void msgpack_packer_ext_registry_destroy(msgpack_packer_ext_registry_t* pkrg)
@@ -49,7 +45,7 @@ void msgpack_packer_ext_registry_dup(VALUE owner, msgpack_packer_ext_registry_t*
         msgpack_packer_ext_registry_t* dst);
 
 void msgpack_packer_ext_registry_put(VALUE owner, msgpack_packer_ext_registry_t* pkrg,
-        VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg);
+        VALUE ext_module, int ext_type, int flags, VALUE proc);
 
 static int msgpack_packer_ext_find_superclass(VALUE key, VALUE value, VALUE arg)
 {
@@ -71,7 +67,7 @@ static inline VALUE msgpack_packer_ext_registry_fetch(msgpack_packer_ext_registr
     VALUE type = rb_hash_lookup(pkrg->hash, lookup_class);
     if(type != Qnil) {
         *ext_type_result = FIX2INT(rb_ary_entry(type, 0));
-        *ext_flags_result = FIX2INT(rb_ary_entry(type, 3));
+        *ext_flags_result = FIX2INT(rb_ary_entry(type, 2));
         return rb_ary_entry(type, 1);
     }
 
@@ -80,7 +76,7 @@ static inline VALUE msgpack_packer_ext_registry_fetch(msgpack_packer_ext_registr
         VALUE type_inht = rb_hash_lookup(pkrg->cache, lookup_class);
         if(type_inht != Qnil) {
             *ext_type_result = FIX2INT(rb_ary_entry(type_inht, 0));
-            *ext_flags_result = FIX2INT(rb_ary_entry(type_inht, 3));
+            *ext_flags_result = FIX2INT(rb_ary_entry(type_inht, 2));
             return rb_ary_entry(type_inht, 1);
         }
     }
@@ -134,7 +130,7 @@ static inline VALUE msgpack_packer_ext_registry_lookup(msgpack_packer_ext_regist
         VALUE superclass_type = rb_hash_lookup(pkrg->hash, superclass);
         rb_hash_aset(pkrg->cache, lookup_class, superclass_type);
         *ext_type_result = FIX2INT(rb_ary_entry(superclass_type, 0));
-        *ext_flags_result = FIX2INT(rb_ary_entry(superclass_type, 3));
+        *ext_flags_result = FIX2INT(rb_ary_entry(superclass_type, 2));
         return rb_ary_entry(superclass_type, 1);
     }
 

--- a/ext/msgpack/unpacker_ext_registry.c
+++ b/ext/msgpack/unpacker_ext_registry.c
@@ -18,19 +18,6 @@
 
 #include "unpacker_ext_registry.h"
 
-static ID s_call;
-static ID s_dup;
-
-void msgpack_unpacker_ext_registry_static_init(void)
-{
-    s_call = rb_intern("call");
-    s_dup = rb_intern("dup");
-}
-
-
-void msgpack_unpacker_ext_registry_static_destroy(void)
-{ }
-
 void msgpack_unpacker_ext_registry_mark(msgpack_unpacker_ext_registry_t* ukrg)
 {
     if (ukrg) {
@@ -77,11 +64,11 @@ void msgpack_unpacker_ext_registry_release(msgpack_unpacker_ext_registry_t* ukrg
 }
 
 void msgpack_unpacker_ext_registry_put(VALUE owner, msgpack_unpacker_ext_registry_t** ukrg,
-        VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg)
+        VALUE ext_module, int ext_type, int flags, VALUE proc)
 {
     msgpack_unpacker_ext_registry_t* ext_registry = msgpack_unpacker_ext_registry_cow(*ukrg);
 
-    VALUE entry = rb_ary_new3(4, ext_module, proc, arg, INT2FIX(flags));
+    VALUE entry = rb_ary_new3(3, ext_module, proc, INT2FIX(flags));
     RB_OBJ_WRITE(owner, &ext_registry->array[ext_type + 128], entry);
     *ukrg = ext_registry;
 }

--- a/ext/msgpack/unpacker_ext_registry.h
+++ b/ext/msgpack/unpacker_ext_registry.h
@@ -31,10 +31,6 @@ struct msgpack_unpacker_ext_registry_t {
     VALUE array[256];
 };
 
-void msgpack_unpacker_ext_registry_static_init(void);
-
-void msgpack_unpacker_ext_registry_static_destroy(void);
-
 void msgpack_unpacker_ext_registry_release(msgpack_unpacker_ext_registry_t* ukrg);
 
 static inline void msgpack_unpacker_ext_registry_borrow(msgpack_unpacker_ext_registry_t* src, msgpack_unpacker_ext_registry_t** dst)
@@ -48,7 +44,7 @@ static inline void msgpack_unpacker_ext_registry_borrow(msgpack_unpacker_ext_reg
 void msgpack_unpacker_ext_registry_mark(msgpack_unpacker_ext_registry_t* ukrg);
 
 void msgpack_unpacker_ext_registry_put(VALUE owner, msgpack_unpacker_ext_registry_t** ukrg,
-        VALUE ext_module, int ext_type, int flags, VALUE proc, VALUE arg);
+        VALUE ext_module, int ext_type, int flags, VALUE proc);
 
 static inline VALUE msgpack_unpacker_ext_registry_lookup(msgpack_unpacker_ext_registry_t* ukrg,
         int ext_type, int* ext_flags_result)
@@ -56,7 +52,7 @@ static inline VALUE msgpack_unpacker_ext_registry_lookup(msgpack_unpacker_ext_re
     if (ukrg) {
         VALUE entry = ukrg->array[ext_type + 128];
         if (entry != Qnil) {
-            *ext_flags_result = FIX2INT(rb_ary_entry(entry, 3));
+            *ext_flags_result = FIX2INT(rb_ary_entry(entry, 2));
             return rb_ary_entry(entry, 1);
         }
     }

--- a/lib/msgpack/packer.rb
+++ b/lib/msgpack/packer.rb
@@ -6,11 +6,16 @@ module MessagePack
     undef_method :dup
     undef_method :clone
 
+    def register_type(type, klass, method_name = nil, &block)
+      raise ArgumentError, "expected Module/Class got: #{klass.inspect}" unless klass.is_a?(Module)
+      register_type_internal(type, klass, block || method_name.to_proc)
+    end
+
     def registered_types
       list = []
 
       registered_types_internal.each_pair do |klass, ary|
-        list << {type: ary[0], class: klass, packer: ary[2]}
+        list << {type: ary[0], class: klass, packer: ary[1]}
       end
 
       list.sort{|a, b| a[:type] <=> b[:type] }

--- a/lib/msgpack/unpacker.rb
+++ b/lib/msgpack/unpacker.rb
@@ -6,11 +6,20 @@ module MessagePack
     undef_method :dup
     undef_method :clone
 
+    def register_type(type, klass = nil, method_name = nil, &block)
+      if klass && method_name
+        block = klass.method(method_name).to_proc
+      elsif !block_given?
+        raise ArgumentError, "register_type takes either 3 arguments or a block"
+      end
+      register_type_internal(type, klass, block)
+    end
+
     def registered_types
       list = []
 
       registered_types_internal.each_pair do |type, ary|
-        list << {type: type, class: ary[0], unpacker: ary[2]}
+        list << {type: type, class: ary[0], unpacker: ary[1]}
       end
 
       list.sort{|a, b| a[:type] <=> b[:type] }

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -132,18 +132,18 @@ describe MessagePack::Factory do
 
       expect(list[0][:type]).to eq(0x20)
       expect(list[0][:class]).to eq(::MyType)
-      expect(list[0][:packer]).to eq(:to_msgpack_ext)
-      expect(list[0][:unpacker]).to eq(:from_msgpack_ext)
+      expect(list[0][:packer]).to be_a(Proc)
+      expect(list[0][:unpacker]).to be_a(Proc)
 
       expect(list[1][:type]).to eq(0x21)
       expect(list[1][:class]).to eq(::MyType2)
-      expect(list[1][:packer]).to eq(:to_msgpack_ext)
-      expect(list[1][:unpacker]).to eq(:from_msgpack_ext)
+      expect(list[1][:packer]).to be_a(Proc)
+      expect(list[1][:unpacker]).to be_a(Proc)
     end
 
     it 'returns Array of Hash which has nil for unregistered feature' do
-      subject.register_type(0x21, ::MyType2, unpacker: :from_msgpack_ext)
       subject.register_type(0x20, ::MyType, packer: :to_msgpack_ext)
+      subject.register_type(0x21, ::MyType2, unpacker: :from_msgpack_ext)
 
       list = subject.registered_types
 
@@ -155,13 +155,31 @@ describe MessagePack::Factory do
 
       expect(list[0][:type]).to eq(0x20)
       expect(list[0][:class]).to eq(::MyType)
-      expect(list[0][:packer]).to eq(:to_msgpack_ext)
+      expect(list[0][:packer]).to be_a(Proc)
       expect(list[0][:unpacker]).to be_nil
 
       expect(list[1][:type]).to eq(0x21)
       expect(list[1][:class]).to eq(::MyType2)
       expect(list[1][:packer]).to be_nil
-      expect(list[1][:unpacker]).to eq(:from_msgpack_ext)
+      expect(list[1][:unpacker]).to be_a(Proc)
+
+      list = subject.registered_types(:packer)
+      expect(list.size).to eq(1)
+      expect(list[0]).to be_instance_of(Hash)
+      expect(list[0].keys.sort).to eq([:type, :class, :packer].sort)
+
+      expect(list[0][:type]).to eq(0x20)
+      expect(list[0][:class]).to eq(::MyType)
+      expect(list[0][:packer]).to be_a(Proc)
+
+      list = subject.registered_types(:unpacker)
+      expect(list.size).to eq(1)
+      expect(list[0]).to be_instance_of(Hash)
+      expect(list[0].keys.sort).to eq([:type, :class, :unpacker].sort)
+
+      expect(list[0][:type]).to eq(0x21)
+      expect(list[0][:class]).to eq(::MyType2)
+      expect(list[0][:unpacker]).to be_a(Proc)
     end
   end
 

--- a/spec/packer_spec.rb
+++ b/spec/packer_spec.rb
@@ -373,13 +373,13 @@ describe MessagePack::Packer do
       expect(one.keys.sort).to eq([:type, :class, :packer].sort)
       expect(one[:type]).to eq(0x01)
       expect(one[:class]).to eq(ValueOne)
-      expect(one[:packer]).to eq(:to_msgpack_ext)
+      expect(one[:packer]).to be_a(Proc)
 
       two = packer.registered_types[1]
       expect(two.keys.sort).to eq([:type, :class, :packer].sort)
       expect(two[:type]).to eq(0x02)
       expect(two[:class]).to eq(ValueTwo)
-      expect(two[:packer]).to eq(:to_msgpack_ext)
+      expect(two[:packer]).to be_a(Proc)
     end
 
     context 'when it has no ext type but a super class has' do

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -481,13 +481,13 @@ describe MessagePack::Unpacker do
       expect(one.keys.sort).to eq([:type, :class, :unpacker].sort)
       expect(one[:type]).to eq(0x01)
       expect(one[:class]).to eq(ValueOne)
-      expect(one[:unpacker]).to eq(:from_msgpack_ext)
+      expect(one[:unpacker]).to be_a(Proc)
 
       two = list[1]
       expect(two.keys.sort).to eq([:type, :class, :unpacker].sort)
       expect(two[:type]).to eq(0x02)
       expect(two[:class]).to eq(ValueTwo)
-      expect(two[:unpacker]).to eq(:from_msgpack_ext)
+      expect(two[:unpacker]).to be_a(Proc)
     end
 
     it 'returns a Array of Hash, which contains nil for class if block unpacker specified' do


### PR DESCRIPTION
It's a tiny bit faster, however it requires the receiver to be an actual Proc.

By refactoring the register_type interface we can eagerly cast all callbacks to actual procs.

In the end it makes the C side of the code simpler which is nice.

There is an extremely minor backward incompatibility in `#registered_types` which no longer return the original callable, but always returns a Proc.