### PR TITLE
Use batch APIs to create arrays and hashes

### DIFF
--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 have_func("rb_enc_interned_str", "ruby.h") # Ruby 3.0+
 have_func("rb_hash_new_capa", "ruby.h") # Ruby 3.2+
 have_func("rb_proc_call_with_block", "ruby.h") # CRuby (TruffleRuby doesn't have it)
+have_func("rb_hash_bulk_insert", "ruby.h") # Ruby 2.6+ and missing on TruffleRuby 24.0
 
 append_cflags([
   "-fvisibility=hidden",

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -65,11 +65,8 @@ static size_t Unpacker_memsize(const void *ptr)
         total_size += sizeof(msgpack_unpacker_ext_registry_t) / (uk->ext_registry->borrow_count + 1);
     }
 
-    msgpack_unpacker_stack_t *stack = uk->stack;
-    while (stack) {
-        total_size += (stack->depth + 1) * sizeof(msgpack_unpacker_stack_t);
-        stack = stack->parent;
-    }
+    total_size += (uk->stack->depth + 1) * sizeof(msgpack_unpacker_stack_t);
+    total_size += (uk->value_stack.depth * sizeof(VALUE));
 
     return total_size + msgpack_buffer_memsize(&uk->buffer);
 }
@@ -163,6 +160,7 @@ static VALUE Unpacker_allow_unknown_ext_p(VALUE self)
 NORETURN(static void raise_unpacker_error(msgpack_unpacker_t *uk, int r))
 {
     uk->stack->depth = 0;
+
     switch(r) {
     case PRIMITIVE_EOF:
         rb_raise(rb_eEOFError, "end of buffer reached");


### PR DESCRIPTION
Basically a port of https://github.com/ruby/json/pull/678

Rather than to allocate the container and push elements one by one, we accumulate them on a stack and then use the faster batch APIs to directly create the final container.

The original action stack remains, as we need to keep track of what we're currently parsing and how big it is.
    
But for the recursive cases, we no longer need to create a child stack.