### PR TITLE
CI: Use GH Actions checkout@v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
             ruby: '3.2'
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -39,7 +39,7 @@ jobs:
   valgrind:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
@@ -55,7 +55,7 @@ jobs:
         ruby: ['jruby-9.3', 'jruby-9.4', 'truffleruby']
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -73,7 +73,7 @@ jobs:
         ruby: ['ruby-head', 'jruby-head']
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu]
         ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
         include:
-          - os: macos
+          - os: macos-13
             ruby: '2.5'
           - os: macos
             ruby: '3.2'
@@ -25,6 +25,7 @@ jobs:
             ruby: '2.5'
           - os: windows
             ruby: '3.2'
+            
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,19 +14,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu]
+        os: [ubuntu-latest]
         ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
         include:
           - os: macos-13
             ruby: '2.5'
-          - os: macos
+          - os: macos-latest
             ruby: '3.2'
-          - os: windows
+          - os: windows-latest
             ruby: '2.5'
-          - os: windows
+          - os: windows-latest
             ruby: '3.2'
             
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
In order to avoid deprecation warnings in the CI run, this PR uses latest release of the well-known GH Actions.

EDIT: In order to make this run, I had to edit the matrix a little bit, dropping the -latest suffix, so that macos-13 could be mentioned. Now, though, a job is running, that I can't get to stop. Perhaps I should just force-push over it.