### PR TITLE
Zero-out msgpack_buffer_chunk_t after allocation

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -251,12 +251,14 @@ bool _msgpack_buffer_read_all2(msgpack_buffer_t* b, char* buffer, size_t length)
 
 static inline msgpack_buffer_chunk_t* _msgpack_buffer_alloc_new_chunk(msgpack_buffer_t* b)
 {
-    msgpack_buffer_chunk_t* reuse = b->free_list;
-    if(reuse == NULL) {
-        return xmalloc(sizeof(msgpack_buffer_chunk_t));
+    msgpack_buffer_chunk_t* chunk = b->free_list;
+    if (chunk) {
+        b->free_list = b->free_list->next;
+    } else {
+        chunk = xmalloc(sizeof(msgpack_buffer_chunk_t));
     }
-    b->free_list = b->free_list->next;
-    return reuse;
+    memset(chunk, 0, sizeof(msgpack_buffer_chunk_t));
+    return chunk;
 }
 
 static inline void _msgpack_buffer_add_new_chunk(msgpack_buffer_t* b)


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/issues/341

These struct contain a VALUE reference so if we don't zero it out, it could be pointing at a T_NONE or some other old object slot.

Especially since we can re-use existing chunks.

cc @peterzhu2118 @pavel-workato