### PR TITLE
CI: Add Ruby 3.3 to build matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         include:
           - os: macos-13
             ruby: '2.5'


### PR DESCRIPTION
This PR extends the build matrix with the current GA Ruby version.

