### PR TITLE
Ignore empty strings when feeding buffers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+* Fix a regression where feeding an empty string to an Unpacker would be considered like the end of the buffer.
+
 2023-05-19 1.7.1:
 
 * Fix JRuby 9.4 compatibility.

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -268,7 +268,9 @@ static inline size_t msgpack_buffer_append_string(msgpack_buffer_t* b, VALUE str
 static inline size_t msgpack_buffer_append_string_reference(msgpack_buffer_t* b, VALUE string)
 {
     size_t length = RSTRING_LEN(string);
-    _msgpack_buffer_append_long_string(b, string);
+    if (length > 0) {
+        _msgpack_buffer_append_long_string(b, string);
+    }
     return length;
 }
 

--- a/spec/unpacker_spec.rb
+++ b/spec/unpacker_spec.rb
@@ -188,6 +188,20 @@ describe MessagePack::Unpacker do
     objects.should == [sample_object] * 4
   end
 
+  it 'feed and each empty string' do
+    raw = sample_object.to_msgpack.to_s
+    objects = []
+
+    unpacker.feed("")
+    unpacker.feed(raw)
+    unpacker.feed("")
+
+    unpacker.each { |c|
+      objects << c
+    }
+    objects.should == [sample_object]
+  end
+
   it 'feed_each continues internal state' do
     raw = sample_object.to_msgpack.to_s * 4
     objects = []


### PR DESCRIPTION
Fix: https://github.com/msgpack/msgpack-ruby/issues/345