### PR TITLE
Fix some Factory/ext_type optimization edge cases

### DIFF
--- a/ext/java/org/msgpack/jruby/Factory.java
+++ b/ext/java/org/msgpack/jruby/Factory.java
@@ -59,6 +59,7 @@ public class Factory extends RubyObject {
     Factory clone = (Factory)super.dup();
     clone.extensionRegistry = extensionRegistry();
     clone.hasSymbolExtType = hasSymbolExtType;
+    clone.hasBigIntExtType = hasBigIntExtType;
     return clone;
   }
 

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -121,7 +121,10 @@ static VALUE Factory_dup(VALUE self)
     msgpack_factory_t *fc = Factory_get(self);
     msgpack_factory_t *cloned_fc = Factory_get(clone);
 
+    cloned_fc->has_bigint_ext_type = fc->has_bigint_ext_type;
     cloned_fc->has_symbol_ext_type = fc->has_symbol_ext_type;
+    cloned_fc->optimized_symbol_ext_type = fc->optimized_symbol_ext_type;
+    cloned_fc->symbol_ext_type = fc->symbol_ext_type;
     cloned_fc->pkrg = fc->pkrg;
     msgpack_unpacker_ext_registry_borrow(fc->ukrg, &cloned_fc->ukrg);
     msgpack_packer_ext_registry_dup(clone, &fc->pkrg, &cloned_fc->pkrg);
@@ -230,6 +233,7 @@ static VALUE Factory_register_type_internal(VALUE self, VALUE rb_ext_type, VALUE
     }
 
     if(ext_module == rb_cSymbol) {
+        fc->symbol_ext_type = ext_type;
         if(NIL_P(options) || RTEST(rb_hash_aref(options, ID2SYM(rb_intern("packer"))))) {
             fc->has_symbol_ext_type = true;
         }

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -512,10 +512,10 @@ describe MessagePack::Factory do
       before do
         skip if IS_JRUBY # JRuby implementation doesn't support the optimized symbols unpacker for now
         subject.register_type(
-          0x00,
+          0x01,
           ::Symbol,
           packer: :to_msgpack_ext,
-          unpacker: :from_msgpack_ext,
+          unpacker: ->(_) { raise "symbol unpacking not optimized" },
           optimized_symbols_parsing: true,
         )
       end


### PR DESCRIPTION
Previously, optimized_symbol_parsing would enable a fast path for symbols but it never actually registered the Symbol's ext_type (so it was always 0x0). This resulted in the optimization not working if Symbol is registered with a different type and could additionally cause data corruption if some other type is registered as 0x0.

Additionally, many of these Factory fields were not copied over on dup, meaning pooled Factories would have optimized_symbol_parsing disabled if they don't explicitly `freeze` before calling `pool` (which would do `dup.freeze`).