### PR TITLE
More metadata for the gem package

### DIFF
--- a/msgpack.gemspec
+++ b/msgpack.gemspec
@@ -23,6 +23,13 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.5"
 
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/msgpack/msgpack-ruby/issues",
+    "changelog_uri" => "https://github.com/msgpack/msgpack-ruby/blob/master/ChangeLog",
+    "documentation_uri" => "https://github.com/msgpack/msgpack/blob/master/spec.md",
+    "source_code_uri" => "https://github.com/msgpack/msgpack-ruby"
+  }
+
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rake-compiler', ['>= 1.1.9']
@@ -31,6 +38,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
   s.add_development_dependency 'json'
   s.add_development_dependency 'benchmark-ips', ['~> 2.10.0']
-
-  s.metadata["changelog_uri"] = "https://github.com/msgpack/msgpack-ruby/blob/master/ChangeLog"
 end


### PR DESCRIPTION
In addition to `changelog_uri` added via #380, this patch adds `bug_tracker_uri`, `documentation_uri`, and `source_code_uri`.

Among others, my main concern is `source_code_uri` which we use from [gem-src](https://github.com/amatsuda/gem-src), so I don't mind if other two are not accepted.