### PR TITLE
Refactor unpacking of recursive types

### DIFF
--- a/ext/msgpack/unpacker.c
+++ b/ext/msgpack/unpacker.c
@@ -245,7 +245,7 @@ static inline int _msgpack_unpacker_stack_push(msgpack_unpacker_t* uk, enum stac
     return PRIMITIVE_CONTAINER_START;
 }
 
-static inline VALUE msgpack_unpacker_stack_pop(msgpack_unpacker_t* uk)
+static inline size_t msgpack_unpacker_stack_pop(msgpack_unpacker_t* uk)
 {
     return --uk->stack.depth;
 }

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -49,7 +49,7 @@ struct msgpack_unpacker_stack_t {
 
 struct msgpack_unpacker_t {
     msgpack_buffer_t buffer;
-    msgpack_unpacker_stack_t *stack;
+    msgpack_unpacker_stack_t stack;
     unsigned int head_byte;
 
     VALUE self;

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -31,6 +31,7 @@ enum stack_type_t {
     STACK_TYPE_ARRAY,
     STACK_TYPE_MAP_KEY,
     STACK_TYPE_MAP_VALUE,
+    STACK_TYPE_RECURSIVE,
 };
 
 typedef struct {
@@ -44,7 +45,6 @@ struct msgpack_unpacker_stack_t {
     size_t depth;
     size_t capacity;
     msgpack_unpacker_stack_entry_t *data;
-    msgpack_unpacker_stack_t *parent;
 };
 
 struct msgpack_unpacker_t {

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -50,25 +50,26 @@ struct msgpack_unpacker_stack_t {
 struct msgpack_unpacker_t {
     msgpack_buffer_t buffer;
     msgpack_unpacker_stack_t stack;
-    unsigned int head_byte;
 
     VALUE self;
     VALUE last_object;
 
     VALUE reading_raw;
     size_t reading_raw_remaining;
-    int reading_raw_type;
 
     VALUE buffer_ref;
 
     msgpack_unpacker_ext_registry_t *ext_registry;
 
+    int reading_raw_type;
+    unsigned int head_byte;
+
     /* options */
+    int symbol_ext_type;
     bool symbolize_keys;
     bool freeze;
     bool allow_unknown_ext;
     bool optimized_symbol_ext_type;
-    int symbol_ext_type;
 };
 
 #define UNPACKER_BUFFER_(uk) (&(uk)->buffer)

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -58,17 +58,16 @@ static void Unpacker_mark(void *ptr)
 
 static size_t Unpacker_memsize(const void *ptr)
 {
+    const msgpack_unpacker_t* uk = ptr;
+
     size_t total_size = sizeof(msgpack_unpacker_t);
 
-    const msgpack_unpacker_t* uk = ptr;
     if (uk->ext_registry) {
         total_size += sizeof(msgpack_unpacker_ext_registry_t) / (uk->ext_registry->borrow_count + 1);
     }
 
-    msgpack_unpacker_stack_t *stack = uk->stack;
-    while (stack) {
-        total_size += (stack->depth + 1) * sizeof(msgpack_unpacker_stack_t);
-        stack = stack->parent;
+    if (uk->stack) {
+        total_size += (uk->stack->depth + 1) * sizeof(msgpack_unpacker_stack_t);
     }
 
     return total_size + msgpack_buffer_memsize(&uk->buffer);

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -66,8 +66,8 @@ static size_t Unpacker_memsize(const void *ptr)
         total_size += sizeof(msgpack_unpacker_ext_registry_t) / (uk->ext_registry->borrow_count + 1);
     }
 
-    if (uk->stack) {
-        total_size += (uk->stack->depth + 1) * sizeof(msgpack_unpacker_stack_t);
+    if (uk->stack.data) {
+        total_size += (uk->stack.depth + 1) * sizeof(msgpack_unpacker_stack_t);
     }
 
     return total_size + msgpack_buffer_memsize(&uk->buffer);
@@ -161,7 +161,7 @@ static VALUE Unpacker_allow_unknown_ext_p(VALUE self)
 
 NORETURN(static void raise_unpacker_error(msgpack_unpacker_t *uk, int r))
 {
-    uk->stack->depth = 0;
+    uk->stack.depth = 0;
     switch(r) {
     case PRIMITIVE_EOF:
         rb_raise(rb_eEOFError, "end of buffer reached");


### PR DESCRIPTION
Extracted from: https://github.com/msgpack/msgpack-ruby/pull/370

As initially implemented, we allocate a new stack whenever we encounter a recursive type. This means acquiring a whole 4kiB chunk from the arena, which generally is overkill.

Instead we can introduce a new type of stack item, that behave just like a Hash or Array.