### PR TITLE
Unpacker: `key_cache` option.

### DIFF
--- a/doclib/msgpack/unpacker.rb
+++ b/doclib/msgpack/unpacker.rb
@@ -19,6 +19,8 @@ module MessagePack
     # Supported options:
     #
     # * *:symbolize_keys* deserialize keys of Hash objects as Symbol instead of String
+    # * *:freeze* freeze the deserialized objects. Can allow string deduplication and some allocation elision.
+    # * *:key_cache* Enable caching of map keys, this can improve performance significantly if the same map keys are frequently encountered, but also degrade performance if that's not the case.
     # * *:allow_unknown_ext* allow to deserialize ext type object with unknown type id as ExtensionValue instance. Otherwise (by default), unpacker throws UnknownExtTypeError.
     #
     # See also Buffer#initialize for other options.

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 have_func("rb_enc_interned_str", "ruby.h") # Ruby 3.0+
 have_func("rb_hash_new_capa", "ruby.h") # Ruby 3.2+
 have_func("rb_proc_call_with_block", "ruby.h") # CRuby (TruffleRuby doesn't have it)
+have_func("rb_gc_mark_locations", "ruby.h") # Missing on TruffleRuby
 
 append_cflags([
   "-fvisibility=hidden",

--- a/ext/msgpack/unpacker.h
+++ b/ext/msgpack/unpacker.h
@@ -50,6 +50,7 @@ struct msgpack_unpacker_stack_t {
 struct msgpack_unpacker_t {
     msgpack_buffer_t buffer;
     msgpack_unpacker_stack_t stack;
+    msgpack_key_cache_t key_cache;
 
     VALUE self;
     VALUE last_object;
@@ -66,10 +67,12 @@ struct msgpack_unpacker_t {
 
     /* options */
     int symbol_ext_type;
-    bool symbolize_keys;
-    bool freeze;
-    bool allow_unknown_ext;
-    bool optimized_symbol_ext_type;
+
+    bool use_key_cache: 1;
+    bool symbolize_keys: 1;
+    bool freeze: 1;
+    bool allow_unknown_ext: 1;
+    bool optimized_symbol_ext_type: 1;
 };
 
 #define UNPACKER_BUFFER_(uk) (&(uk)->buffer)
@@ -99,6 +102,11 @@ void _msgpack_unpacker_reset(msgpack_unpacker_t* uk);
 static inline void msgpack_unpacker_set_symbolized_keys(msgpack_unpacker_t* uk, bool enable)
 {
     uk->symbolize_keys = enable;
+}
+
+static inline void msgpack_unpacker_set_key_cache(msgpack_unpacker_t* uk, bool enable)
+{
+    uk->use_key_cache = enable;
 }
 
 static inline void msgpack_unpacker_set_freeze(msgpack_unpacker_t* uk, bool enable)

--- a/ext/msgpack/unpacker_class.c
+++ b/ext/msgpack/unpacker_class.c
@@ -34,6 +34,7 @@ static VALUE eUnknownExtTypeError;
 static VALUE mTypeError;  // obsoleted. only for backward compatibility. See #86.
 
 static VALUE sym_symbolize_keys;
+static VALUE sym_key_cache;
 static VALUE sym_freeze;
 static VALUE sym_allow_unknown_ext;
 
@@ -127,6 +128,9 @@ VALUE MessagePack_Unpacker_initialize(int argc, VALUE* argv, VALUE self)
 
     if(options != Qnil) {
         VALUE v;
+
+        v = rb_hash_aref(options, sym_key_cache);
+        msgpack_unpacker_set_key_cache(uk, RTEST(v));
 
         v = rb_hash_aref(options, sym_symbolize_keys);
         msgpack_unpacker_set_symbolized_keys(uk, RTEST(v));
@@ -413,6 +417,7 @@ void MessagePack_Unpacker_module_init(VALUE mMessagePack)
     eUnknownExtTypeError = rb_define_class_under(mMessagePack, "UnknownExtTypeError", eUnpackError);
 
     sym_symbolize_keys = ID2SYM(rb_intern("symbolize_keys"));
+    sym_key_cache = ID2SYM(rb_intern("key_cache"));
     sym_freeze = ID2SYM(rb_intern("freeze"));
     sym_allow_unknown_ext = ID2SYM(rb_intern("allow_unknown_ext"));
 


### PR DESCRIPTION
Heavily inspired from https://github.com/ruby/json/pull/675.

When parsing documents with the same structure repeatedly, a lot of time can be saved by keeping a small cache of map keys encountered.

Using the existing `bench/bench.rb`, comparing with and without the cache shows a 30% performance improvement:

```
Calculating -------------------------------------
       unpack-pooled    960.380k (± 1.4%) i/s -      4.865M in   5.066600s
    unpack-key-cache      1.245M (± 1.6%) i/s -      6.232M in   5.009060s

Comparison:
       unpack-pooled:   960379.8 i/s
    unpack-key-cache:  1244517.6 i/s - 1.30x  (± 0.00) faster
```

However, on the same benchmark, but with the cache filled with other keys, the performance is notably degraded:

```
Calculating -------------------------------------
       unpack-pooled    926.849k (± 2.1%) i/s -      4.639M in   5.007333s
    unpack-key-cache    822.266k (± 2.4%) i/s -      4.113M in   5.004645s

Comparison:
       unpack-pooled:   926849.2 i/s
    unpack-key-cache:   822265.6 i/s - 1.13x  (± 0.00) slower
```

So this feature is powerful but situational, hence why it is opt-in.