### PR TITLE
Remove useless check for st.h

### DIFF
--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -1,7 +1,5 @@
 require 'mkmf'
 
-have_header("ruby/st.h")
-have_header("st.h")
 have_func("rb_enc_interned_str", "ruby.h") # Ruby 3.0+
 have_func("rb_hash_new_capa", "ruby.h") # Ruby 3.2+
 


### PR DESCRIPTION
This was added 10 years ago for Ruby 1.8 support.
We no longer need it.