### PR TITLE
Update README.md example for extension types

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,11 @@ factory = MessagePack::Factory.new
 factory.register_type(
   0x01,
   Point,
-  packer: ->(point, packer) {
-    packer.write(point.x)
-    packer.write(point.y)
+  packer: ->(point) {
+    [point.x, point.y].pack("L>2")
   },
-  unpacker: ->(unpacker) {
-    x = unpacker.read
-    y = unpacker.read
+  unpacker: ->(data) {
+    x, y = data.unpack("L>2")
     Point.new(x, y)
   },
   recursive: true,
@@ -222,13 +220,11 @@ factory = MessagePack::Factory.new
 factory.register_type(
   0x01,
   Point,
-  packer: ->(point, packer) {
-    packer.write(point.x)
-    packer.write(point.y)
+  packer: ->(point) {
+    [point.x, point.y].pack("L>2")
   },
-  unpacker: ->(unpacker) {
-    x = unpacker.read
-    y = unpacker.read
+  unpacker: ->(data) {
+    x, y = data.unpack("L>2")
     Point.new(x, y)
   },
   recursive: true,


### PR DESCRIPTION
Hello 👋 

I have found that extension type example code in the `README.md` is not working...

Since the `MessagePack#pack` only gives the value to `unpack` and `pack` function:
https://github.com/msgpack/msgpack-ruby/blob/e52d18bacc5a69bd0c823e8daf2792b187a6be46/lib/msgpack.rb#L39-L44

I have updated the example to be functional.