### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/msgpack

### DIFF
--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
   s.add_development_dependency 'json'
   s.add_development_dependency 'benchmark-ips', ['~> 2.10.0']
+
+  s.metadata["changelog_uri"] = "https://github.com/msgpack/msgpack-ruby/blob/master/ChangeLog"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/msgpack which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata