### PR TITLE
Fix build failure on mswin due to empty UNREACHABLE_RETURN()

### DIFF
--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -25,11 +25,6 @@
 #define MSGPACK_PACKER_IO_FLUSH_THRESHOLD_TO_WRITE_STRING_BODY (1024)
 #endif
 
-#ifndef UNREACHABLE_RETURN
-// Ruby 2.5
-#define UNREACHABLE_RETURN() return
-#endif
-
 struct msgpack_packer_t;
 typedef struct msgpack_packer_t msgpack_packer_t;
 
@@ -418,7 +413,6 @@ static inline void msgpack_packer_write_string_value(msgpack_packer_t* pk, VALUE
 
     if(RB_UNLIKELY(len > 0xffffffffL)) {
         rb_raise(rb_eArgError, "size of string is too long to pack: %lu bytes should be <= %ld", len, 0xffffffffL);
-        UNREACHABLE_RETURN();
     }
 
     if (RB_UNLIKELY(pk->compatibility_mode)) {


### PR DESCRIPTION
Installing msgpack 1.8.3 on the x64-mswin64_140 platform fails to compile with the following error.

```
packer.h(421): warning C4003: not enough arguments for function-like macro invocation 'RBIMPL_UNREACHABLE_RETURN'
packer.h(421): error C2059: syntax error: ')'
```

On MSVC, ruby.h expands `UNREACHABLE_RETURN(val)` to `return (__assume(0), (val))`, so calling it without an argument produces an empty parenthesized expression that fails to parse. GCC and Clang happen to accept the empty argument, which is why this only surfaces on mswin. `rb_raise` is declared `NORETURN` so the unreachability hint is redundant. This removes the call along with the Ruby 2.5 fallback definition that existed only for it.

With this change the extension builds with MSVC 14.51 and the test suite passes on Windows with 455 examples and 0 failures.
