### PR TITLE
Fix rmem page released while a later chunk still points into it

### DIFF
--- a/ext/msgpack/buffer.c
+++ b/ext/msgpack/buffer.c
@@ -127,6 +127,15 @@ void msgpack_buffer_mark(void *ptr)
 
 bool _msgpack_buffer_shift_chunk(msgpack_buffer_t* b)
 {
+    if(b->rmem_owner == &b->head->mem) {
+        /* the chunk that owns the rmem page is going away and takes the page
+         * with it. don't carve the remaining space out of a page that is
+         * already back in the pool. */
+        b->rmem_end = NULL;
+        b->rmem_last = NULL;
+        b->rmem_owner = NULL;
+    }
+
     _msgpack_buffer_chunk_destroy(b->head);
 
     if(b->head == &b->tail) {
@@ -264,6 +273,18 @@ static inline msgpack_buffer_chunk_t* _msgpack_buffer_alloc_new_chunk(msgpack_bu
     return chunk;
 }
 
+/* b->tail is copied into nc and then rebuilt, so the rmem page pointer moves
+ * to nc. the owner has to follow it: if it kept pointing at b->tail.mem, the
+ * transfer in _msgpack_buffer_chunk_malloc would degenerate into a
+ * self-assignment and the page would be released by nc while the rebuilt tail
+ * is still reading from it. */
+static inline void _msgpack_buffer_transfer_rmem_owner(msgpack_buffer_t* b, msgpack_buffer_chunk_t* nc)
+{
+    if(b->rmem_owner == &b->tail.mem) {
+        b->rmem_owner = &nc->mem;
+    }
+}
+
 static inline void _msgpack_buffer_add_new_chunk(msgpack_buffer_t* b)
 {
     if(b->head == &b->tail) {
@@ -275,6 +296,7 @@ static inline void _msgpack_buffer_add_new_chunk(msgpack_buffer_t* b)
         msgpack_buffer_chunk_t* nc = _msgpack_buffer_alloc_new_chunk(b);
 
         *nc = b->tail;
+        _msgpack_buffer_transfer_rmem_owner(b, nc);
         b->head = nc;
         nc->next = &b->tail;
 
@@ -295,6 +317,7 @@ static inline void _msgpack_buffer_add_new_chunk(msgpack_buffer_t* b)
 
         /* rebuild tail */
         *nc = b->tail;
+        _msgpack_buffer_transfer_rmem_owner(b, nc);
         before_tail->next = nc;
         nc->next = &b->tail;
     }

--- a/spec/cruby/buffer_spec.rb
+++ b/spec/cruby/buffer_spec.rb
@@ -620,4 +620,49 @@ describe Buffer do
 
     expect(b1.read_all).to eq(('C' * 128).b)
   end
+
+  it "keeps an rmem page alive while a later chunk still points into it" do
+    threshold = 1024
+    long = 'L' * (threshold * 2)
+
+    b1 = MessagePack::Buffer.new(nil, write_reference_threshold: threshold)
+    b1.write('a' * 100)  # first rmem page
+    b1.write(long)       # written by reference
+    b1.write('b' * 10)   # second rmem page, left mostly unused
+    b1.write(long)       # reclaims the unused part of that page
+    b1.write('c' * 50)   # carved out of the reclaimed part
+    b1.read(100 + long.bytesize + 10 + long.bytesize)
+
+    # the pool must not hand that page to anyone else while b1 still reads from it
+    others = 6.times.map do |i|
+      b = MessagePack::Buffer.new
+      b.write(('A'.ord + i).chr * 4000)
+      b
+    end
+
+    expect(b1.read_all).to eq(('c' * 50).b)
+    expect(others.size).to eq(6)
+  end
+
+  it "does not carve a new chunk out of an rmem page it already released" do
+    threshold = 1024
+    long = 'L' * (threshold * 2)
+
+    b1 = MessagePack::Buffer.new(nil, write_reference_threshold: threshold)
+    b1.write('a' * 100)
+    b1.write(long)
+    b1.write('b' * 10)
+    b1.write(long)                     # reclaims the unused part of the page
+    b1.read(100 + long.bytesize + 10)  # releases that very page
+    b1.write('d' * 50)                 # must not be carved out of it
+
+    others = 6.times.map do |i|
+      b = MessagePack::Buffer.new
+      b.write(('a'.ord + i).chr * 4000)
+      b
+    end
+
+    expect(b1.read_all).to eq((long + ('d' * 50)).b)
+    expect(others.size).to eq(6)
+  end
 end


### PR DESCRIPTION
## Summary

A `MessagePack::Buffer` (and therefore `Packer`) can serve bytes out of an rmem page that has already been returned to the process global pool and handed to a different buffer. Reads return the other buffer's data, and further writes corrupt it. Nothing crashes, so the two buffers silently exchange content.

In a server that serializes per request, that means bytes of one request's payload can surface inside another request's buffer.

## Root cause

`_msgpack_buffer_chunk_malloc` carves a new chunk out of the unused tail of the current rmem page, and transfers ownership of the page to that new chunk so the page is released only when the last chunk using it dies:

```c
/* update rmem owner */
c->mem = *b->rmem_owner;
*b->rmem_owner = NULL;
b->rmem_owner = &c->mem;
```

The transfer never happened, because `b->rmem_owner` was always an alias of `&b->tail.mem`. It is only ever assigned as `&c->mem`, and `c` is `&b->tail` at every call site, so the three lines above degenerate into a self-assignment that is immediately nulled.

The page pointer had in fact moved elsewhere: `_msgpack_buffer_add_new_chunk` copies the tail into a freshly allocated chunk with `*nc = b->tail`, which duplicates `mem` into `nc`, but leaves `b->rmem_owner` pointing at the old location. Ownership therefore stayed with the *older* chunk. Chunks are destroyed head first, so that chunk released the page while the rebuilt tail was still reading from it.

The fix lets the owner follow the page when the tail is copied, so the newest chunk carved out of a page is the one that releases it.

### Second, related hole

While confirming the above, a sibling case turned up: `_msgpack_buffer_shift_chunk` destroys a chunk without invalidating `rmem_last` / `rmem_end`. When the chunk being destroyed is the one owning the current page, the page goes back to the pool but the carve window still points into it, so a later small write carves a new chunk out of a page that another buffer may already own. This patch drops the carve window in that case, which costs at most one page's worth of reuse.

The first fix alone does not close this one.

## Reproduction

Both cases use only public API. The `write_reference_threshold` is lowered so the reference-append that leaves an rmem page partly unused can be triggered with short strings; the default 512 KB threshold reaches the same state with larger writes.

```ruby
require 'msgpack'

threshold = 1024
long = 'L' * (threshold * 2)

b1 = MessagePack::Buffer.new(nil, write_reference_threshold: threshold)
b1.write('a' * 100)  # first rmem page
b1.write(long)       # written by reference
b1.write('b' * 10)   # second rmem page, left mostly unused
b1.write(long)       # reclaims the unused part of that page
b1.write('c' * 50)   # carved out of the reclaimed part
b1.read(100 + long.bytesize + 10 + long.bytesize)

6.times { |i| b = MessagePack::Buffer.new; b.write(('A'.ord + i).chr * 4000) }

p b1.read_all
```

Before this patch:

```
"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
```

After:

```
"cccccccccccccccccccccccccccccccccccccccccccccccccc"
```

## Tests

Two examples were added to `spec/cruby/buffer_spec.rb`, one per case above. Both fail on the current `master` build with the other buffer's bytes in place of the expected content, and pass with this patch.

- `rake spec`: 458 examples, 0 failures
- `rake spec:valgrind`: 458 examples, 0 failures, no memcheck errors

## Notes

This is not a use-after-free in the libc sense in the common case. `msgpack_rmem_free` only flips a bit in the pool's mask, and the backing 128 KB block stays allocated, so the access is to live memory and the failure is silent aliasing rather than a fault. It does become a genuine heap use-after-free in the case where the whole rmem chunk is drained and `_msgpack_rmem_chunk_free` calls `xfree(c->pages)` while a buffer chunk still points into that block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
