### PR TITLE
Various micro optimizations

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -300,7 +300,7 @@ static inline void _msgpack_buffer_add_new_chunk(msgpack_buffer_t* b)
 static inline void _msgpack_buffer_append_reference(msgpack_buffer_t* b, VALUE string)
 {
     VALUE mapped_string;
-    if(ENCODING_GET(string) == msgpack_rb_encindex_ascii8bit && RTEST(rb_obj_frozen_p(string))) {
+    if(ENCODING_GET_INLINED(string) == msgpack_rb_encindex_ascii8bit && RB_OBJ_FROZEN_RAW(string)) {
         mapped_string = string;
     } else {
         mapped_string = rb_str_dup(string);
@@ -309,8 +309,9 @@ static inline void _msgpack_buffer_append_reference(msgpack_buffer_t* b, VALUE s
 
     _msgpack_buffer_add_new_chunk(b);
 
-    char* data = RSTRING_PTR(mapped_string);
-    size_t length = RSTRING_LEN(mapped_string);
+    char* data;
+    size_t length;
+    RSTRING_GETMEM(mapped_string, data, length);
 
     b->tail.first = (char*) data;
     b->tail.last = (char*) data + length;
@@ -330,7 +331,7 @@ void _msgpack_buffer_append_long_string(msgpack_buffer_t* b, VALUE string)
 {
     if(b->io != Qnil) {
         msgpack_buffer_flush(b);
-        if (ENCODING_GET(string) == msgpack_rb_encindex_ascii8bit) {
+        if (ENCODING_GET_INLINED(string) == msgpack_rb_encindex_ascii8bit) {
             rb_funcall(b->io, b->io_write_all_method, 1, string);
         } else {
             msgpack_buffer_append(b, RSTRING_PTR(string), RSTRING_LEN(string));

--- a/ext/msgpack/buffer.h
+++ b/ext/msgpack/buffer.h
@@ -237,13 +237,14 @@ void _msgpack_buffer_append_long_string(msgpack_buffer_t* b, VALUE string);
 
 static inline size_t msgpack_buffer_append_string(msgpack_buffer_t* b, VALUE string)
 {
-    size_t length = RSTRING_LEN(string);
+    size_t length;
+    char *ptr;
+    RSTRING_GETMEM(string, ptr, length);
 
     if(length > b->write_reference_threshold) {
         _msgpack_buffer_append_long_string(b, string);
-
     } else {
-        msgpack_buffer_append(b, RSTRING_PTR(string), length);
+        msgpack_buffer_append(b, ptr, length);
     }
 
     return length;

--- a/ext/msgpack/extconf.rb
+++ b/ext/msgpack/extconf.rb
@@ -9,12 +9,13 @@ append_cflags([
   "-fvisibility=hidden",
   "-I..",
   "-Wall",
-  "-O3",
   "-std=gnu99"
 ])
-append_cflags(RbConfig::CONFIG["debugflags"]) if RbConfig::CONFIG["debugflags"]
 
-append_cflags("-DRUBY_DEBUG=1") if ENV["MSGPACK_DEBUG"]
+if ENV["MSGPACK_DEBUG"]
+  append_cflags(RbConfig::CONFIG["debugflags"]) if RbConfig::CONFIG["debugflags"]
+  append_cflags("-DRUBY_DEBUG=1")
+end
 
 if RUBY_VERSION.start_with?('3.0.') && RUBY_VERSION <= '3.0.5'
   # https://bugs.ruby-lang.org/issues/18772


### PR DESCRIPTION
Nothing major, mostly use more direct APIs to bypass safety checks that we can assert aren't needed.

e.g. `OBJ_FROZEN_RAW` doesn't bother checking if the VALUE is an immediate, which we know it isn't because we know it's a T_STRING.

Or `ENCODING_GET_INLINED` doesn't check if we're dealing with an extended encoding, which in our case we don't need to know.