### PR TITLE
Update Apache license identifier

### DIFF
--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description = %q{MessagePack is a binary-based efficient object serialization library. It enables to exchange structured objects between many languages like JSON. But unlike JSON, it is very fast and small.}
   s.authors = ["Sadayuki Furuhashi", "Theo Hultberg", "Satoshi Tagomori"]
   s.email = ["frsyuki@gmail.com", "theo@iconara.net", "tagomoris@gmail.com"]
-  s.license = "Apache 2.0"
+  s.license = "Apache-2.0"
   s.homepage = "http://msgpack.org/"
   s.require_paths = ["lib"]
   if /java/ =~ RUBY_PLATFORM


### PR DESCRIPTION
According to https://spdx.org/licenses/, the correct identifier for the Apache 2.0 license is `Apache-2.0` (instead of `Apache 2.0`). 